### PR TITLE
Use mesh as reference object instead of poiner in mesh instance

### DIFF
--- a/demos/basic-triangle/src/main.cpp
+++ b/demos/basic-triangle/src/main.cpp
@@ -119,7 +119,7 @@ int main() {
   mesh.addGeometry(geom);
 
   liquid::SharedPtr<liquid::MeshInstance<liquid::Mesh>> instance(
-      new liquid::MeshInstance(&mesh, renderer->getResourceAllocator()));
+      new liquid::MeshInstance(mesh, renderer->getResourceAllocator()));
   context.setComponent<liquid::MeshComponent>(entity, {instance});
 
   context.setComponent<liquid::AnimationComponent>(entity,

--- a/demos/pong-3d/src/main.cpp
+++ b/demos/pong-3d/src/main.cpp
@@ -44,11 +44,11 @@ public:
     });
 
     barInstance.reset(new liquid::MeshInstance<liquid::Mesh>(
-        &barMesh, renderer->getResourceAllocator()));
+        barMesh, renderer->getResourceAllocator()));
     barInstance->setMaterial(material);
 
     ballInstance.reset(new liquid::MeshInstance<liquid::Mesh>(
-        &ballMesh, renderer->getResourceAllocator()));
+        ballMesh, renderer->getResourceAllocator()));
     ballInstance->setMaterial(material);
 
     setupScene();

--- a/demos/scene-viewer/src/main.cpp
+++ b/demos/scene-viewer/src/main.cpp
@@ -32,7 +32,7 @@ bool changed = true;
 
 bool leftMouseBtnPressed = false;
 
-liquid::Entity getNewSkybox(GLFWwindow *window, liquid::Mesh *mesh,
+liquid::Entity getNewSkybox(GLFWwindow *window, const liquid::Mesh &mesh,
                             liquid::VulkanRenderer *renderer,
                             liquid::EntityContext &context) {
   liquid::KtxTextureLoader ktxLoader(renderer->getResourceAllocator());
@@ -209,7 +209,7 @@ int main() {
 
     ui.onEnvironmentOpen([&window, &context, &cubeMesh, &renderer, &node,
                           &environmentNode]() mutable {
-      auto environment = getNewSkybox(window->getInstance(), &cubeMesh,
+      auto environment = getNewSkybox(window->getInstance(), cubeMesh,
                                       renderer.get(), context);
 
       if (environment == std::numeric_limits<liquid::Entity>::max()) {

--- a/engine/src/liquid/loaders/GLTFLoader.cpp
+++ b/engine/src/liquid/loaders/GLTFLoader.cpp
@@ -619,12 +619,12 @@ getMeshes(const tinygltf::Model &model,
       if (isSkinnedMesh) {
         entityContext.setComponent<SkinnedMeshComponent>(
             entity, {std::make_shared<MeshInstance<SkinnedMesh>>(
-                        &skinnedMesh, renderer->getResourceAllocator())});
+                        skinnedMesh, renderer->getResourceAllocator())});
 
       } else {
         entityContext.setComponent<MeshComponent>(
             entity, {std::make_shared<MeshInstance<Mesh>>(
-                        &mesh, renderer->getResourceAllocator())});
+                        mesh, renderer->getResourceAllocator())});
       }
 
       entityMap.insert({i, entity});

--- a/engine/src/liquid/scene/MeshInstance.h
+++ b/engine/src/liquid/scene/MeshInstance.h
@@ -17,8 +17,8 @@ public:
    * @param mesh Mesh
    * @param resourceAllocator Resource allocator
    */
-  MeshInstance(Mesh *mesh, ResourceAllocator *resourceAllocator) {
-    for (auto &geometry : mesh->getGeometries()) {
+  MeshInstance(const Mesh &mesh, ResourceAllocator *resourceAllocator) {
+    for (auto &geometry : mesh.getGeometries()) {
       const auto &vertexBuffer = resourceAllocator->createVertexBuffer(
           geometry.getVertices().size() * sizeof(typename Mesh::Vertex));
 

--- a/engine/tests/scene/MeshInstance.test.cpp
+++ b/engine/tests/scene/MeshInstance.test.cpp
@@ -19,7 +19,7 @@ TEST(MeshInstanceTest, CreatesVertexAndIndexBuffersOnConstruct) {
   mesh.addGeometry(geom1);
   mesh.addGeometry(geom2);
 
-  liquid::MeshInstance<liquid::Mesh> instance(&mesh, &resourceAllocator);
+  liquid::MeshInstance<liquid::Mesh> instance(mesh, &resourceAllocator);
 
   EXPECT_EQ(instance.getVertexBuffers().size(), 2);
   EXPECT_EQ(instance.getIndexBuffers().size(), 2);
@@ -43,7 +43,7 @@ TEST(MeshInstanceTest, CreateWithoutIndexBuffersOnConstruct) {
 
   mesh.addGeometry(geom1);
   mesh.addGeometry(geom2);
-  liquid::MeshInstance<liquid::Mesh> instance(&mesh, &resourceAllocator);
+  liquid::MeshInstance<liquid::Mesh> instance(mesh, &resourceAllocator);
 
   EXPECT_EQ(instance.getVertexBuffers().size(), 2);
   EXPECT_EQ(instance.getIndexBuffers().size(), 2);
@@ -66,7 +66,7 @@ TEST(MeshInstanceTest, SetsMaterial) {
   liquid::Geometry geom;
   mesh.addGeometry(geom);
   MaterialPtr material(new liquid::Material({}, {}, &resourceAllocator));
-  liquid::MeshInstance<liquid::Mesh> instance(&mesh, &resourceAllocator);
+  liquid::MeshInstance<liquid::Mesh> instance(mesh, &resourceAllocator);
   EXPECT_EQ(instance.getMaterials().size(), 1);
   EXPECT_EQ(instance.getMaterials().at(0), nullptr);
 


### PR DESCRIPTION
Use mesh as reference object instead of poiner in mesh instance