### PR TITLE
Extract status bar height from docking viewport height

### DIFF
--- a/editor/src/ui/Layout.cpp
+++ b/editor/src/ui/Layout.cpp
@@ -7,10 +7,13 @@
 namespace liquidator {
 
 void Layout::setup() {
+  const float WINDOW_AND_STATUS_BAR_HEIGHT = ImGui::GetFrameHeight() * 2.0f;
   const auto &viewport = ImGui::GetMainViewport();
   ImGui::SetNextWindowPos(
       ImVec2(viewport->Pos.x, viewport->Pos.y + ImGui::GetFrameHeight()));
-  ImGui::SetNextWindowSize(viewport->Size);
+  ImGui::SetNextWindowSize(ImVec2(
+      // Extract status bar from viewport size
+      viewport->Size.x, viewport->Size.y - WINDOW_AND_STATUS_BAR_HEIGHT));
   ImGui::SetNextWindowViewport(viewport->ID);
   ImGui::PushStyleVar(ImGuiStyleVar_WindowRounding, 0.0f);
   ImGui::PushStyleVar(ImGuiStyleVar_WindowBorderSize, 0.0f);

--- a/editor/src/ui/StatusBar.cpp
+++ b/editor/src/ui/StatusBar.cpp
@@ -33,7 +33,7 @@ void StatusBar::render(SceneManager &sceneManager) {
       ImGuiWindowFlags_NoMove | ImGuiWindowFlags_NoScrollWithMouse |
       ImGuiWindowFlags_NoSavedSettings |
       ImGuiWindowFlags_NoBringToFrontOnFocus | ImGuiWindowFlags_NoBackground |
-      ImGuiWindowFlags_MenuBar;
+      ImGuiWindowFlags_MenuBar | ImGuiWindowFlags_NoDocking;
   if (ImGui::Begin("StatusBar", nullptr, flags)) {
     if (ImGui::BeginMenuBar()) {
       ImGui::Text("%s", state.c_str());

--- a/editor/src/ui/UIRoot.cpp
+++ b/editor/src/ui/UIRoot.cpp
@@ -13,11 +13,10 @@ UIRoot::UIRoot(liquid::EntityContext &context,
 void UIRoot::render(SceneManager &sceneManager) {
   layout.setup();
   menuBar.render(sceneManager);
-
+  statusBar.render(sceneManager);
   sceneHierarchyPanel.render(sceneManager);
   entityPanel.render(sceneManager);
   editorCameraPanel.render(sceneManager);
-  statusBar.render(sceneManager);
 }
 
 void UIRoot::handleNodeClick(liquid::SceneNode *node) {


### PR DESCRIPTION
- This allows for status bar to be visible at the bottom of the screen
- Disable docking for status bar