### PR TITLE
Write to the same resources from all passes

### DIFF
--- a/demos/basic-triangle/src/main.cpp
+++ b/demos/basic-triangle/src/main.cpp
@@ -94,22 +94,19 @@ int main() {
   };
 
   liquid::RenderGraph graph;
+
+  graph.create("depthBuffer",
+               {liquid::AttachmentType::Depth,
+                liquid::AttachmentSizeMethod::SwapchainRelative, 100, 100, 1,
+                VK_FORMAT_D32_SFLOAT, liquid::DepthStencilClear{1.0f, 0}});
   graph.addInlinePass<Scope>(
       "mainPass",
       [shaderBasicVert, shaderBasicFrag, shaderRedFrag, shaderTextureVert,
        shaderTextureFrag,
        &materials](liquid::RenderGraphBuilder &builder, Scope &scope) {
-        builder.writeSwapchain("mainColor",
-                               {liquid::AttachmentType::Color,
-                                liquid::AttachmentLoadOp::Clear,
-                                liquid::AttachmentStoreOp::Store,
-                                glm::vec4{0.19f, 0.21f, 0.26f, 1.0f}});
+        builder.write("SWAPCHAIN");
 
-        builder.writeSwapchain("mainDepth",
-                               {liquid::AttachmentType::Depth,
-                                liquid::AttachmentLoadOp::Clear,
-                                liquid::AttachmentStoreOp::Store,
-                                liquid::DepthStencilClear{1.0f, 0}});
+        builder.write("depthBuffer");
 
         auto createTrianglePipelines =
             [&builder](const liquid::SharedPtr<liquid::Shader> &vertShader,
@@ -173,7 +170,7 @@ int main() {
       });
 
   graph.addPass<liquid::ImguiPass>("imgui", renderer->getRenderBackend(),
-                                   renderer->getShaderLibrary(), "mainColor");
+                                   renderer->getShaderLibrary(), "SWAPCHAIN");
 
   mainLoop.run(
       graph, [instancePtr, materials](double dt) mutable { return true; },

--- a/editor/src/main.cpp
+++ b/editor/src/main.cpp
@@ -74,20 +74,9 @@ int main() {
           "editorDebug",
           [&renderer](liquid::RenderGraphBuilder &builder,
                       EditorDebugScope &scope) {
-            builder.read("environmentColor");
-            builder.writeSwapchain("editorDebugColor",
-                                   liquid::RenderPassSwapchainAttachment{
-                                       liquid::AttachmentType::Color,
-                                       liquid::AttachmentLoadOp::Load,
-                                       liquid::AttachmentStoreOp::Store,
-                                       glm::vec4(1.0f, 1.0f, 1.0f, 1.0f)});
+            builder.write("SWAPCHAIN");
+            builder.write("depthBuffer");
 
-            builder.writeSwapchain("editorDebugDepth",
-                                   liquid::RenderPassSwapchainAttachment{
-                                       liquid::AttachmentType::Depth,
-                                       liquid::AttachmentLoadOp::Load,
-                                       liquid::AttachmentStoreOp::Store,
-                                       liquid::DepthStencilClear{1.0, 0}});
             scope.editorGridPipeline =
                 builder.create(liquid::PipelineDescriptor{
                     renderer->getShaderLibrary()->getShader("editor-grid.vert"),

--- a/engine/src/renderer/Texture.cpp
+++ b/engine/src/renderer/Texture.cpp
@@ -4,8 +4,10 @@
 namespace liquid {
 
 Texture::Texture(const SharedPtr<TextureBinder> &binder_, size_t size_,
-                 StatsManager &statsManager_)
-    : binder(binder_), size(size_), statsManager(statsManager_) {
+                 uint32_t width_, uint32_t height_, uint32_t layers_,
+                 uint32_t format_, StatsManager &statsManager_)
+    : binder(binder_), size(size_), width(width_), height(height_),
+      layers(layers_), format(format_), statsManager(statsManager_) {
   statsManager.addTexture(size);
 }
 

--- a/engine/src/renderer/Texture.h
+++ b/engine/src/renderer/Texture.h
@@ -34,8 +34,10 @@ struct TextureCubemapData {
 struct TextureFramebufferData {
   uint32_t width = 0;
   uint32_t height = 0;
-  uint32_t format = 0;
   uint32_t layers = 0;
+  uint32_t format = 0;
+  uint32_t usageFlags = 0;
+  uint32_t aspectMask = 0;
 };
 
 class Texture : public std::enable_shared_from_this<Texture> {
@@ -45,9 +47,14 @@ public:
    *
    * @param binder Texture binder
    * @param size Texture size
+   * @param width Texture width
+   * @param height Texture height
+   * @param layers Texture layers
+   * @param format Texture format
    * @param statsManager Stats manager
    */
-  Texture(const SharedPtr<TextureBinder> &binder, size_t size,
+  Texture(const SharedPtr<TextureBinder> &binder, size_t size, uint32_t width,
+          uint32_t height, uint32_t layers, uint32_t format,
           StatsManager &statsManager);
 
   /**
@@ -76,10 +83,42 @@ public:
    */
   inline size_t getSize() const { return size; }
 
+  /**
+   * @brief Get width
+   *
+   * @return Width
+   */
+  inline uint32_t getWidth() const { return width; }
+
+  /**
+   * @brief Get height
+   *
+   * @return Height
+   */
+  inline uint32_t getHeight() const { return height; }
+
+  /**
+   * @brief Get layers
+   *
+   * @return Layers
+   */
+  inline uint32_t getLayers() const { return layers; }
+
+  /**
+   * @brief Get format
+   *
+   * @return Format
+   */
+  inline uint32_t getFormat() const { return format; }
+
 private:
   SharedPtr<TextureBinder> binder = nullptr;
   StatsManager &statsManager;
   size_t size = 0;
+  uint32_t width = 0;
+  uint32_t height = 0;
+  uint32_t layers = 0;
+  uint32_t format = 0;
 };
 
 } // namespace liquid

--- a/engine/src/renderer/passes/EnvironmentPass.cpp
+++ b/engine/src/renderer/passes/EnvironmentPass.cpp
@@ -12,7 +12,6 @@ EnvironmentPass::EnvironmentPass(const String &name,
       shaderLibrary(shaderLibrary_), renderData(renderData_) {}
 
 void EnvironmentPass::buildInternal(RenderGraphBuilder &builder) {
-  builder.read("mainColor");
   pipelineId = builder.create(PipelineDescriptor{
       shaderLibrary->getShader("__engine.skybox.default.vertex"),
       shaderLibrary->getShader("__engine.skybox.default.fragment"),
@@ -21,14 +20,8 @@ void EnvironmentPass::buildInternal(RenderGraphBuilder &builder) {
                          FrontFace::Clockwise},
       PipelineColorBlend{{PipelineColorBlendAttachment{}}}});
 
-  builder.writeSwapchain("environmentColor",
-                         RenderPassSwapchainAttachment{
-                             AttachmentType::Color, AttachmentLoadOp::Load,
-                             AttachmentStoreOp::Store, glm::vec4{}});
-  builder.writeSwapchain("environmentDepth",
-                         RenderPassSwapchainAttachment{
-                             AttachmentType::Depth, AttachmentLoadOp::Load,
-                             AttachmentStoreOp::Store, DepthStencilClear{}});
+  builder.write("SWAPCHAIN");
+  builder.write("depthBuffer");
 }
 
 void EnvironmentPass::execute(RenderCommandList &commandList,

--- a/engine/src/renderer/passes/ImguiPass.cpp
+++ b/engine/src/renderer/passes/ImguiPass.cpp
@@ -14,11 +14,8 @@ ImguiPass::ImguiPass(const String &name, GraphResourceId renderPassId,
       shaderLibrary(shaderLibrary_), previousColor(previousColor_) {}
 
 void ImguiPass::buildInternal(RenderGraphBuilder &builder) {
-  builder.read(previousColor);
-  builder.writeSwapchain(
-      "imguiColor", RenderPassSwapchainAttachment{AttachmentType::Color,
-                                                  AttachmentLoadOp::Load,
-                                                  AttachmentStoreOp::Store});
+  builder.read("SWAPCHAIN");
+  builder.write("SWAPCHAIN");
 
   pipelineId = builder.create(PipelineDescriptor{
       shaderLibrary->getShader("__engine.imgui.default.vertex"),

--- a/engine/src/renderer/passes/ScenePass.cpp
+++ b/engine/src/renderer/passes/ScenePass.cpp
@@ -3,8 +3,6 @@
 
 namespace liquid {
 
-constexpr glm::vec4 blueishClearValue{0.19f, 0.21f, 0.26f, 1.0f};
-
 ScenePass::ScenePass(const String &name, GraphResourceId resourceId,
                      EntityContext &entityContext,
                      ShaderLibrary *shaderLibrary_,
@@ -15,14 +13,9 @@ ScenePass::ScenePass(const String &name, GraphResourceId resourceId,
       debugManager(debugManager_) {}
 
 void ScenePass::buildInternal(RenderGraphBuilder &builder) {
-  builder.writeSwapchain("mainColor",
-                         RenderPassSwapchainAttachment{
-                             AttachmentType::Color, AttachmentLoadOp::Clear,
-                             AttachmentStoreOp::Store, blueishClearValue});
-  builder.writeSwapchain(
-      "mainDepth", RenderPassSwapchainAttachment{
-                       AttachmentType::Depth, AttachmentLoadOp::Clear,
-                       AttachmentStoreOp::Store, DepthStencilClear{1.0f, 0}});
+  builder.write("SWAPCHAIN");
+  builder.write("depthBuffer");
+
   shadowMapTextureId = builder.read("shadowmap");
   pipelineId = builder.create(PipelineDescriptor{
       shaderLibrary->getShader("__engine.default.pbr.vertex"),

--- a/engine/src/renderer/passes/ShadowPass.cpp
+++ b/engine/src/renderer/passes/ShadowPass.cpp
@@ -3,9 +3,6 @@
 
 namespace liquid {
 
-constexpr uint32_t NUM_LIGHTS = 16;
-constexpr uint32_t SHADOWMAP_DIMENSIONS = 2048;
-
 ShadowPass::ShadowPass(const String &name, GraphResourceId renderPass,
                        EntityContext &entityContext,
                        ShaderLibrary *shaderLibrary_,
@@ -14,17 +11,7 @@ ShadowPass::ShadowPass(const String &name, GraphResourceId renderPass,
       sceneRenderer(entityContext, false), shadowMaterials(shadowMaterials_) {}
 
 void ShadowPass::buildInternal(RenderGraphBuilder &builder) {
-  shadowMapId = builder.write("shadowmap",
-                              RenderPassAttachment{AttachmentType::Depth,
-                                                   TextureFramebufferData{
-                                                       SHADOWMAP_DIMENSIONS,
-                                                       SHADOWMAP_DIMENSIONS,
-                                                       VK_FORMAT_D16_UNORM,
-                                                       NUM_LIGHTS,
-                                                   },
-                                                   AttachmentLoadOp::Clear,
-                                                   AttachmentStoreOp::Store,
-                                                   DepthStencilClear{1.0f, 0}});
+  shadowMapId = builder.write("shadowmap");
 
   pipelineId = builder.create(PipelineDescriptor{
       shaderLibrary->getShader("__engine.default.shadowmap.vertex"),

--- a/engine/src/renderer/render-graph/RenderGraph.h
+++ b/engine/src/renderer/render-graph/RenderGraph.h
@@ -11,8 +11,6 @@
 
 namespace liquid {
 
-class RenderGraph;
-
 class RenderGraph {
 public:
   RenderGraph() = default;
@@ -59,6 +57,14 @@ public:
   }
 
   /**
+   * @brief Create texture resource
+   *
+   * @param name Resource name
+   * @param data Texture data
+   */
+  GraphResourceId create(const String &name, const AttachmentData &data);
+
+  /**
    * @brief Compile graph
    *
    * @return Topologically sorted list of render passes
@@ -66,25 +72,11 @@ public:
   std::vector<RenderGraphPassBase *> compile();
 
   /**
-   * @brief Add attachment
+   * @brief Set swapchain clear color
    *
-   * @param name Attachment name
-   * @param attachment Attachment object
-   * @return Attachment ID
+   * @param color Swapchain color
    */
-  GraphResourceId addAttachment(const String &name,
-                                const RenderPassAttachment &attachment);
-
-  /**
-   * @brief Add swapchain attachment
-   *
-   * @param name Attachment name
-   * @param attachment Attachment object
-   * @return Attachment ID
-   */
-  GraphResourceId
-  addSwapchainAttachment(const String &name,
-                         const RenderPassSwapchainAttachment &attachment);
+  void setSwapchainColor(const glm::vec4 &color);
 
   /**
    * @brief Add pipeline
@@ -116,26 +108,41 @@ public:
   }
 
   /**
-   * @brief Check if resource ID has associated attachment
+   * @brief Check if resource ID has associated texture
    *
    * @param id Resource ID
-   * @retval true Attachment exists for resource ID
-   * @retval false No attachment associated with resource ID
+   * @retval true Texture exists for resource ID
+   * @retval false Texture does not exist for resource ID
    */
-  inline const bool hasAttachment(GraphResourceId id) const {
-    return attachments.find(id) != attachments.end();
+  inline const bool hasTexture(GraphResourceId id) const {
+    return textures.find(id) != textures.end();
   }
 
   /**
-   * @brief Check if resource ID has associated swapchain attachment
+   * @brief Get textures
+   *
+   * @return Textures
+   */
+  inline const std::unordered_map<GraphResourceId, AttachmentData> &
+  getTextures() const {
+    return textures;
+  }
+
+  /**
+   * @brief Get swapchain color
+   *
+   * @return Swapchain color
+   */
+  inline const glm::vec4 &getSwapchainColor() const { return swapchainColor; }
+
+  /**
+   * @brief Check if resource is swapchain
    *
    * @param id Resource ID
-   * @retval true Swapchain attachment exists for resource ID
-   * @retval false No swapchain attachment associated with resource ID
+   * @retval true Resource is swapchain
+   * @retval false Resource is not swapchain
    */
-  inline const bool hasSwapchainAttachment(GraphResourceId id) const {
-    return swapchainAttachments.find(id) != swapchainAttachments.end();
-  }
+  inline const bool isSwapchain(GraphResourceId id) const { return id == 0; }
 
   /**
    * @brief Check if resource is a pipeline
@@ -146,27 +153,6 @@ public:
    */
   inline const bool isPipeline(GraphResourceId id) const {
     return pipelines.find(id) != pipelines.end();
-  }
-
-  /**
-   * @brief Get attachment resource
-   *
-   * @param id Resource ID
-   * @return Attachment
-   */
-  inline const RenderPassAttachment &getAttachment(GraphResourceId id) const {
-    return attachments.at(id);
-  }
-
-  /**
-   * @brief Get swapchain attachment resource
-   *
-   * @param id Resource ID
-   * @return Attachment
-   */
-  inline const RenderPassSwapchainAttachment &
-  getSwapchainAttachment(GraphResourceId id) const {
-    return swapchainAttachments.at(id);
   }
 
   /**
@@ -225,16 +211,16 @@ private:
   void addPassInternal(RenderGraphPassBase *pass);
 
 private:
-  std::unordered_map<GraphResourceId, RenderPassAttachment> attachments;
   std::unordered_map<GraphResourceId, PipelineDescriptor> pipelines;
-  std::unordered_map<String, GraphResourceId> resourceMap;
-  std::unordered_map<GraphResourceId, RenderPassSwapchainAttachment>
-      swapchainAttachments;
+  std::unordered_map<GraphResourceId, AttachmentData> textures;
+  std::unordered_map<String, GraphResourceId> resourceMap{{"SWAPCHAIN", 0}};
   std::vector<RenderGraphPassBase *> passes;
 
-  GraphResourceId lastId = 0;
+  GraphResourceId lastId = 1;
 
   RenderGraphRegistry registry;
+
+  glm::vec4 swapchainColor{};
 };
 
 } // namespace liquid

--- a/engine/src/renderer/render-graph/RenderGraphAttachmentDescriptor.h
+++ b/engine/src/renderer/render-graph/RenderGraphAttachmentDescriptor.h
@@ -1,7 +1,5 @@
 #pragma once
 
-#include "renderer/Texture.h"
-
 namespace liquid {
 
 enum class AttachmentLoadOp { Load, Clear, DontCare };
@@ -10,21 +8,24 @@ enum class AttachmentStoreOp { Store, DontCare };
 
 enum class AttachmentType { Color, Depth };
 
+enum class AttachmentSizeMethod { Fixed, SwapchainRelative };
+
 struct DepthStencilClear {
   float clearDepth = 0.0f;
   uint32_t clearStencil = 0;
 };
 
-struct RenderPassAttachment {
-  AttachmentType type;
-  TextureFramebufferData textureData{};
-  AttachmentLoadOp loadOp;
-  AttachmentStoreOp storeOp;
+struct AttachmentData {
+  AttachmentType type = AttachmentType::Color;
+  AttachmentSizeMethod sizeMethod = AttachmentSizeMethod::Fixed;
+  uint32_t width = 0;
+  uint32_t height = 0;
+  uint32_t layers = 0;
+  uint32_t format = 0;
   std::variant<glm::vec4, DepthStencilClear> clearValue;
 };
 
-struct RenderPassSwapchainAttachment {
-  AttachmentType type;
+struct RenderPassAttachment {
   AttachmentLoadOp loadOp;
   AttachmentStoreOp storeOp;
   std::variant<glm::vec4, DepthStencilClear> clearValue;

--- a/engine/src/renderer/render-graph/RenderGraphBuilder.cpp
+++ b/engine/src/renderer/render-graph/RenderGraphBuilder.cpp
@@ -11,23 +11,23 @@ RenderGraphBuilder::RenderGraphBuilder(RenderGraph &graph_,
                                        RenderGraphPassBase *pass_)
     : graph(graph_), pass(pass_) {}
 
-GraphResourceId
-RenderGraphBuilder::write(const String &name,
-                          const RenderPassAttachment &attachment) {
-  GraphResourceId resourceId = graph.addAttachment(name, attachment);
-  pass->addOutput(resourceId);
-  return resourceId;
-}
+GraphResourceId RenderGraphBuilder::write(const String &name) {
+  LIQUID_ASSERT(graph.hasResourceId(name),
+                "Resource named \"" + name + "\" does not exist");
+  GraphResourceId resourceId = graph.getResourceId(name);
+  pass->addOutput(resourceId, {});
 
-GraphResourceId RenderGraphBuilder::writeSwapchain(
-    const String &name, const RenderPassSwapchainAttachment &attachment) {
-  GraphResourceId resourceId = graph.addSwapchainAttachment(name, attachment);
-  pass->addOutput(resourceId);
-  pass->setSwapchainRelative(true);
+  if (graph.isSwapchain(resourceId) ||
+      graph.getTextures().at(resourceId).sizeMethod ==
+          AttachmentSizeMethod::SwapchainRelative) {
+    pass->setSwapchainRelative(true);
+  }
   return resourceId;
 }
 
 GraphResourceId RenderGraphBuilder::read(const String &name) {
+  LIQUID_ASSERT(graph.hasResourceId(name),
+                "Resource named \"" + name + "\" does not exist");
   GraphResourceId resourceId = graph.getResourceId(name);
   pass->addInput(resourceId);
   return resourceId;

--- a/engine/src/renderer/render-graph/RenderGraphBuilder.h
+++ b/engine/src/renderer/render-graph/RenderGraphBuilder.h
@@ -22,34 +22,18 @@ public:
   /**
    * @brief Write attachment resource
    *
-   * Adds resource to graph and adds resource ID
-   * to render pass output
+   * Adds resource ID to render pass output
    *
    * @param name Resource name
-   * @param attachment Attachment object
    * @return ID associated with resource
    */
-  GraphResourceId write(const String &name,
-                        const RenderPassAttachment &attachment);
-
-  /**
-   * @brief Write swapchain resource
-   *
-   * @param name Swapchain attachment name
-   * @param attachment Swapchain attachment description
-   *
-   * @return Swapchain resource ID
-   */
-  GraphResourceId
-  writeSwapchain(const String &name,
-                 const RenderPassSwapchainAttachment &attachment);
+  GraphResourceId write(const String &name);
 
   /**
    * @brief Read attachment resource
    *
    * Reads ID resource from graph and adds it
-   * to render pass input. ID will be provided
-   * regardless of existence of resource
+   * to render pass input.
    *
    * @param name Resource name
    * @return ID associated with resource

--- a/engine/src/renderer/render-graph/RenderGraphPassBase.cpp
+++ b/engine/src/renderer/render-graph/RenderGraphPassBase.cpp
@@ -17,8 +17,9 @@ void RenderGraphPassBase::addInput(GraphResourceId resourceId) {
   inputs.push_back(resourceId);
 }
 
-void RenderGraphPassBase::addOutput(GraphResourceId resourceId) {
-  outputs.push_back(resourceId);
+void RenderGraphPassBase::addOutput(GraphResourceId resourceId,
+                                    const RenderPassAttachment &attachment) {
+  outputs.insert({resourceId, attachment});
 }
 
 void RenderGraphPassBase::addResource(GraphResourceId resourceId) {

--- a/engine/src/renderer/render-graph/RenderGraphPassBase.h
+++ b/engine/src/renderer/render-graph/RenderGraphPassBase.h
@@ -5,6 +5,8 @@
 #include "../RenderCommandList.h"
 #include "RenderGraphRegistry.h"
 
+#include "RenderGraphAttachmentDescriptor.h"
+
 namespace liquid {
 
 class RenderGraphPassBase {
@@ -72,8 +74,10 @@ public:
    * @brief Add output resource
    *
    * @param resourceId Output resource ID
+   * @param attachment Attachment
    */
-  void addOutput(GraphResourceId resourceId);
+  void addOutput(GraphResourceId resourceId,
+                 const RenderPassAttachment &attachment);
 
   /**
    * @brief Add resource
@@ -103,7 +107,8 @@ public:
    *
    * @return Output resources
    */
-  inline const std::vector<GraphResourceId> &getOutputs() const {
+  inline std::unordered_map<GraphResourceId, RenderPassAttachment> &
+  getOutputs() {
     return outputs;
   }
 
@@ -141,8 +146,9 @@ public:
 
 private:
   std::vector<GraphResourceId> inputs;
-  std::vector<GraphResourceId> outputs;
   std::vector<GraphResourceId> resources;
+  std::unordered_map<GraphResourceId, RenderPassAttachment> outputs;
+
   bool swapchainRelative = false;
 
   GraphResourceId renderPass;

--- a/engine/src/renderer/vulkan/VulkanGraphEvaluator.h
+++ b/engine/src/renderer/vulkan/VulkanGraphEvaluator.h
@@ -20,7 +20,6 @@ class VulkanGraphEvaluator {
     uint32_t width = 0;
     uint32_t height = 0;
     uint32_t layers = 0;
-    SharedPtr<Texture> texture = nullptr;
   };
 
 public:
@@ -73,44 +72,39 @@ private:
   void buildPass(RenderGraphPassBase *pass, RenderGraph &graph, bool force);
 
   /**
-   * @brief Create swapchain color attachment
+   * @brief Create swapchain attachment
    *
-   * @param attachment Swapchain attachment description
+   * @param attachment Attachment description
    * @param index Attachment index
    * @return Attachment info
    */
-  VulkanAttachmentInfo createSwapchainColorAttachment(
-      const RenderPassSwapchainAttachment &attachment, uint32_t index);
-
-  /**
-   * @brief Create swapchain depth attachment
-   *
-   * @param attachment Swapchain attachment description
-   * @param index Attachment index
-   * @return Attachment info
-   */
-  VulkanAttachmentInfo createSwapchainDepthAttachment(
-      const RenderPassSwapchainAttachment &attachment, uint32_t index);
+  VulkanAttachmentInfo
+  createSwapchainAttachment(const RenderPassAttachment &attachment,
+                            uint32_t index);
 
   /**
    * @brief Create color attachment
    *
    * @param attachment Attachment description
+   * @param texture Texture
    * @param index Attachment index
    * @return Attachment info
    */
   VulkanAttachmentInfo
-  createColorAttachment(const RenderPassAttachment &attachment, uint32_t index);
+  createColorAttachment(const RenderPassAttachment &attachment,
+                        const SharedPtr<Texture> &texture, uint32_t index);
 
   /**
    * @brief Create depth attachment
    *
    * @param attachment Attachment description
+   * @param texture Texture
    * @param index Attachment index
    * @return Attachment info
    */
   VulkanAttachmentInfo
-  createDepthAttachment(const RenderPassAttachment &attachment, uint32_t index);
+  createDepthAttachment(const RenderPassAttachment &attachment,
+                        const SharedPtr<Texture> &texture, uint32_t index);
 
   /**
    * @brief Create graphics pipeline
@@ -122,6 +116,16 @@ private:
   const SharedPtr<Pipeline>
   createGraphicsPipeline(const PipelineDescriptor &descriptor,
                          VkRenderPass renderPass);
+
+  /**
+   * @brief Create texture
+   *
+   * @param resourceId Resource Id
+   * @param data Attachment data
+   * @return Texture
+   */
+  SharedPtr<Texture> createTexture(GraphResourceId resourceId,
+                                   const AttachmentData &data);
 
 private:
   VulkanContext &vulkanInstance;

--- a/engine/src/renderer/vulkan/VulkanRenderer.cpp
+++ b/engine/src/renderer/vulkan/VulkanRenderer.cpp
@@ -70,6 +70,25 @@ RenderGraph
 VulkanRenderer::createRenderGraph(const SharedPtr<VulkanRenderData> &renderData,
                                   const String &imguiDep) {
   RenderGraph graph;
+  constexpr uint32_t NUM_LIGHTS = 16;
+  constexpr uint32_t SHADOWMAP_DIMENSIONS = 2048;
+  constexpr glm::vec4 BLUEISH_CLEAR_VALUE{0.19f, 0.21f, 0.26f, 1.0f};
+
+  graph.setSwapchainColor(BLUEISH_CLEAR_VALUE);
+
+  graph.create("shadowmap",
+               AttachmentData{AttachmentType::Depth,
+                              AttachmentSizeMethod::Fixed, SHADOWMAP_DIMENSIONS,
+                              SHADOWMAP_DIMENSIONS, NUM_LIGHTS,
+                              VK_FORMAT_D16_UNORM, DepthStencilClear{1.0f, 0}});
+
+  constexpr uint32_t DEPTH_BUFFER_SIZE_PERCENTAGE = 100;
+  graph.create(
+      "depthBuffer",
+      AttachmentData{AttachmentType::Depth,
+                     AttachmentSizeMethod::SwapchainRelative,
+                     DEPTH_BUFFER_SIZE_PERCENTAGE, DEPTH_BUFFER_SIZE_PERCENTAGE,
+                     1, VK_FORMAT_D32_SFLOAT, DepthStencilClear{1.0f, 0}});
 
   graph.addPass<ShadowPass>("shadowPass", entityContext, shaderLibrary,
                             shadowMaterials);

--- a/engine/src/renderer/vulkan/VulkanSwapchain.h
+++ b/engine/src/renderer/vulkan/VulkanSwapchain.h
@@ -102,20 +102,6 @@ public:
     return imageViews;
   }
 
-  /**
-   * @brief Gets depth format
-   *
-   * @return Depth format
-   */
-  inline VkFormat getDepthFormat() { return depthFormat; }
-
-  /**
-   * @brief Gets depth image view
-   *
-   * @return Depth image view
-   */
-  inline VkImageView getDepthImageView() { return depthImageView; }
-
 private:
   /**
    * @brief Picks most suitable surface format
@@ -154,12 +140,8 @@ private:
 private:
   VkSwapchainKHR swapchain = VK_NULL_HANDLE;
   std::vector<VkImageView> imageViews;
-  VkImageView depthImageView = VK_NULL_HANDLE;
-  VkImage depthImage = VK_NULL_HANDLE;
 
-  VmaAllocation depthImageAllocation = nullptr;
   VmaAllocator allocator = nullptr;
-  VkFormat depthFormat = VK_FORMAT_D32_SFLOAT;
 
   VkExtent2D extent{};
   VkSurfaceFormatKHR surfaceFormat{};

--- a/engine/tests/mocks/TestResourceAllocator.h
+++ b/engine/tests/mocks/TestResourceAllocator.h
@@ -32,7 +32,8 @@ public:
     binder->height = texture.width;
     binder->data = texture.data;
     return std::make_shared<liquid::Texture>(
-        binder, texture.width * texture.height * 4, statsManager);
+        binder, texture.width * texture.height * 4, texture.width,
+        texture.height, 1, texture.format, statsManager);
   }
 
   virtual liquid::SharedPtr<liquid::Texture>
@@ -43,7 +44,8 @@ public:
     binder->height = texture.height;
     binder->data = texture.data;
     return std::make_shared<liquid::Texture>(
-        binder, texture.width * texture.height * 6 * 4, statsManager);
+        binder, texture.width * texture.height * 6 * 4, texture.width,
+        texture.height, 6, texture.format, statsManager);
   }
 
   virtual liquid::SharedPtr<liquid::Texture>
@@ -54,8 +56,9 @@ public:
     binder->height = data.height;
     binder->format = data.format;
     binder->data = nullptr;
-    return std::make_shared<liquid::Texture>(binder, data.width * data.height,
-                                             statsManager);
+    return std::make_shared<liquid::Texture>(
+        binder, data.width * data.height, data.width, data.height, data.layers,
+        data.format, statsManager);
   }
 
 protected:

--- a/engine/tests/renderer/Descriptor.test.cpp
+++ b/engine/tests/renderer/Descriptor.test.cpp
@@ -20,10 +20,10 @@ using DescriptorDeathTest = DescriptorTest;
 TEST_F(DescriptorTest, AddsTextureBinding) {
   liquid::Descriptor descriptor;
 
-  const auto &tex1 =
-      std::make_shared<liquid::Texture>(nullptr, 250, statsManager);
-  const auto &tex2 =
-      std::make_shared<liquid::Texture>(nullptr, 350, statsManager);
+  const auto &tex1 = std::make_shared<liquid::Texture>(nullptr, 250, 25, 10, 1,
+                                                       0, statsManager);
+  const auto &tex2 = std::make_shared<liquid::Texture>(nullptr, 350, 35, 10, 1,
+                                                       0, statsManager);
   descriptor.bind(2, {tex1, tex2},
                   liquid::DescriptorType::CombinedImageSampler);
   EXPECT_EQ(descriptor.getBindings().at(2).type,
@@ -49,10 +49,10 @@ TEST_F(DescriptorTest, AddsUniformBufferBinding) {
 
 TEST_F(DescriptorTest, CreatesHashFromBindings) {
   liquid::Descriptor descriptor;
-  const auto &tex1 =
-      std::make_shared<liquid::Texture>(nullptr, 250, statsManager);
-  const auto &tex2 =
-      std::make_shared<liquid::Texture>(nullptr, 350, statsManager);
+  const auto &tex1 = std::make_shared<liquid::Texture>(nullptr, 250, 25, 10, 1,
+                                                       0, statsManager);
+  const auto &tex2 = std::make_shared<liquid::Texture>(nullptr, 350, 35, 10, 1,
+                                                       0, statsManager);
   const auto &buffer1 = std::make_shared<TestBuffer>(
       liquid::HardwareBuffer::Uniform, 250, statsManager);
   const auto &buffer2 = std::make_shared<TestBuffer>(
@@ -83,8 +83,8 @@ TEST_F(DescriptorDeathTest, FailsIfBufferIsUsedForCombinedImageSampler) {
 }
 
 TEST_F(DescriptorDeathTest, FailsIfBufferIsUsedForSampler) {
-  const auto &tex =
-      std::make_shared<liquid::Texture>(nullptr, 250, statsManager);
+  const auto &tex = std::make_shared<liquid::Texture>(nullptr, 250, 25, 10, 1,
+                                                      0, statsManager);
   liquid::Descriptor descriptor;
   EXPECT_DEATH(
       { descriptor.bind(0, {tex}, liquid::DescriptorType::UniformBuffer); },

--- a/engine/tests/renderer/MaterialPBR.test.cpp
+++ b/engine/tests/renderer/MaterialPBR.test.cpp
@@ -15,13 +15,13 @@ TEST_F(MaterialPBRTest, GetsTextures) {
   EXPECT_EQ(properties.getTextures().size(), 0);
 
   properties.baseColorTexture =
-      std::make_shared<liquid::Texture>(nullptr, 0, statsManager);
+      std::make_shared<liquid::Texture>(nullptr, 0, 0, 0, 0, 0, statsManager);
   EXPECT_EQ(properties.getTextures().size(), 1);
   EXPECT_EQ(properties.getTextures()[0].get(),
             properties.baseColorTexture.get());
 
   properties.metallicRoughnessTexture =
-      std::make_shared<liquid::Texture>(nullptr, 0, statsManager);
+      std::make_shared<liquid::Texture>(nullptr, 0, 0, 0, 0, 0, statsManager);
   EXPECT_EQ(properties.getTextures().size(), 2);
   EXPECT_EQ(properties.getTextures()[0].get(),
             properties.baseColorTexture.get());
@@ -29,7 +29,7 @@ TEST_F(MaterialPBRTest, GetsTextures) {
             properties.metallicRoughnessTexture.get());
 
   properties.normalTexture =
-      std::make_shared<liquid::Texture>(nullptr, 0, statsManager);
+      std::make_shared<liquid::Texture>(nullptr, 0, 0, 0, 0, 0, statsManager);
   EXPECT_EQ(properties.getTextures().size(), 3);
   EXPECT_EQ(properties.getTextures()[0].get(),
             properties.baseColorTexture.get());
@@ -38,7 +38,7 @@ TEST_F(MaterialPBRTest, GetsTextures) {
   EXPECT_EQ(properties.getTextures()[2].get(), properties.normalTexture.get());
 
   properties.occlusionTexture =
-      std::make_shared<liquid::Texture>(nullptr, 0, statsManager);
+      std::make_shared<liquid::Texture>(nullptr, 0, 0, 0, 0, 0, statsManager);
   EXPECT_EQ(properties.getTextures().size(), 4);
   EXPECT_EQ(properties.getTextures()[0].get(),
             properties.baseColorTexture.get());
@@ -49,7 +49,7 @@ TEST_F(MaterialPBRTest, GetsTextures) {
             properties.occlusionTexture.get());
 
   properties.emissiveTexture =
-      std::make_shared<liquid::Texture>(nullptr, 0, statsManager);
+      std::make_shared<liquid::Texture>(nullptr, 0, 0, 0, 0, 0, statsManager);
   EXPECT_EQ(properties.getTextures().size(), 5);
   EXPECT_EQ(properties.getTextures()[0].get(),
             properties.baseColorTexture.get());
@@ -107,29 +107,29 @@ TEST_F(MaterialPBRTest, GetsProperties) {
   EXPECT_PROP_EQ(15, "emissiveFactor", glm::vec3, glm::vec3(1.0, 0.2, 0.4));
 
   properties.baseColorTexture =
-      std::make_shared<liquid::Texture>(nullptr, 0, statsManager);
+      std::make_shared<liquid::Texture>(nullptr, 0, 0, 0, 0, 0, statsManager);
   EXPECT_PROP_EQ(0, "baseColorTexture", int, 0);
 
   properties.normalTexture =
-      std::make_shared<liquid::Texture>(nullptr, 0, statsManager);
+      std::make_shared<liquid::Texture>(nullptr, 0, 0, 0, 0, 0, statsManager);
   EXPECT_PROP_EQ(0, "baseColorTexture", int, 0);
   EXPECT_PROP_EQ(7, "normalTexture", int, 1);
 
   properties.occlusionTexture =
-      std::make_shared<liquid::Texture>(nullptr, 0, statsManager);
+      std::make_shared<liquid::Texture>(nullptr, 0, 0, 0, 0, 0, statsManager);
   EXPECT_PROP_EQ(0, "baseColorTexture", int, 0);
   EXPECT_PROP_EQ(7, "normalTexture", int, 1);
   EXPECT_PROP_EQ(10, "occlusionTexture", int, 2);
 
   properties.metallicRoughnessTexture =
-      std::make_shared<liquid::Texture>(nullptr, 0, statsManager);
+      std::make_shared<liquid::Texture>(nullptr, 0, 0, 0, 0, 0, statsManager);
   EXPECT_PROP_EQ(0, "baseColorTexture", int, 0);
   EXPECT_PROP_EQ(3, "metallicRoughnessTexture", int, 1);
   EXPECT_PROP_EQ(7, "normalTexture", int, 2);
   EXPECT_PROP_EQ(10, "occlusionTexture", int, 3);
 
   properties.emissiveTexture =
-      std::make_shared<liquid::Texture>(nullptr, 0, statsManager);
+      std::make_shared<liquid::Texture>(nullptr, 0, 0, 0, 0, 0, statsManager);
   EXPECT_PROP_EQ(0, "baseColorTexture", int, 0);
   EXPECT_PROP_EQ(3, "metallicRoughnessTexture", int, 1);
   EXPECT_PROP_EQ(7, "normalTexture", int, 2);
@@ -143,20 +143,20 @@ TEST_F(MaterialPBRTest, SetsShadersPropertiesAndTextures) {
   TestResourceAllocator resourceAllocator;
 
   liquid::MaterialPBR::Properties properties{
-      std::make_shared<liquid::Texture>(nullptr, 0, statsManager),
+      std::make_shared<liquid::Texture>(nullptr, 0, 0, 0, 0, 0, statsManager),
       0,
       {1.0f, 0.2f, 0.3f, 0.4f},
       nullptr,
       0,
       0.2f,
       0.6f,
-      std::make_shared<liquid::Texture>(nullptr, 0, statsManager),
+      std::make_shared<liquid::Texture>(nullptr, 0, 0, 0, 0, 0, statsManager),
       1,
       0.7f,
       nullptr,
       0,
       0.3f,
-      std::make_shared<liquid::Texture>(nullptr, 0, statsManager),
+      std::make_shared<liquid::Texture>(nullptr, 0, 0, 0, 0, 0, statsManager),
       0,
       glm::vec3(1.0f, 0.2f, 0.4f)};
 

--- a/engine/tests/renderer/RenderGraphPassBase.test.cpp
+++ b/engine/tests/renderer/RenderGraphPassBase.test.cpp
@@ -25,6 +25,7 @@ public:
 
 TEST_F(RenderGraphPassBaseTest, SetsDirtyFlagToFalseIfBuildIsCalled) {
   RenderGraphPassMock pass("Test", 1);
+  EXPECT_CALL(pass, buildInternal).Times(1);
   EXPECT_TRUE(pass.isDirty());
   pass.build(liquid::RenderGraphBuilder(graph, &pass));
   EXPECT_FALSE(pass.isDirty());

--- a/engine/tests/renderer/RenderGraphRegistry.test.cpp
+++ b/engine/tests/renderer/RenderGraphRegistry.test.cpp
@@ -14,18 +14,18 @@ public:
 };
 
 TEST_F(RenderGraphRegistryTest, AddsTextureToRegistry) {
-  registry.addTexture(
-      1, std::make_shared<liquid::Texture>(nullptr, 100, statsManager));
+  registry.addTexture(1, std::make_shared<liquid::Texture>(nullptr, 100, 20, 5,
+                                                           1, 0, statsManager));
 
   EXPECT_TRUE(registry.hasTexture(1));
   EXPECT_EQ(registry.getTexture(1)->getSize(), 100);
 }
 
-TEST_F(RenderGraphRegistryTest, UpdatedExistingTextureInRegistry) {
-  registry.addTexture(
-      1, std::make_shared<liquid::Texture>(nullptr, 100, statsManager));
-  registry.addTexture(
-      1, std::make_shared<liquid::Texture>(nullptr, 250, statsManager));
+TEST_F(RenderGraphRegistryTest, UpdatesExistingTextureInRegistry) {
+  registry.addTexture(1, std::make_shared<liquid::Texture>(nullptr, 100, 20, 5,
+                                                           1, 0, statsManager));
+  registry.addTexture(1, std::make_shared<liquid::Texture>(nullptr, 250, 20, 5,
+                                                           1, 0, statsManager));
 
   EXPECT_TRUE(registry.hasTexture(1));
   EXPECT_EQ(registry.getTexture(1)->getSize(), 250);

--- a/engine/tests/renderer/Texture.test.cpp
+++ b/engine/tests/renderer/Texture.test.cpp
@@ -4,10 +4,22 @@
 #include "../mocks/TestTextureResourceBinder.h"
 #include <gtest/gtest.h>
 
-TEST(TextureTest, GetsResourceBinder) {
+TEST(TextureTest, StoresMetadataAndResourceBinder) {
   auto binder = std::make_shared<TestTextureResourceBinder>();
   liquid::StatsManager statsManager;
-  liquid::Texture texture(binder, 0, statsManager);
+
+  size_t size = 10;
+  uint32_t width = 20;
+  uint32_t height = 30;
+  uint32_t layers = 1;
+  uint32_t format = 1212;
+  liquid::Texture texture(binder, size, width, height, layers, format,
+                          statsManager);
 
   EXPECT_EQ(texture.getResourceBinder().get(), binder.get());
+  EXPECT_EQ(texture.getSize(), size);
+  EXPECT_EQ(texture.getWidth(), width);
+  EXPECT_EQ(texture.getHeight(), height);
+  EXPECT_EQ(texture.getLayers(), layers);
+  EXPECT_EQ(texture.getFormat(), format);
 }

--- a/engine/tests/renderer/vulkan/VulkanResourceAllocator.test.cpp
+++ b/engine/tests/renderer/vulkan/VulkanResourceAllocator.test.cpp
@@ -51,7 +51,13 @@ TEST_F(VulkanResourceAllocatorTests, CreatesTexture2D) {
   liquid::VulkanResourceAllocator resourceAllocator(uploadContext, nullptr,
                                                     nullptr, statsManager);
 
-  const auto &texture = resourceAllocator.createTexture2D({1, 7, 1, 0, data});
+  liquid::TextureData textureData{};
+  textureData.width = 1;
+  textureData.height = 7;
+  textureData.channels = 1;
+  textureData.format = 12121;
+  textureData.data = data;
+  const auto &texture = resourceAllocator.createTexture2D(textureData);
 
   EXPECT_NE(texture, nullptr);
   EXPECT_NE(texture->getResourceBinder(), nullptr);
@@ -64,6 +70,12 @@ TEST_F(VulkanResourceAllocatorTests, CreatesTexture2D) {
   EXPECT_NE(vulkanBinder->imageView, nullptr);
   EXPECT_NE(vulkanBinder->sampler, nullptr);
   EXPECT_NE(vulkanBinder->allocation, nullptr);
+
+  EXPECT_EQ(texture->getSize(), textureData.width * textureData.height * 4);
+  EXPECT_EQ(texture->getWidth(), textureData.width);
+  EXPECT_EQ(texture->getHeight(), textureData.height);
+  EXPECT_EQ(texture->getLayers(), 1);
+  EXPECT_EQ(texture->getFormat(), textureData.format);
 }
 
 TEST_F(VulkanResourceAllocatorTests, CreatesTextureCubemap) {
@@ -105,8 +117,14 @@ TEST_F(VulkanResourceAllocatorTests, CreatesTextureCubemap) {
   liquid::VulkanResourceAllocator resourceAllocator(uploadContext, nullptr,
                                                     nullptr, statsManager);
 
-  const auto &texture =
-      resourceAllocator.createTextureCubemap({5, 5, 1, 0, data});
+  liquid::TextureCubemapData textureData;
+  textureData.size = 250;
+  textureData.width = 5;
+  textureData.height = 6;
+  textureData.data = data;
+  textureData.format = 1211;
+
+  const auto &texture = resourceAllocator.createTextureCubemap(textureData);
 
   EXPECT_NE(texture, nullptr);
   EXPECT_NE(texture->getResourceBinder(), nullptr);
@@ -119,6 +137,11 @@ TEST_F(VulkanResourceAllocatorTests, CreatesTextureCubemap) {
   EXPECT_NE(vulkanBinder->imageView, nullptr);
   EXPECT_NE(vulkanBinder->sampler, nullptr);
   EXPECT_NE(vulkanBinder->allocation, nullptr);
+  EXPECT_EQ(texture->getSize(), textureData.size);
+  EXPECT_EQ(texture->getWidth(), textureData.width);
+  EXPECT_EQ(texture->getHeight(), textureData.height);
+  EXPECT_EQ(texture->getLayers(), 6);
+  EXPECT_EQ(texture->getFormat(), textureData.format);
 
   delete[] outData;
 }
@@ -156,7 +179,7 @@ TEST_F(VulkanResourceAllocatorTests, CreatesTextureFramebuffer) {
 
   liquid::TextureFramebufferData textureData{};
   textureData.width = 1024;
-  textureData.height = 1024;
+  textureData.height = 2048;
   textureData.layers = 5;
   textureData.format = VK_FORMAT_D16_UNORM;
   const auto &texture = resourceAllocator.createTextureFramebuffer(textureData);
@@ -172,4 +195,9 @@ TEST_F(VulkanResourceAllocatorTests, CreatesTextureFramebuffer) {
   EXPECT_NE(vulkanBinder->imageView, nullptr);
   EXPECT_NE(vulkanBinder->sampler, nullptr);
   EXPECT_NE(vulkanBinder->allocation, nullptr);
+  EXPECT_EQ(texture->getSize(), textureData.width * textureData.height);
+  EXPECT_EQ(texture->getWidth(), textureData.width);
+  EXPECT_EQ(texture->getHeight(), textureData.height);
+  EXPECT_EQ(texture->getLayers(), textureData.layers);
+  EXPECT_EQ(texture->getFormat(), textureData.format);
 }


### PR DESCRIPTION
- Add swapchain relative resource sizes
- Pass aspect mask and image usage to framebuffer creation function
- Add attachment size method
- Split attachment data from texture framebuffer data
- Store texture width, height, layers, and format metadata
- Create resource in graph
- Resources must exist before we can read or write to them
- Add depth buffer resource
- Remove depth image views from swapchain
- Update all passes to use depth buffer
- Automatically calculate loadOp and storeOp
- Remove writeSwapchain function
- Set "SWAPCHAIN" name as predefined swapchain attachment
- Remove second argument from builder.write
- Add clear value to Attachment data
- Cleanup