### PR TITLE
Create handles for swapchain images

### DIFF
--- a/engine/src/liquid/renderer/vulkan/VulkanGraphEvaluator.h
+++ b/engine/src/liquid/renderer/vulkan/VulkanGraphEvaluator.h
@@ -32,7 +32,6 @@ public:
    */
   VulkanGraphEvaluator(
       experimental::VulkanRenderDevice *device,
-      experimental::VulkanSwapchain &swapchain,
       experimental::ResourceRegistry &registry,
       const experimental::VulkanResourceRegistry &realRegistry);
 
@@ -41,10 +40,12 @@ public:
    *
    * @param graph Render graph
    * @param swapchainRecreated Compile swapchain related passes
+   * @param extent Swapchain extent
    * @return Topologically sorted list of passes
    */
   std::vector<RenderGraphPassBase *> compile(RenderGraph &graph,
-                                             bool swapchainRecreated);
+                                             bool swapchainRecreated,
+                                             const glm::uvec2 &extent);
 
   /**
    * @brief Build passes
@@ -52,9 +53,12 @@ public:
    * @param compiled Compiled passes
    * @param graph Render graph
    * @param swapchainRecreated Rebuild swapchain related passes
+   * @param numSwapchainImages Number of swapchain images
+   * @param extent Swapchain extent
    */
   void build(std::vector<RenderGraphPassBase *> &compiled, RenderGraph &graph,
-             bool swapchainRecreated);
+             bool swapchainRecreated, uint32_t numSwapchainImages,
+             const glm::uvec2 &extent);
 
   /**
    * @brief Execute render graph
@@ -75,19 +79,25 @@ private:
    * @param pass Render pass
    * @param graph Render graph
    * @param force Force build even if the pass resources exist
+   * @param numSwapchainImages Number of swapchain images
+   * @param extent Swapchain extent
    */
-  void buildPass(RenderGraphPassBase *pass, RenderGraph &graph, bool force);
+  void buildPass(RenderGraphPassBase *pass, RenderGraph &graph, bool force,
+                 uint32_t numSwapchainImages, const glm::uvec2 &extent);
 
   /**
    * @brief Create swapchain attachment
    *
    * @param attachment Attachment description
    * @param index Attachment index
+   * @param numSwapchainAttachments Number of swapchain attachments
+   * @param extent Swapchain extent
    * @return Attachment info
    */
   VulkanAttachmentInfo
   createSwapchainAttachment(const RenderPassAttachment &attachment,
-                            uint32_t index);
+                            uint32_t index, uint32_t numSwapchainAttachments,
+                            const glm::uvec2 &extent);
 
   /**
    * @brief Create color attachment
@@ -128,13 +138,14 @@ private:
    * @brief Create texture
    *
    * @param data Attachment data
+   * @param extent Swapchain extent
    * @return Texture
    */
-  TextureHandle createTexture(const AttachmentData &data);
+  TextureHandle createTexture(const AttachmentData &data,
+                              const glm::uvec2 &extent);
 
 private:
   experimental::VulkanRenderDevice *device;
-  experimental::VulkanSwapchain &swapchain;
   experimental::ResourceRegistry &registry;
   const experimental::VulkanResourceRegistry &realRegistry;
 };

--- a/engine/src/liquid/rhi/ResourceRegistry.h
+++ b/engine/src/liquid/rhi/ResourceRegistry.h
@@ -6,6 +6,8 @@
 
 namespace liquid::experimental {
 
+static constexpr uint32_t RESERVED_HANDLE_SIZE = 20;
+
 /**
  * @brief Registry map
  *
@@ -15,9 +17,14 @@ namespace liquid::experimental {
  *
  * @tparam THandle Resource Handle type
  * @tparam TDescription Description type
+ * @tparam TStartingHandle Starting handle id
  */
-template <class THandle, class TDescription> class ResourceRegistryMap {
+template <class THandle, class TDescription,
+          THandle TStartingHandleId =
+              static_cast<THandle>(RESERVED_HANDLE_SIZE)>
+class ResourceRegistryMap {
   using HandleList = std::vector<THandle>;
+  static_assert(TStartingHandleId >= 1, "Starting handle cannot be ZERO");
 
 public:
   /**
@@ -120,7 +127,7 @@ private:
   std::vector<THandle> mDirtyDeletes;
 
   // ZERO means undefined
-  THandle mLastHandle = 1;
+  THandle mLastHandle = TStartingHandleId;
 };
 
 class ResourceRegistry {

--- a/engine/src/liquid/rhi/vulkan/VulkanRenderDevice.h
+++ b/engine/src/liquid/rhi/vulkan/VulkanRenderDevice.h
@@ -13,6 +13,7 @@
 #include "VulkanResourceRegistry.h"
 #include "VulkanCommandPool.h"
 #include "VulkanDescriptorManager.h"
+#include "VulkanSwapchain.h"
 
 namespace liquid::experimental {
 
@@ -26,6 +27,8 @@ public:
    */
   VulkanRenderDevice(VulkanRenderBackend &backend,
                      const VulkanPhysicalDevice &physicalDevice);
+
+  void synchronizeSwapchain(const VulkanSwapchain &swapchain);
 
   void synchronize(ResourceRegistry &registry);
 
@@ -102,6 +105,8 @@ private:
   VulkanCommandPool mCommandPool;
   VulkanRenderContext mRenderContext;
   VulkanUploadContext mUploadContext;
+
+  TextureHandle mNumSwapchainImages = 0;
 };
 
 } // namespace liquid::experimental

--- a/engine/src/liquid/rhi/vulkan/VulkanResourceRegistry.cpp
+++ b/engine/src/liquid/rhi/vulkan/VulkanResourceRegistry.cpp
@@ -28,4 +28,9 @@ void VulkanResourceRegistry::removeTexture(TextureHandle handle) {
   mTextures.erase(handle);
 }
 
+void VulkanResourceRegistry::updateTexture(
+    TextureHandle handle, std::unique_ptr<VulkanTexture> &&texture) {
+  mTextures.at(handle) = std::move(texture);
+}
+
 } // namespace liquid::experimental

