### PR TITLE
Fix editor debug pass artifacts

### DIFF
--- a/editor/assets/shaders/editor-grid.frag
+++ b/editor/assets/shaders/editor-grid.frag
@@ -22,6 +22,9 @@ void main() {
   // pos(t) = near + t * (far - near)
   vec3 fragPos = inNearPoint + t * (inFarPoint - inNearPoint);
 
+  // Default color
+  outColor = vec4(0.0, 0.0, 0.0, 0.0);
+
   // Compute lines
   if (t > 0) {
     vec2 gridCoord = fragPos.xz;

--- a/editor/src/main.cpp
+++ b/editor/src/main.cpp
@@ -86,7 +86,6 @@ int main() {
           "editorDebug",
           [&renderer](liquid::RenderGraphBuilder &builder,
                       EditorDebugScope &scope) {
-            builder.read("mainColor");
             builder.write("mainColor");
             builder.write("depthBuffer");
 


### PR DESCRIPTION
- Set default output color if no lines are drawn for the fragment
- Make editor grid not depend on main color