### PR TITLE
Add separate local transform values

### DIFF
--- a/demos/basic-triangle/src/main.cpp
+++ b/demos/basic-triangle/src/main.cpp
@@ -79,7 +79,7 @@ int main() {
       {std::make_shared<liquid::Camera>(renderer->getResourceAllocator())});
 
   scene->setActiveCamera(camera);
-  scene->getRootNode()->addChild(entity, glm::mat4{1.0f});
+  scene->getRootNode()->addChild(entity);
 
   glfwSetKeyCallback(window->getInstance(), key_callback);
 

--- a/demos/pong-3d/src/main.cpp
+++ b/demos/pong-3d/src/main.cpp
@@ -142,15 +142,22 @@ private:
   }
 
   void updateScene(float dt) {
-    p2->setTransform(glm::translate(glm::mat4{1.0f}, {botPosition, 0.0, 3.0}) *
-                     glm::scale(glm::mat4{1.0}, {1.0, 0.2, 0.1}));
+    {
+      auto &transform = p2->getTransform();
+      transform.localPosition = glm::vec3(botPosition, 0.0f, 3.0f);
+      transform.localScale = glm::vec3{1.0f, 0.2f, 0.1f};
+    }
 
-    p1->setTransform(
-        glm::translate(glm::mat4{1.0f}, {playerPosition, 0.0, -3.0}) *
-        glm::scale(glm::mat4{1.0}, {1.0, 0.2, 0.1}));
+    {
+      auto &transform = p1->getTransform();
+      transform.localPosition = glm::vec3(playerPosition, 0.0f, -3.0f);
+      transform.localScale = glm::vec3{1.0f, 0.2f, 0.1f};
+    }
 
-    ball->setTransform(glm::translate(
-        glm::mat4{1.0f}, {ballPosition.x, ballPosition.y, ballPosition.z}));
+    {
+      auto &transform = ball->getTransform();
+      transform.localPosition = ballPosition;
+    }
 
     scene->update();
   }
@@ -265,19 +272,22 @@ private:
         e4, createWallTransform({0.0, 0.0, -3.5}, 0, 5.0));
 
     // Create paddles
-    p1 = scene->getRootNode()->addChild(pe1, glm::mat4());
-    p2 = scene->getRootNode()->addChild(pe2, glm::mat4());
+    p1 = scene->getRootNode()->addChild(pe1);
+    p2 = scene->getRootNode()->addChild(pe2);
 
     // create ball
-    ball = scene->getRootNode()->addChild(ballEntity, glm::mat4());
+    ball = scene->getRootNode()->addChild(ballEntity);
   }
 
-  glm::mat4 createWallTransform(glm::vec3 position, float rotation,
-                                float scaleX) {
-    return glm::translate(glm::mat4{1.0}, position) *
-           glm::rotate(glm::mat4{1.0}, glm::radians(rotation),
-                       glm::vec3(0, 1, 0)) *
-           glm::scale(glm::mat4{1.0}, {scaleX, 0.2, 0.1});
+  liquid::TransformComponent createWallTransform(glm::vec3 position,
+                                                 float rotation, float scaleX) {
+    liquid::TransformComponent transform{};
+    transform.localPosition = position;
+    transform.localRotation =
+        glm::angleAxis(glm::radians(rotation), glm::vec3(0, 1, 0));
+
+    transform.localScale = glm::vec3(scaleX, 0.2f, 0.1f);
+    return transform;
   }
 
 private:

--- a/demos/scene-viewer/src/main.cpp
+++ b/demos/scene-viewer/src/main.cpp
@@ -277,11 +277,11 @@ int main() {
 
       editorCamera.update();
 
-      node->setTransform(
-          glm::rotate(glm::mat4{1.0f}, glm::radians(horizontalAngle),
-                      glm::vec3{0.0, 1.0, 0.0}) *
-          glm::rotate(glm::mat4{1.0f}, glm::radians(verticalAngle),
-                      glm::vec3{1.0, 0.0, 0.0}));
+      node->getTransform().localRotation =
+          glm::angleAxis(glm::radians(horizontalAngle),
+                         glm::vec3(0.0f, 1.0f, 0.0f)) *
+          glm::angleAxis(glm::radians(verticalAngle),
+                         glm::vec3(1.0f, 0.0f, 0.0f));
 
       return !changed;
     });

