### PR TITLE
Fix editor grid transparency

### DIFF
--- a/editor/assets/shaders/editor-grid.frag
+++ b/editor/assets/shaders/editor-grid.frag
@@ -23,7 +23,7 @@ void main() {
   vec3 fragPos = inNearPoint + t * (inFarPoint - inNearPoint);
 
   // Default color
-  outColor = vec4(0.0, 0.0, 0.0, 0.0);
+  outColor = vec4(0.0);
 
   // Compute lines
   if (t > 0) {
@@ -36,10 +36,12 @@ void main() {
     float lineAlpha = 1.0 - min(line, 1.0);
     vec2 center = min(derivative, vec2(1.0, 1.0)) * 0.5;
 
+    float nonAxisAlpha = min(lineAlpha, 0.3);
+
     vec4 color = vec4(0.0);
     // Set non-axis line color
     if (uGridData.gridLines.x == 1) {
-      color = vec4(LINE_COLOR, lineAlpha);
+      color = vec4(LINE_COLOR, nonAxisAlpha);
     }
 
     // Set Z axis color if X position is at zero

--- a/editor/src/main.cpp
+++ b/editor/src/main.cpp
@@ -102,9 +102,9 @@ int main() {
                     liquid::PipelineColorBlend{
                         {liquid::PipelineColorBlendAttachment{
                             true, liquid::BlendFactor::SrcAlpha,
-                            liquid::BlendFactor::OneMinusSrcAlpha,
-                            liquid::BlendOp::Add, liquid::BlendFactor::One,
-                            liquid::BlendFactor::OneMinusSrcAlpha,
+                            liquid::BlendFactor::DstAlpha, liquid::BlendOp::Add,
+                            liquid::BlendFactor::SrcAlpha,
+                            liquid::BlendFactor::DstAlpha,
                             liquid::BlendOp::Add}}}});
           },
           [&renderer, &cameraObj, &editorCamera, &editorGrid](

--- a/engine/src/liquid/renderer/render-graph/RenderGraph.cpp
+++ b/engine/src/liquid/renderer/render-graph/RenderGraph.cpp
@@ -85,7 +85,7 @@ std::vector<RenderGraphPassBase *> RenderGraph::compile() {
   sortedPasses.reserve(tempPasses.size());
   std::vector<bool> visited(tempPasses.size(), false);
 
-  for (size_t i = 0; i < tempPasses.size(); ++i) {
+  for (size_t i = tempPasses.size(); i-- > 0;) {
     if (!visited.at(i)) {
       topologicalSort(i, visited, adjacencyList, sortedPasses);
     }

--- a/engine/tests/renderer/RenderGraph.test.cpp
+++ b/engine/tests/renderer/RenderGraph.test.cpp
@@ -139,7 +139,7 @@ TEST_F(RenderGraphTest, TopologicallySortRenderGraph) {
   // Trim last space
   output.erase(output.find_last_not_of(' ') + 1);
 
-  EXPECT_EQ(output, "H A D B C E F G");
+  EXPECT_EQ(output, "A D B H C E F G");
 }
 
 TEST_F(RenderGraphTest, SetsPassLoadOperations) {


### PR DESCRIPTION
- Change color blend factor values for editor grid
- Retain order of passes in render graph based on when they were defined
- Change alpha value of non axis lines to 0.5