### PR TITLE
Update macOS support

### DIFF
--- a/.premake/core/toolset.lua
+++ b/.premake/core/toolset.lua
@@ -2,7 +2,7 @@
 function setupToolsetOptions()
     filter { "system:macosx" }
         xcodebuildsettings {
-            ["MACOSX_DEPLOYMENT_TARGET"] = "11.1",
+            ["MACOSX_DEPLOYMENT_TARGET"] = "12.0",
             ["ONLY_ACTIVE_ARCH"] = "YES",
             ["ENABLE_TESTABILITY"] = "YES",
             ["ARCHS"] = "$(ARCHS_STANDARD)",
@@ -48,4 +48,8 @@ function setupToolsetOptions()
         debugdir "$(TargetDir)"
 
     filter{}
+
+    -- Disable edit and continue feature
+    -- in all toolset
+    editandcontinue "Off"
 end

--- a/editor/src/main.cpp
+++ b/editor/src/main.cpp
@@ -21,7 +21,6 @@
 #include "editor-scene/SceneManager.h"
 #include "ui/UIRoot.h"
 
-static const glm::vec4 CLEAR_COLOR{0.19, 0.21, 0.26, 1.0};
 static const uint32_t INITIAL_WIDTH = 1024;
 static const uint32_t INITIAL_HEIGHT = 768;
 
@@ -56,7 +55,6 @@ int main() {
       mainLoop.run(
           graph,
           [&editorCamera, &sceneManager](double dt) mutable {
-            ImGuiIO &io = ImGui::GetIO();
             editorCamera.update();
             sceneManager.getActiveScene()->update();
             return !sceneManager.hasNewScene();

--- a/editor/src/ui/ConfirmationDialog.cpp
+++ b/editor/src/ui/ConfirmationDialog.cpp
@@ -21,7 +21,7 @@ void ConfirmationDialog::render(SceneManager &sceneManager) {
   }
 
   if (ImGui::BeginPopupModal(title.c_str())) {
-    ImGui::Text(prompt.c_str());
+    ImGui::Text("%s", prompt.c_str());
     if (ImGui::Button(confirmButtonLabel.c_str())) {
       confirmHandler(sceneManager);
       ImGui::CloseCurrentPopup();

--- a/engine/premake5.lua
+++ b/engine/premake5.lua
@@ -2,7 +2,7 @@ project "LiquidEngine"
     basedir "../workspace/engine"
     kind "StaticLib"
 
-    pchheader "engine/src/core/Base.h"
+    pchheader "../../engine/src/core/Base.h"
 
     filter { "toolset:msc-*" }
         pchheader "core/Base.h"
@@ -33,7 +33,7 @@ project "LiquidEngineTest"
     basedir "../workspace/engine-test"
     kind "ConsoleApp"
 
-    pchheader "engine/src/core/Base.h"
+    pchheader "../../engine/src/core/Base.h"
 
     filter { "toolset:msc-*" }
         pchheader "core/Base.h"

--- a/engine/src/renderer/render-graph/RenderGraph.cpp
+++ b/engine/src/renderer/render-graph/RenderGraph.cpp
@@ -9,7 +9,7 @@ RenderGraph::RenderGraph(RenderGraph &&rhs) {
   passes = rhs.passes;
   attachments = rhs.attachments;
   swapchainAttachments = rhs.swapchainAttachments;
-  resourceMap = resourceMap;
+  resourceMap = rhs.resourceMap;
   registry = rhs.registry;
 
   rhs.passes.clear();

--- a/engine/src/renderer/vulkan/VulkanRenderData.cpp
+++ b/engine/src/renderer/vulkan/VulkanRenderData.cpp
@@ -29,8 +29,6 @@ VulkanRenderData::VulkanRenderData(
     : entityContext(entityContext_), scene(scene_),
       shadowMaterials(shadowMaterials_), shadowmaps(shadowmaps_) {
 
-  const auto &cameraBuffer = std::static_pointer_cast<VulkanHardwareBuffer>(
-      scene->getActiveCamera()->getUniformBuffer());
   sceneBuffer = std::dynamic_pointer_cast<VulkanHardwareBuffer>(
       resourceAllocator->createUniformBuffer(sizeof(SceneBufferObject)));
 }

--- a/engine/src/renderer/vulkan/VulkanRenderer.cpp
+++ b/engine/src/renderer/vulkan/VulkanRenderer.cpp
@@ -23,8 +23,6 @@
 
 namespace liquid {
 
-constexpr uint32_t NUM_LIGHTS = 16;
-
 VulkanRenderer::VulkanRenderer(EntityContext &entityContext_,
                                GLFWWindow *window, bool enableValidations)
     : entityContext(entityContext_), renderBackend(window, enableValidations),

--- a/engine/tests/renderer/RenderGraph.test.cpp
+++ b/engine/tests/renderer/RenderGraph.test.cpp
@@ -8,8 +8,6 @@ struct EmptyScope {};
 constexpr auto noopExecutor = [](liquid::RenderCommandList &commandList,
                                  EmptyScope &scope,
                                  liquid::RenderGraphRegistry &registry) {};
-constexpr auto noopBuilder = [](liquid::RenderGraphBuilder &builder,
-                                EmptyScope &scope) {};
 
 class RenderGraphTest : public ::testing::Test {
 public:

--- a/engine/tests/renderer/RenderGraphBuilder.test.cpp
+++ b/engine/tests/renderer/RenderGraphBuilder.test.cpp
@@ -90,7 +90,7 @@ TEST_F(RenderGraphBuilderDeathTest,
                                      liquid::AttachmentLoadOp::Load,
                                      liquid::AttachmentStoreOp::Store,
                                      glm::vec4{1.0f, 0.0f, 2.0f, 0.5f}};
-  auto resourceId = builder.write("Test color", color);
+  builder.write("Test color", color);
   EXPECT_DEATH(builder.write("Test color", {}), ".*");
 }
 
@@ -139,7 +139,7 @@ TEST_F(RenderGraphBuilderDeathTest,
   auto pass1 = std::make_shared<NoncePass>("nonce", 1);
 
   liquid::RenderGraphBuilder builder(graph, pass1.get());
-  auto resourceId = builder.writeSwapchain("Test color", {});
+  builder.writeSwapchain("Test color", {});
   EXPECT_DEATH(builder.writeSwapchain("Test color", {}), ".*");
 }
 


### PR DESCRIPTION
- Remove unused variables
- Fix warnings
- Disable editandcontinue for all toolsets
- Fix precompiled headers for clang
- Update macOS deployment target to 12.0