--- a/engine/src/liquid/rhi/vulkan/VulkanResourceRegistry.h
+++ b/engine/src/liquid/rhi/vulkan/VulkanResourceRegistry.h
@@ -35,6 +35,9 @@ public:
 
   void removeTexture(TextureHandle handle);
 
+  void updateTexture(TextureHandle handle,
+                     std::unique_ptr<VulkanTexture> &&texture);
+
   inline const std::unique_ptr<VulkanTexture> &
   getTexture(TextureHandle handle) const {
     return mTextures.at(handle);

--- a/engine/src/liquid/rhi/vulkan/VulkanSwapchain.h
+++ b/engine/src/liquid/rhi/vulkan/VulkanSwapchain.h
@@ -62,14 +62,14 @@ public:
    *
    * @return Surface format
    */
-  inline VkSurfaceFormatKHR getSurfaceFormat() { return mSurfaceFormat; }
+  inline VkSurfaceFormatKHR getSurfaceFormat() const { return mSurfaceFormat; }
 
   /**
    * @brief Gets present mode
    *
    * @return Present mode
    */
-  inline VkPresentModeKHR getPresentMode() { return mPresentMode; }
+  inline VkPresentModeKHR getPresentMode() const { return mPresentMode; }
 
   /**
    * @brief Gets Vulkan swapchain
@@ -83,7 +83,7 @@ public:
    *
    * @return Vulkan extent
    */
-  inline const VkExtent2D &getExtent() { return mExtent; }
+  inline const glm::uvec2 &getExtent() { return mExtent; }
 
   /**
    * @brief Gets Vulkan image views
@@ -93,6 +93,13 @@ public:
   inline const std::vector<VkImageView> &getImageViews() const {
     return mImageViews;
   }
+
+  /**
+   * @brief Get Vulkan images
+   *
+   * @return Vulkan images
+   */
+  inline const std::vector<VkImage> &getImages() const { return mImages; }
 
 private:
   /**
@@ -137,8 +144,9 @@ private:
 private:
   VkSwapchainKHR mSwapchain = VK_NULL_HANDLE;
   std::vector<VkImageView> mImageViews;
+  std::vector<VkImage> mImages;
 
-  VkExtent2D mExtent{};
+  glm::uvec2 mExtent{};
   VkSurfaceFormatKHR mSurfaceFormat{};
   VkPresentModeKHR mPresentMode{};
 

--- a/engine/src/liquid/rhi/vulkan/VulkanTexture.h
+++ b/engine/src/liquid/rhi/vulkan/VulkanTexture.h
@@ -15,6 +15,21 @@ public:
   /**
    * @brief Create Vulkan texture
    *
+   * Create texture from available resources
+   * @param image Vulkan image
+   * @param imageView Vulkan image view
+   * @param sampler Vulkan sampler
+   * @param format Vulkan format
+   * @param resourceAllocator Resource allocator
+   * @param device Vulkan device
+   */
+  VulkanTexture(VkImage image, VkImageView imageView, VkSampler sampler,
+                VkFormat format, VulkanResourceAllocator &allocator,
+                VulkanDeviceObject &device);
+
+  /**
+   * @brief Create Vulkan texture
+   *
    * @param description Texture description
    * @param allocator Vma allocator
    * @param device Vulkan device
@@ -62,7 +77,13 @@ public:
    */
   inline VmaAllocation getAllocation() const { return mAllocation; }
 
+  /**
+   * @brief Get Vulkan format
+   */
+  inline VkFormat getFormat() const { return mFormat; }
+
 private:
+  VkFormat mFormat = VK_FORMAT_MAX_ENUM;
   VkImage mImage = VK_NULL_HANDLE;
   VkImageView mImageView = VK_NULL_HANDLE;
   VkSampler mSampler = VK_NULL_HANDLE;


### PR DESCRIPTION
- Reserve first 20 (predefined items) slots in the resource description registry for system handles (e.g swapchain)
- Store swapchain images in the registry (for now through synchronization)