--- a/demos/scene-viewer/src/ui/EntityPropertyPanel.cpp
+++ b/demos/scene-viewer/src/ui/EntityPropertyPanel.cpp
@@ -42,23 +42,6 @@ void EntityPropertyPanel::renderTransformDetails() {
       context.getComponent<TransformComponent>(entity);
 
   if (ImGui::CollapsingHeader("Transform")) {
-    if (ImGui::BeginTable("table-transformLocal", 4,
-                          ImGuiTableFlags_Borders |
-                              ImGuiTableColumnFlags_WidthStretch |
-                              ImGuiTableFlags_RowBg)) {
-
-      ImGui::Text("Local transform");
-      for (uint32_t i = 0; i < 4; ++i) {
-        ImGui::TableNextRow();
-        for (uint32_t j = 0; j < 4; ++j) {
-          ImGui::TableNextColumn();
-          ImGui::Text("%f", transformComponent.transformLocal[i][j]);
-        }
-      }
-
-      ImGui::EndTable();
-    }
-
     if (ImGui::BeginTable("table-transformWorld", 4,
                           ImGuiTableFlags_Borders |
                               ImGuiTableColumnFlags_WidthStretch |
@@ -69,7 +52,7 @@ void EntityPropertyPanel::renderTransformDetails() {
         ImGui::TableNextRow();
         for (uint32_t j = 0; j < 4; ++j) {
           ImGui::TableNextColumn();
-          ImGui::Text("%f", transformComponent.transformWorld[i][j]);
+          ImGui::Text("%f", transformComponent.worldTransform[i][j]);
         }
       }
 

--- a/editor/src/ui/EntityPanel.cpp
+++ b/editor/src/ui/EntityPanel.cpp
@@ -4,6 +4,9 @@
 
 namespace liquidator {
 
+constexpr size_t VEC3_ARRAY_SIZE = 3;
+constexpr size_t VEC4_ARRAY_SIZE = 4;
+
 EntityPanel::EntityPanel(liquid::EntityContext &entityContext)
     : context(entityContext) {}
 
@@ -64,8 +67,6 @@ void EntityPanel::renderLight() {
       context.getComponent<liquid::LightComponent>(selectedEntity);
 
   if (ImGui::CollapsingHeader("Light")) {
-    constexpr size_t VEC3_ARRAY_SIZE = 3;
-    constexpr size_t VEC4_ARRAY_SIZE = 4;
     ImGui::Text("Type: %s", component.light->getTypeName().c_str());
 
     ImGui::Text("Direction");
@@ -103,23 +104,24 @@ void EntityPanel::renderTransform() {
       context.getComponent<liquid::TransformComponent>(selectedEntity);
 
   if (ImGui::CollapsingHeader("Transform")) {
-    if (ImGui::BeginTable("table-transformLocal", 4,
-                          ImGuiTableFlags_Borders |
-                              ImGuiTableColumnFlags_WidthStretch |
-                              ImGuiTableFlags_RowBg)) {
-
-      ImGui::Text("Local transform");
-      for (glm::mat4::length_type i = 0; i < 4; ++i) {
-        ImGui::TableNextRow();
-        for (glm::mat4::length_type j = 0; j < 4; ++j) {
-          ImGui::TableNextColumn();
-          ImGui::Text("%f", component.transformLocal[i][j]);
-        }
-      }
-
-      ImGui::EndTable();
+    ImGui::Text("Position");
+    std::array<float, VEC3_ARRAY_SIZE> imguiPosition{component.localPosition.x,
+                                                     component.localPosition.y,
+                                                     component.localPosition.z};
+    if (ImGui::InputFloat3("###InputTransformPosition", imguiPosition.data())) {
+      component.localPosition = {imguiPosition.at(0), imguiPosition.at(1),
+                                 imguiPosition.at(2)};
     }
 
+    ImGui::Text("Scale");
+    std::array<float, VEC3_ARRAY_SIZE> imguiScale{
+        component.localScale.x, component.localScale.y, component.localScale.z};
+    if (ImGui::InputFloat3("###InputTransformScale", imguiScale.data())) {
+      component.localScale = {imguiScale.at(0), imguiScale.at(1),
+                              imguiScale.at(2)};
+    }
+
+    ImGui::Text("World Transform");
     if (ImGui::BeginTable("table-transformWorld", 4,
                           ImGuiTableFlags_Borders |
                               ImGuiTableColumnFlags_WidthStretch |
@@ -130,7 +132,7 @@ void EntityPanel::renderTransform() {
         ImGui::TableNextRow();
         for (glm::mat4::length_type j = 0; j < 4; ++j) {
           ImGui::TableNextColumn();
-          ImGui::Text("%f", component.transformWorld[i][j]);
+          ImGui::Text("%f", component.worldTransform[i][j]);
         }
       }
 

--- a/editor/src/ui/MenuBar.cpp
+++ b/editor/src/ui/MenuBar.cpp
@@ -42,7 +42,10 @@ void MenuBar::handleGLTFImport(const liquid::String &filePath,
   const auto &invViewMatrix =
       glm::inverse(scene->getActiveCamera()->getViewMatrix());
 
-  sceneNode->setTransform(invViewMatrix * glm::translate(distanceFromEye));
+  const auto &orientation = invViewMatrix * glm::translate(distanceFromEye);
+
+  auto &transform = sceneNode->getTransform();
+  transform.localPosition = orientation[3];
 
   scene->getRootNode()->addChild(sceneNode);
 }

--- a/editor/src/ui/SceneHierarchyPanel.cpp
+++ b/editor/src/ui/SceneHierarchyPanel.cpp
@@ -102,7 +102,7 @@ void SceneHierarchyPanel::handleMoveToNode(liquid::SceneNode *node,
       context.getComponent<liquid::TransformComponent>(node->getEntity());
 
   const auto &translation =
-      glm::vec3(glm::column(transformComponent.transformWorld, 3));
+      glm::vec3(glm::column(transformComponent.worldTransform, 3));
 
   constexpr glm::vec3 distanceFromCenter{0.0f, 0.0f, 10.0f};
 

--- a/engine/src/core/Base.h
+++ b/engine/src/core/Base.h
@@ -30,6 +30,7 @@
 #include <glm/gtc/quaternion.hpp>
 #include <glm/gtc/type_ptr.hpp>
 #include <glm/gtx/transform.hpp>
+#include <glm/gtx/quaternion.hpp>
 
 #include "Assert.h"
 

--- a/engine/src/renderer/SceneRenderer.cpp
+++ b/engine/src/renderer/SceneRenderer.cpp
@@ -19,7 +19,7 @@ void SceneRenderer::render(RenderCommandList &commandList,
         const auto &instance = mesh.instance;
 
         auto *transformConstant = new VulkanStandardPushConstants;
-        transformConstant->modelMatrix = transform.transformWorld;
+        transformConstant->modelMatrix = transform.worldTransform;
 
         commandList.pushConstants(pipeline, VK_SHADER_STAGE_VERTEX_BIT, 0,
                                   sizeof(VulkanStandardPushConstants),

--- a/engine/src/scene/Scene.h
+++ b/engine/src/scene/Scene.h
@@ -17,11 +17,12 @@ public:
    * @brief Create scene node
    *
    * @param entity Entity
-   * @param transform Local transform
+   * @param transform Transform component
    * @param parent Parent node
+   * @param context Entity context
    */
-  SceneNode(Entity entity, glm::mat4 transform, SceneNode *parent,
-            EntityContext &context);
+  SceneNode(Entity entity, const TransformComponent &transform,
+            SceneNode *parent, EntityContext &context);
 
   /**
    * @brief Destroys scene node and its children
@@ -35,19 +36,17 @@ public:
 
   /**
    * @brief Updates children
-   *
-   * @param forceUpdate Force update even if node is not modified
    */
-  void update(bool forceUpdate = false);
+  void update();
 
   /**
    * @brief Adds child node with entity
    *
    * @param entity Entity
-   * @param transform Local transform
+   * @param transform Transform component
    * @return Pointer to newly created scene node
    */
-  SceneNode *addChild(Entity entity, glm::mat4 transform = glm::mat4{1.0});
+  SceneNode *addChild(Entity entity, const TransformComponent &component = {});
 
   /*
    * @brief Add child node
@@ -64,18 +63,20 @@ public:
   void removeChild(SceneNode *node);
 
   /**
-   * @brief Sets transform
-   *
-   * @param transform Local transform
-   */
-  void setTransform(glm::mat4 transform);
-
-  /**
    * @brief Set entity
    *
    * @param entity Entity
    */
   void setEntity(Entity entity);
+
+  /**
+   * @brief Get transform
+   *
+   * @return Transform component
+   */
+  inline TransformComponent &getTransform() {
+    return entityContext.getComponent<TransformComponent>(entity);
+  }
 
   /**
    * @brief Gets world transform
@@ -84,7 +85,7 @@ public:
    */
   inline const glm::mat4 &getWorldTransform() const {
     return entityContext.getComponent<TransformComponent>(entity)
-        .transformWorld;
+        .worldTransform;
   }
 
   /**
@@ -111,7 +112,6 @@ public:
   inline SceneNode *getParent() { return parent; }
 
 private:
-  bool dirty = true;
   Entity entity = std::numeric_limits<Entity>::max();
 
   SceneNode *parent = nullptr;

--- a/engine/src/scene/TransformComponent.h
+++ b/engine/src/scene/TransformComponent.h
@@ -3,8 +3,11 @@
 namespace liquid {
 
 struct TransformComponent {
-  glm::mat4 transformLocal;
-  glm::mat4 transformWorld{1.0f};
+  glm::vec3 localPosition{0.0f};
+  glm::quat localRotation{1.0f, 0.0f, 0.0f, 0.0f};
+  glm::vec3 localScale{1.0f};
+
+  glm::mat4 worldTransform{1.0f};
 };
 
 } // namespace liquid


### PR DESCRIPTION
- Add local position, rotation, and scale values
- Remove calculated local transform
- Remove dirty flag from scene node update
- Add position and scale values to transform panel
- Update all demos to use local values instead of transform matrix
- Update GLTF loader to use the new transform values