### PR TITLE
Restict RHI render handle types

### DIFF
--- a/engine/src/liquid/renderer/Material.h
+++ b/engine/src/liquid/renderer/Material.h
@@ -81,7 +81,7 @@ private:
 
 private:
   std::vector<rhi::TextureHandle> textures;
-  rhi::BufferHandle uniformBuffer = 0;
+  rhi::BufferHandle uniformBuffer = rhi::BufferHandle::Invalid;
 
   rhi::ResourceRegistry &registry;
   char *data = nullptr;

--- a/engine/src/liquid/renderer/MaterialPBR.cpp
+++ b/engine/src/liquid/renderer/MaterialPBR.cpp
@@ -6,23 +6,23 @@ namespace liquid {
 const std::vector<rhi::TextureHandle>
 MaterialPBR::Properties::getTextures() const {
   std::vector<rhi::TextureHandle> textures;
-  if (baseColorTexture > 0) {
+  if (rhi::isHandleValid(baseColorTexture)) {
     textures.push_back(baseColorTexture);
   }
 
-  if (metallicRoughnessTexture > 0) {
+  if (rhi::isHandleValid(metallicRoughnessTexture)) {
     textures.push_back(metallicRoughnessTexture);
   }
 
-  if (normalTexture > 0) {
+  if (rhi::isHandleValid(normalTexture)) {
     textures.push_back(normalTexture);
   }
 
-  if (occlusionTexture > 0) {
+  if (rhi::isHandleValid(occlusionTexture)) {
     textures.push_back(occlusionTexture);
   }
 
-  if (emissiveTexture > 0) {
+  if (rhi::isHandleValid(emissiveTexture)) {
     textures.push_back(emissiveTexture);
   }
 
@@ -32,12 +32,14 @@ MaterialPBR::Properties::getTextures() const {
 const std::vector<std::pair<String, Property>>
 MaterialPBR::Properties::getProperties() const {
   int index = 0;
-  int baseColorTextureIndex = baseColorTexture > 0 ? index++ : -1;
+  int baseColorTextureIndex =
+      rhi::isHandleValid(baseColorTexture) ? index++ : -1;
   int metallicRoughnessTextureIndex =
-      metallicRoughnessTexture > 0 ? index++ : -1;
-  int normalTextureIndex = normalTexture > 0 ? index++ : -1;
-  int occlusionTextureIndex = occlusionTexture > 0 ? index++ : -1;
-  int emissiveTextureIndex = emissiveTexture > 0 ? index++ : -1;
+      rhi::isHandleValid(metallicRoughnessTexture) ? index++ : -1;
+  int normalTextureIndex = rhi::isHandleValid(normalTexture) ? index++ : -1;
+  int occlusionTextureIndex =
+      rhi::isHandleValid(occlusionTexture) ? index++ : -1;
+  int emissiveTextureIndex = rhi::isHandleValid(emissiveTexture) ? index++ : -1;
 
   return {{"baseColorTexture", baseColorTextureIndex},
           {"baseColorTextureCoord", baseColorTextureCoord},

--- a/engine/src/liquid/renderer/MaterialPBR.h
+++ b/engine/src/liquid/renderer/MaterialPBR.h
@@ -24,24 +24,24 @@ public:
     const std::vector<std::pair<String, Property>> getProperties() const;
 
   public:
-    rhi::TextureHandle baseColorTexture = 0;
+    rhi::TextureHandle baseColorTexture = rhi::TextureHandle::Invalid;
     int baseColorTextureCoord = -1;
     glm::vec4 baseColorFactor;
 
-    rhi::TextureHandle metallicRoughnessTexture = 0;
+    rhi::TextureHandle metallicRoughnessTexture = rhi::TextureHandle::Invalid;
     int metallicRoughnessTextureCoord = -1;
     float metallicFactor = 0.0f;
     float roughnessFactor = 0.0f;
 
-    rhi::TextureHandle normalTexture = 0;
+    rhi::TextureHandle normalTexture = rhi::TextureHandle::Invalid;
     int normalTextureCoord = -1;
     float normalScale = 0.0f;
 
-    rhi::TextureHandle occlusionTexture = 0;
+    rhi::TextureHandle occlusionTexture = rhi::TextureHandle::Invalid;
     int occlusionTextureCoord = -1;
     float occlusionStrength = 0.0f;
 
-    rhi::TextureHandle emissiveTexture = 0;
+    rhi::TextureHandle emissiveTexture = rhi::TextureHandle::Invalid;
     int emissiveTextureCoord = -1;
     glm::vec3 emissiveFactor;
   };

--- a/engine/src/liquid/renderer/SceneRenderer.cpp
+++ b/engine/src/liquid/renderer/SceneRenderer.cpp
@@ -33,7 +33,7 @@ void SceneRenderer::render(rhi::RenderCommandList &commandList,
                 pipeline, 2, instance->getMaterials().at(i)->getDescriptor());
           }
 
-          if (instance->getIndexBuffers().at(i) > 0) {
+          if (rhi::isHandleValid(instance->getIndexBuffers().at(i))) {
             commandList.bindIndexBuffer(instance->getIndexBuffers().at(i),
                                         VK_INDEX_TYPE_UINT32);
             commandList.drawIndexed(instance->getIndexCounts().at(i), 0, 0);
@@ -75,7 +75,7 @@ void SceneRenderer::renderSkinned(rhi::RenderCommandList &commandList,
                 pipeline, 2, instance->getMaterials().at(i)->getDescriptor());
           }
 
-          if (instance->getIndexBuffers().at(i) > 0) {
+          if (rhi::isHandleValid(instance->getIndexBuffers().at(i))) {
             commandList.bindIndexBuffer(instance->getIndexBuffers().at(i),
                                         VK_INDEX_TYPE_UINT32);
             commandList.drawIndexed(instance->getIndexCounts().at(i), 0, 0);

--- a/engine/src/liquid/renderer/imgui/ImguiRenderer.h
+++ b/engine/src/liquid/renderer/imgui/ImguiRenderer.h
@@ -11,11 +11,11 @@ namespace liquid {
 
 class ImguiRenderer {
   struct FrameData {
-    rhi::BufferHandle vertexBuffer = 0;
+    rhi::BufferHandle vertexBuffer = rhi::BufferHandle::Invalid;
     size_t vertexBufferSize = 0;
     void *vertexBufferData = nullptr;
 
-    rhi::BufferHandle indexBuffer = 0;
+    rhi::BufferHandle indexBuffer = rhi::BufferHandle::Invalid;
     void *indexBufferData = nullptr;
     size_t indexBufferSize = 0;
 
@@ -46,7 +46,7 @@ private:
 private:
   rhi::ResourceRegistry &registry;
 
-  rhi::TextureHandle fontTexture = 0;
+  rhi::TextureHandle fontTexture = rhi::TextureHandle::Invalid;
 
   std::vector<FrameData> frameData;
   uint32_t currentFrame = 0;

--- a/engine/src/liquid/renderer/passes/EnvironmentPass.cpp
+++ b/engine/src/liquid/renderer/passes/EnvironmentPass.cpp
@@ -47,7 +47,7 @@ void EnvironmentPass::execute(rhi::RenderCommandList &commandList,
               pipeline, 1,
               mesh.instance->getMaterials().at(i)->getDescriptor());
 
-          if (mesh.instance->getIndexBuffers().at(i) > 0) {
+          if (rhi::isHandleValid(mesh.instance->getIndexBuffers().at(i))) {
             commandList.bindIndexBuffer(mesh.instance->getIndexBuffers().at(i),
                                         VK_INDEX_TYPE_UINT32);
             commandList.drawIndexed(mesh.instance->getIndexCounts().at(i), 0,

--- a/engine/src/liquid/renderer/passes/ImguiPass.cpp
+++ b/engine/src/liquid/renderer/passes/ImguiPass.cpp
@@ -48,7 +48,7 @@ void ImguiPass::execute(rhi::RenderCommandList &commandList,
   const auto &pipeline = registry.getPipeline(pipelineId);
   auto sceneTexture = registry.hasTexture(sceneTextureId)
                           ? registry.getTexture(sceneTextureId)
-                          : 0;
+                          : rhi::TextureHandle::Invalid;
 
   imguiRenderer.beginRendering();
 

--- a/engine/src/liquid/renderer/render-graph/RenderGraphEvaluator.cpp
+++ b/engine/src/liquid/renderer/render-graph/RenderGraphEvaluator.cpp
@@ -87,7 +87,7 @@ void RenderGraphEvaluator::buildPass(RenderGraphPassBase *pass,
       imageViewsPerFramebuffer);
 
   rhi::RenderPassDescription renderPassDesc{};
-  rhi::RenderPassHandle renderPass = 0;
+  rhi::RenderPassHandle renderPass = rhi::RenderPassHandle::Invalid;
 
   for (auto &[resourceId, graphAttachment] : pass->getOutputs()) {
     VulkanAttachmentInfo info{};
@@ -130,7 +130,7 @@ void RenderGraphEvaluator::buildPass(RenderGraphPassBase *pass,
   }
 
   if (!renderPassDesc.colorAttachments.empty() ||
-      renderPassDesc.depthAttachment.texture > 0) {
+      rhi::isHandleValid(renderPassDesc.depthAttachment.texture)) {
     renderPassDesc.bindPoint = VK_PIPELINE_BIND_POINT_GRAPHICS;
 
     bool renderPassExists =
@@ -147,7 +147,7 @@ void RenderGraphEvaluator::buildPass(RenderGraphPassBase *pass,
     }
 
     std::vector<rhi::FramebufferHandle> framebuffers(
-        framebufferAttachments.size(), 0);
+        framebufferAttachments.size(), rhi::FramebufferHandle::Invalid);
 
     for (size_t i = 0; i < framebuffers.size(); ++i) {
       rhi::FramebufferDescription framebufferDesc;
@@ -200,7 +200,7 @@ void RenderGraphEvaluator::buildPass(RenderGraphPassBase *pass,
       description.inputLayout = desc.inputLayout;
       description.renderPass = renderPass;
 
-      rhi::PipelineHandle handle = 0;
+      rhi::PipelineHandle handle = rhi::PipelineHandle::Invalid;
       if (hasPipeline) {
         handle = graph.getResourceRegistry().getPipeline(resource);
         mRegistry.updatePipeline(handle, description);
@@ -233,7 +233,8 @@ RenderGraphEvaluator::createSwapchainAttachment(
       std::get<glm::vec4>(attachment.clearValue).w;
 
   // Framebuffer image views
-  info.framebufferAttachments.resize(numSwapchainImages, 0);
+  info.framebufferAttachments.resize(numSwapchainImages,
+                                     rhi::TextureHandle::Invalid);
 
   for (uint32_t i = 0; i < numSwapchainImages; ++i) {
     auto handle = static_cast<rhi::TextureHandle>(i + 1);
@@ -243,7 +244,7 @@ RenderGraphEvaluator::createSwapchainAttachment(
 
   info.attachment.loadOp = attachment.loadOp;
   info.attachment.storeOp = attachment.storeOp;
-  info.attachment.texture = 1;
+  info.attachment.texture = rhi::TextureHandle{1};
   info.attachment.layout = VK_IMAGE_LAYOUT_PRESENT_SRC_KHR;
 
   // Dimensions

--- a/engine/src/liquid/renderer/render-graph/RenderGraphPipelineDescription.h
+++ b/engine/src/liquid/renderer/render-graph/RenderGraphPipelineDescription.h
@@ -167,8 +167,8 @@ struct PipelineColorBlend {
 };
 
 struct RenderGraphPipelineDescription {
-  rhi::ShaderHandle vertexShader = 0;
-  rhi::ShaderHandle fragmentShader = 0;
+  rhi::ShaderHandle vertexShader = rhi::ShaderHandle::Invalid;
+  rhi::ShaderHandle fragmentShader = rhi::ShaderHandle::Invalid;
   PipelineVertexInputLayout inputLayout;
   PipelineInputAssembly inputAssembly;
   PipelineRasterizer rasterizer;

--- a/engine/src/liquid/rhi/Descriptor.cpp
+++ b/engine/src/liquid/rhi/Descriptor.cpp
@@ -12,8 +12,8 @@ Descriptor &Descriptor::bind(uint32_t binding,
   bindings.insert({binding, DescriptorBinding{type, textures}});
   std::stringstream ss;
   ss << "b:" << binding << ";t:" << static_cast<uint32_t>(type) << ";";
-  for (auto &x : textures) {
-    ss << "d:" << x << ";";
+  for (auto x : textures) {
+    ss << "d:" << rhi::castHandleToUint(x) << ";";
   }
   ss << "|";
   hashCode += ss.str();
@@ -29,7 +29,7 @@ Descriptor &Descriptor::bind(uint32_t binding, BufferHandle buffer,
   bindings.insert({binding, DescriptorBinding{type, buffer}});
   std::stringstream ss;
   ss << "b:" << binding << ";t:" << static_cast<uint32_t>(type)
-     << ";d:" << buffer << "|";
+     << ";d:" << rhi::castHandleToUint(buffer) << "|";
   hashCode += ss.str();
   return *this;
 }

--- a/engine/src/liquid/rhi/FramebufferDescription.h
+++ b/engine/src/liquid/rhi/FramebufferDescription.h
@@ -5,7 +5,7 @@
 namespace liquid::rhi {
 
 struct FramebufferDescription {
-  rhi::RenderPassHandle renderPass = 0;
+  RenderPassHandle renderPass = RenderPassHandle::Invalid;
   uint32_t width = 0;
   uint32_t height = 0;
   uint32_t layers = 0;

--- a/engine/src/liquid/rhi/PipelineDescription.h
+++ b/engine/src/liquid/rhi/PipelineDescription.h
@@ -5,9 +5,9 @@
 namespace liquid::rhi {
 
 struct PipelineDescription {
-  RenderPassHandle renderPass = 0;
-  ShaderHandle vertexShader = 0;
-  ShaderHandle fragmentShader = 0;
+  RenderPassHandle renderPass = RenderPassHandle::Invalid;
+  ShaderHandle vertexShader = ShaderHandle::Invalid;
+  ShaderHandle fragmentShader = ShaderHandle::Invalid;
   PipelineVertexInputLayout inputLayout;
   PipelineInputAssembly inputAssembly;
   PipelineRasterizer rasterizer;

--- a/engine/src/liquid/rhi/RenderHandle.h
+++ b/engine/src/liquid/rhi/RenderHandle.h
@@ -2,16 +2,58 @@
 
 namespace liquid::rhi {
 
-using ShaderHandle = uint32_t;
+enum class ShaderHandle : uint32_t { Invalid = 0 };
 
-using BufferHandle = uint32_t;
+enum class BufferHandle : uint32_t { Invalid = 0 };
 
-using TextureHandle = uint32_t;
+enum class TextureHandle : uint32_t { Invalid = 0 };
 
-using RenderPassHandle = uint32_t;
+enum class RenderPassHandle : uint32_t { Invalid = 0 };
 
-using FramebufferHandle = uint32_t;
+enum class FramebufferHandle : uint32_t { Invalid = 0 };
 
-using PipelineHandle = uint32_t;
+enum class PipelineHandle : uint32_t { Invalid = 0 };
+
+/**
+ * @brief Check if type equals any of the other types
+ *
+ * @tparam T Type
+ * @tparam ...Rest Other types
+ */
+template <class T, class... Rest>
+inline constexpr bool is_any_same = (std::is_same_v<T, Rest> || ...);
+
+/**
+ * @brief Check if handle is valid
+ *
+ * @tparam THandle Handle type
+ * @param handle Handle
+ * @retval true Handle is valid
+ * @retval false Handle is not valid
+ */
+template <class THandle> constexpr inline bool isHandleValid(THandle handle) {
+  static_assert(
+      is_any_same<THandle, ShaderHandle, BufferHandle, TextureHandle,
+                  RenderPassHandle, FramebufferHandle, PipelineHandle>,
+      "Type must be a render handle");
+  return handle != THandle::Invalid;
+}
+
+/**
+ * @brief Cast handle to uint
+ *
+ * @tparam THandle Handle type
+ * @param handle Handle
+ * @return Handle value in uint
+ */
+template <class THandle>
+constexpr inline uint32_t castHandleToUint(THandle handle) {
+  static_assert(
+      is_any_same<THandle, ShaderHandle, BufferHandle, TextureHandle,
+                  RenderPassHandle, FramebufferHandle, PipelineHandle>,
+      "Type must be a render handle");
+
+  return static_cast<uint32_t>(handle);
+}
 
 } // namespace liquid::rhi

--- a/engine/src/liquid/rhi/RenderPassDescription.h
+++ b/engine/src/liquid/rhi/RenderPassDescription.h
@@ -9,7 +9,7 @@ namespace liquid::rhi {
 struct RenderPassAttachmentDescription {
   AttachmentLoadOp loadOp;
   AttachmentStoreOp storeOp;
-  TextureHandle texture = 0;
+  TextureHandle texture = TextureHandle::Invalid;
   VkImageLayout layout = VK_IMAGE_LAYOUT_MAX_ENUM;
 };
 

--- a/engine/src/liquid/rhi/ResourceRegistry.cpp
+++ b/engine/src/liquid/rhi/ResourceRegistry.cpp
@@ -21,7 +21,7 @@ void ResourceRegistry::deleteBuffer(BufferHandle handle) {
 
 void ResourceRegistry::updateBuffer(BufferHandle handle,
                                     const BufferDescription &description) {
-  LIQUID_ASSERT(handle > 0, "Buffer does not exist");
+  LIQUID_ASSERT(rhi::isHandleValid(handle), "Buffer does not exist");
   mBuffers.updateDescription(handle, description);
 }
 
@@ -41,7 +41,7 @@ ResourceRegistry::addRenderPass(const RenderPassDescription &description) {
 
 void ResourceRegistry::updateRenderPass(
     rhi::RenderPassHandle handle, const RenderPassDescription &description) {
-  LIQUID_ASSERT(handle > 0, "Render pass does not exist");
+  LIQUID_ASSERT(rhi::isHandleValid(handle), "Render pass does not exist");
   mRenderPasses.updateDescription(handle, description);
 }
 
@@ -56,7 +56,7 @@ ResourceRegistry::addFramebuffer(const FramebufferDescription &description) {
 
 void ResourceRegistry::updateFramebuffer(
     FramebufferHandle handle, const FramebufferDescription &description) {
-  LIQUID_ASSERT(handle > 0, "Framebuffer does not exist");
+  LIQUID_ASSERT(rhi::isHandleValid(handle), "Framebuffer does not exist");
   mFramebuffers.updateDescription(handle, description);
 }
 
@@ -71,7 +71,7 @@ ResourceRegistry::addPipeline(const PipelineDescription &description) {
 
 void ResourceRegistry::updatePipeline(PipelineHandle handle,
                                       const PipelineDescription &description) {
-  LIQUID_ASSERT(handle > 0, "Pipeline does not exist");
+  LIQUID_ASSERT(rhi::isHandleValid(handle), "Pipeline does not exist");
   mPipelines.updateDescription(handle, description);
 }
 

--- a/engine/src/liquid/rhi/ResourceRegistry.h
+++ b/engine/src/liquid/rhi/ResourceRegistry.h
@@ -24,11 +24,11 @@ static constexpr uint32_t RESERVED_HANDLE_SIZE = 20;
  * @tparam TStartingHandle Starting handle id
  */
 template <class THandle, class TDescription,
-          THandle TStartingHandleId =
-              static_cast<THandle>(RESERVED_HANDLE_SIZE)>
+          THandle TStartingHandleId = THandle(RESERVED_HANDLE_SIZE)>
 class ResourceRegistryMap {
   using HandleList = std::vector<THandle>;
-  static_assert(TStartingHandleId >= 1, "Starting handle cannot be ZERO");
+  static_assert(TStartingHandleId != THandle::Invalid,
+                "Starting handle cannot be invalid");
 
 public:
   /**
@@ -38,7 +38,8 @@ public:
    * @return Resource handle
    */
   THandle addDescription(const TDescription &description) {
-    THandle newHandle = mLastHandle++;
+    THandle newHandle = mLastHandle;
+    mLastHandle = static_cast<THandle>(rhi::castHandleToUint(mLastHandle) + 1);
     mDescriptions.insert({newHandle, description});
     mDirtyCreates.push_back(newHandle);
 

--- a/engine/src/liquid/rhi/vulkan/VulkanDescriptorManager.cpp
+++ b/engine/src/liquid/rhi/vulkan/VulkanDescriptorManager.cpp
@@ -81,7 +81,7 @@ VulkanDescriptorManager::createDescriptorSet(const Descriptor &descriptor,
       const auto &textures =
           std::get<std::vector<TextureHandle>>(binding.second.data);
       for (const auto tex : textures) {
-        if (tex == 0)
+        if (!rhi::isHandleValid(tex))
           continue;
 
         const auto &native = mRegistry.getTextures().at(tex);

--- a/engine/src/liquid/rhi/vulkan/VulkanRenderDevice.cpp
+++ b/engine/src/liquid/rhi/vulkan/VulkanRenderDevice.cpp
@@ -48,9 +48,7 @@ void VulkanRenderDevice::synchronizeSwapchain(size_t prevNumSwapchainImages) {
     mRegistry.removeTexture(static_cast<TextureHandle>(i));
   }
 
-  auto numSwapchainImages = static_cast<TextureHandle>(numNewSwapchainImages);
-
-  for (size_t i = 0; i < numSwapchainImages; ++i) {
+  for (size_t i = 0; i < numNewSwapchainImages; ++i) {
     TextureHandle handle = static_cast<TextureHandle>(i + 1);
 
     auto &&ptr = std::make_unique<VulkanTexture>(

--- a/engine/src/liquid/rhi/vulkan/VulkanRenderPass.cpp
+++ b/engine/src/liquid/rhi/vulkan/VulkanRenderPass.cpp
@@ -17,7 +17,8 @@ VulkanRenderPass::VulkanRenderPass(const RenderPassDescription &description,
       description.colorAttachments.size());
   VkAttachmentReference depthReference;
 
-  bool hasDepthAttachment = description.depthAttachment.texture > 0;
+  bool hasDepthAttachment =
+      rhi::isHandleValid(description.depthAttachment.texture);
 
   std::vector<VkAttachmentDescription> attachments(
       description.colorAttachments.size() + (hasDepthAttachment ? 1 : 0));

--- a/engine/src/liquid/rhi/vulkan/VulkanResourceRegistry.cpp
+++ b/engine/src/liquid/rhi/vulkan/VulkanResourceRegistry.cpp
@@ -65,7 +65,7 @@ void VulkanResourceRegistry::addFramebuffer(
 }
 
 void VulkanResourceRegistry::updateFramebuffer(
-    rhi::RenderPassHandle handle,
+    rhi::FramebufferHandle handle,
     std::unique_ptr<VulkanFramebuffer> &&framebuffer) {
   mFramebuffers.at(handle) = std::move(framebuffer);
 }
@@ -76,7 +76,7 @@ void VulkanResourceRegistry::addPipeline(
 }
 
 void VulkanResourceRegistry::updatePipeline(
-    rhi::RenderPassHandle handle, std::unique_ptr<VulkanPipeline> &&pipeline) {
+    rhi::PipelineHandle handle, std::unique_ptr<VulkanPipeline> &&pipeline) {
   mPipelines.at(handle) = std::move(pipeline);
 }
 

--- a/engine/src/liquid/rhi/vulkan/VulkanResourceRegistry.h
+++ b/engine/src/liquid/rhi/vulkan/VulkanResourceRegistry.h
@@ -166,7 +166,7 @@ public:
    * @param handle Framebuffer handle
    * @param framebuffer Vulkan framebuffer
    */
-  void updateFramebuffer(rhi::RenderPassHandle handle,
+  void updateFramebuffer(rhi::FramebufferHandle handle,
                          std::unique_ptr<VulkanFramebuffer> &&framebuffer);
 
   /**
@@ -191,7 +191,7 @@ public:
    * @param handle Pipeline handle
    * @param pipeline Vulkan pipeline
    */
-  void updatePipeline(rhi::RenderPassHandle handle,
+  void updatePipeline(rhi::PipelineHandle handle,
                       std::unique_ptr<VulkanPipeline> &&pipeline);
 
   /**

--- a/engine/src/liquid/scene/EnvironmentComponent.h
+++ b/engine/src/liquid/scene/EnvironmentComponent.h
@@ -3,9 +3,9 @@
 namespace liquid {
 
 struct EnvironmentComponent {
-  rhi::TextureHandle irradianceMap = 0;
-  rhi::TextureHandle specularMap = 0;
-  rhi::TextureHandle brdfLUT = 0;
+  rhi::TextureHandle irradianceMap = rhi::TextureHandle::Invalid;
+  rhi::TextureHandle specularMap = rhi::TextureHandle::Invalid;
+  rhi::TextureHandle brdfLUT = rhi::TextureHandle::Invalid;
 };
 
 } // namespace liquid

--- a/engine/src/liquid/scene/MeshInstance.h
+++ b/engine/src/liquid/scene/MeshInstance.h
@@ -36,7 +36,7 @@ public:
                                 (void *)geometry.getIndices().data()});
         indexBuffers.push_back(indexBuffer);
       } else {
-        indexBuffers.push_back(0);
+        indexBuffers.push_back(rhi::BufferHandle::Invalid);
       }
 
       indexCounts.push_back(

--- a/engine/tests/loaders/ImageTextureLoader.test.cpp
+++ b/engine/tests/loaders/ImageTextureLoader.test.cpp
@@ -14,7 +14,7 @@ TEST_F(ImageTextureLoaderTest, LoadsImageUsingStb) {
   liquid::ImageTextureLoader loader(registry);
   auto texture = loader.loadFromFile("white-image-100x100.png");
 
-  EXPECT_NE(texture, 0);
+  EXPECT_TRUE(liquid::rhi::isHandleValid(texture));
 
   const auto &description = registry.getTextureMap().getDescription(texture);
 

--- a/engine/tests/renderer/Descriptor.test.cpp
+++ b/engine/tests/renderer/Descriptor.test.cpp
@@ -14,7 +14,7 @@ using DescriptorDeathTest = DescriptorTest;
 TEST_F(DescriptorTest, AddsTextureBinding) {
   liquid::rhi::Descriptor descriptor;
 
-  liquid::rhi::TextureHandle tex1 = 1, tex2 = 2;
+  liquid::rhi::TextureHandle tex1{1}, tex2{2};
 
   descriptor.bind(2, {tex1, tex2},
                   liquid::rhi::DescriptorType::CombinedImageSampler);
@@ -28,19 +28,21 @@ TEST_F(DescriptorTest, AddsTextureBinding) {
 
 TEST_F(DescriptorTest, AddsUniformBufferBinding) {
   liquid::rhi::Descriptor descriptor;
-  descriptor.bind(2, 2, liquid::rhi::DescriptorType::UniformBuffer);
+
+  liquid::rhi::BufferHandle buffer{2};
+  descriptor.bind(2, buffer, liquid::rhi::DescriptorType::UniformBuffer);
 
   EXPECT_EQ(descriptor.getBindings().at(2).type,
             liquid::rhi::DescriptorType::UniformBuffer);
   auto data =
       std::get<liquid::rhi::BufferHandle>(descriptor.getBindings().at(2).data);
-  EXPECT_EQ(data, 2);
+  EXPECT_EQ(data, buffer);
 }
 
 TEST_F(DescriptorTest, CreatesHashFromBindings) {
   liquid::rhi::Descriptor descriptor;
-  liquid::rhi::TextureHandle tex1 = 1, tex2 = 2;
-  liquid::rhi::BufferHandle buffer1 = 1, buffer2 = 2;
+  liquid::rhi::TextureHandle tex1{1}, tex2{2};
+  liquid::rhi::BufferHandle buffer1{1}, buffer2{2};
 
   descriptor.bind(0, {tex1, tex2},
                   liquid::rhi::DescriptorType::CombinedImageSampler);
@@ -48,14 +50,14 @@ TEST_F(DescriptorTest, CreatesHashFromBindings) {
   descriptor.bind(2, buffer2, liquid::rhi::DescriptorType::UniformBuffer);
 
   std::stringstream ss;
-  ss << "b:0;t:1;d:" << tex1 << ";d:" << tex2 << ";|b:1;t:0;d:" << buffer1
-     << "|b:2;t:0;d:" << buffer2 << "|";
+  ss << "b:0;t:1;d:" << 1 << ";d:" << 2 << ";|b:1;t:0;d:" << 1
+     << "|b:2;t:0;d:" << 2 << "|";
 
   EXPECT_EQ(descriptor.getHashCode(), ss.str());
 }
 
 TEST_F(DescriptorDeathTest, FailsIfBufferIsUsedForCombinedImageSampler) {
-  liquid::rhi::BufferHandle buffer = 1;
+  liquid::rhi::BufferHandle buffer{1};
   liquid::rhi::Descriptor descriptor;
   EXPECT_DEATH(
       {
@@ -66,7 +68,7 @@ TEST_F(DescriptorDeathTest, FailsIfBufferIsUsedForCombinedImageSampler) {
 }
 
 TEST_F(DescriptorDeathTest, FailsIfTextureIsUsedForUniformBuffer) {
-  liquid::rhi::TextureHandle texture = 1;
+  liquid::rhi::TextureHandle texture{1};
   liquid::rhi::Descriptor descriptor;
   EXPECT_DEATH(
       {

--- a/engine/tests/renderer/Material.test.cpp
+++ b/engine/tests/renderer/Material.test.cpp
@@ -9,7 +9,8 @@ public:
 };
 
 TEST_F(MaterialTest, SetsBuffersAndTextures) {
-  std::vector<liquid::rhi::TextureHandle> textures{0};
+  std::vector<liquid::rhi::TextureHandle> textures{
+      liquid::rhi::TextureHandle(1)};
 
   liquid::Material material(
       textures,
@@ -24,7 +25,7 @@ TEST_F(MaterialTest, SetsBuffersAndTextures) {
 
   EXPECT_EQ(material.getTextures(), textures);
   EXPECT_EQ(material.hasTextures(), true);
-  EXPECT_NE(material.getUniformBuffer(), 0);
+  EXPECT_TRUE(liquid::rhi::isHandleValid(material.getUniformBuffer()));
   // Memory alignment
   EXPECT_EQ(description.size, sizeof(glm::vec4) * 2);
 
@@ -43,13 +44,14 @@ TEST_F(MaterialTest, SetsBuffersAndTextures) {
 }
 
 TEST_F(MaterialTest, DoesNotCreateBuffersIfEmptyProperties) {
-  std::vector<liquid::rhi::TextureHandle> textures{0};
+  std::vector<liquid::rhi::TextureHandle> textures{
+      liquid::rhi::TextureHandle(1)};
 
   liquid::Material material(textures, {}, registry);
 
   EXPECT_EQ(material.getTextures(), textures);
   EXPECT_EQ(material.hasTextures(), true);
-  EXPECT_EQ(material.getUniformBuffer(), 0);
+  EXPECT_FALSE(liquid::rhi::isHandleValid(material.getUniformBuffer()));
   EXPECT_EQ(material.getDescriptor().getBindings().find(0),
             material.getDescriptor().getBindings().end());
   EXPECT_EQ(material.getDescriptor().getBindings().at(1).type,
@@ -61,7 +63,7 @@ TEST_F(MaterialTest, DoesNotSetTexturesIfNoTexture) {
 
   EXPECT_EQ(material.getTextures().size(), 0);
   EXPECT_EQ(material.hasTextures(), false);
-  EXPECT_EQ(material.getUniformBuffer(), 0);
+  EXPECT_FALSE(liquid::rhi::isHandleValid(material.getUniformBuffer()));
 }
 
 TEST_F(MaterialTest, DoesNotUpdatePropertyIfPropertyDoesNotExist) {

--- a/engine/tests/renderer/MaterialPBR.test.cpp
+++ b/engine/tests/renderer/MaterialPBR.test.cpp
@@ -12,54 +12,55 @@ TEST_F(MaterialPBRTest, GetsTextures) {
   liquid::MaterialPBR::Properties properties;
   EXPECT_EQ(properties.getTextures().size(), 0);
 
-  properties.baseColorTexture = 1;
+  properties.baseColorTexture = liquid::rhi::TextureHandle(1);
   EXPECT_EQ(properties.getTextures().size(), 1);
-  EXPECT_EQ(properties.getTextures()[0], 1);
+  EXPECT_EQ(properties.getTextures()[0], properties.baseColorTexture);
 
-  properties.metallicRoughnessTexture = 2;
+  properties.metallicRoughnessTexture = liquid::rhi::TextureHandle(2);
   EXPECT_EQ(properties.getTextures().size(), 2);
-  EXPECT_EQ(properties.getTextures()[0], 1);
-  EXPECT_EQ(properties.getTextures()[1], 2);
+  EXPECT_EQ(properties.getTextures()[0], properties.baseColorTexture);
+  EXPECT_EQ(properties.getTextures()[1], properties.metallicRoughnessTexture);
 
-  properties.normalTexture = 3;
+  properties.normalTexture = liquid::rhi::TextureHandle(2);
   EXPECT_EQ(properties.getTextures().size(), 3);
-  EXPECT_EQ(properties.getTextures()[0], 1);
-  EXPECT_EQ(properties.getTextures()[1], 2);
-  EXPECT_EQ(properties.getTextures()[2], 3);
+  EXPECT_EQ(properties.getTextures()[0], properties.baseColorTexture);
+  EXPECT_EQ(properties.getTextures()[1], properties.metallicRoughnessTexture);
+  EXPECT_EQ(properties.getTextures()[2], properties.normalTexture);
 
-  properties.occlusionTexture = 4;
+  properties.occlusionTexture = liquid::rhi::TextureHandle(4);
   EXPECT_EQ(properties.getTextures().size(), 4);
-  EXPECT_EQ(properties.getTextures()[0], 1);
-  EXPECT_EQ(properties.getTextures()[1], 2);
-  EXPECT_EQ(properties.getTextures()[2], 3);
-  EXPECT_EQ(properties.getTextures()[3], 4);
+  EXPECT_EQ(properties.getTextures()[0], properties.baseColorTexture);
+  EXPECT_EQ(properties.getTextures()[1], properties.metallicRoughnessTexture);
+  EXPECT_EQ(properties.getTextures()[2], properties.normalTexture);
+  EXPECT_EQ(properties.getTextures()[3], properties.occlusionTexture);
 
-  properties.emissiveTexture = 5;
+  properties.emissiveTexture = liquid::rhi::TextureHandle(5);
   EXPECT_EQ(properties.getTextures().size(), 5);
-  EXPECT_EQ(properties.getTextures()[0], 1);
-  EXPECT_EQ(properties.getTextures()[1], 2);
-  EXPECT_EQ(properties.getTextures()[2], 3);
-  EXPECT_EQ(properties.getTextures()[3], 4);
-  EXPECT_EQ(properties.getTextures()[4], 5);
+  EXPECT_EQ(properties.getTextures()[0], properties.baseColorTexture);
+  EXPECT_EQ(properties.getTextures()[1], properties.metallicRoughnessTexture);
+  EXPECT_EQ(properties.getTextures()[2], properties.normalTexture);
+  EXPECT_EQ(properties.getTextures()[3], properties.occlusionTexture);
+  EXPECT_EQ(properties.getTextures()[4], properties.emissiveTexture);
 }
 
 TEST_F(MaterialPBRTest, GetsProperties) {
-  liquid::MaterialPBR::Properties properties{0,
-                                             0,
-                                             {1.0f, 0.2f, 0.3f, 0.4f},
-                                             0,
-                                             0,
-                                             0.2f,
-                                             0.6f,
-                                             0,
-                                             1,
-                                             0.7f,
-                                             0,
-                                             0,
-                                             0.3f,
-                                             0,
-                                             0,
-                                             glm::vec3(1.0f, 0.2f, 0.4f)};
+  liquid::MaterialPBR::Properties properties{
+      liquid::rhi::TextureHandle::Invalid,
+      0,
+      {1.0f, 0.2f, 0.3f, 0.4f},
+      liquid::rhi::TextureHandle::Invalid,
+      0,
+      0.2f,
+      0.6f,
+      liquid::rhi::TextureHandle::Invalid,
+      1,
+      0.7f,
+      liquid::rhi::TextureHandle::Invalid,
+      0,
+      0.3f,
+      liquid::rhi::TextureHandle::Invalid,
+      0,
+      glm::vec3(1.0f, 0.2f, 0.4f)};
 
 #define EXPECT_PROP_EQ(idx, key, type, value)                                  \
   EXPECT_EQ(properties.getProperties()[idx].first, key);                       \
@@ -87,25 +88,25 @@ TEST_F(MaterialPBRTest, GetsProperties) {
   EXPECT_PROP_EQ(14, "emissiveTextureCoord", int, 0);
   EXPECT_PROP_EQ(15, "emissiveFactor", glm::vec3, glm::vec3(1.0, 0.2, 0.4));
 
-  properties.baseColorTexture = 1;
+  properties.baseColorTexture = liquid::rhi::TextureHandle(1);
   EXPECT_PROP_EQ(0, "baseColorTexture", int, 0);
 
-  properties.normalTexture = 2;
+  properties.normalTexture = liquid::rhi::TextureHandle(2);
   EXPECT_PROP_EQ(0, "baseColorTexture", int, 0);
   EXPECT_PROP_EQ(7, "normalTexture", int, 1);
 
-  properties.occlusionTexture = 3;
+  properties.occlusionTexture = liquid::rhi::TextureHandle(3);
   EXPECT_PROP_EQ(0, "baseColorTexture", int, 0);
   EXPECT_PROP_EQ(7, "normalTexture", int, 1);
   EXPECT_PROP_EQ(10, "occlusionTexture", int, 2);
 
-  properties.metallicRoughnessTexture = 4;
+  properties.metallicRoughnessTexture = liquid::rhi::TextureHandle(4);
   EXPECT_PROP_EQ(0, "baseColorTexture", int, 0);
   EXPECT_PROP_EQ(3, "metallicRoughnessTexture", int, 1);
   EXPECT_PROP_EQ(7, "normalTexture", int, 2);
   EXPECT_PROP_EQ(10, "occlusionTexture", int, 3);
 
-  properties.emissiveTexture = 5;
+  properties.emissiveTexture = liquid::rhi::TextureHandle(5);
   EXPECT_PROP_EQ(0, "baseColorTexture", int, 0);
   EXPECT_PROP_EQ(3, "metallicRoughnessTexture", int, 1);
   EXPECT_PROP_EQ(7, "normalTexture", int, 2);
@@ -116,22 +117,23 @@ TEST_F(MaterialPBRTest, GetsProperties) {
 }
 
 TEST_F(MaterialPBRTest, SetsShadersPropertiesAndTextures) {
-  liquid::MaterialPBR::Properties properties{1,
-                                             0,
-                                             {1.0f, 0.2f, 0.3f, 0.4f},
-                                             0,
-                                             0,
-                                             0.2f,
-                                             0.6f,
-                                             2,
-                                             1,
-                                             0.7f,
-                                             0,
-                                             0,
-                                             0.3f,
-                                             3,
-                                             0,
-                                             glm::vec3(1.0f, 0.2f, 0.4f)};
+  liquid::MaterialPBR::Properties properties{
+      liquid::rhi::TextureHandle(1),
+      0,
+      {1.0f, 0.2f, 0.3f, 0.4f},
+      liquid::rhi::TextureHandle::Invalid,
+      0,
+      0.2f,
+      0.6f,
+      liquid::rhi::TextureHandle(2),
+      1,
+      0.7f,
+      liquid::rhi::TextureHandle::Invalid,
+      0,
+      0.3f,
+      liquid::rhi::TextureHandle(3),
+      0,
+      glm::vec3(1.0f, 0.2f, 0.4f)};
 
   liquid::MaterialPBR material(properties, registry);
 

--- a/engine/tests/renderer/RenderGraphRegistry.test.cpp
+++ b/engine/tests/renderer/RenderGraphRegistry.test.cpp
@@ -9,49 +9,54 @@ public:
 };
 
 TEST_F(RenderGraphRegistryTest, AddsTextureToRegistry) {
-  registry.addTexture(1, 2);
+  registry.addTexture(1, liquid::rhi::TextureHandle(2));
 
   EXPECT_TRUE(registry.hasTexture(1));
-  EXPECT_EQ(registry.getTexture(1), 2);
+  EXPECT_EQ(registry.getTexture(1), liquid::rhi::TextureHandle(2));
 }
 
 TEST_F(RenderGraphRegistryTest, UpdatesExistingTextureInRegistry) {
-  registry.addTexture(1, 2);
-  registry.addTexture(1, 3);
+  registry.addTexture(1, liquid::rhi::TextureHandle(2));
+  registry.addTexture(1, liquid::rhi::TextureHandle(3));
 
   EXPECT_TRUE(registry.hasTexture(1));
-  EXPECT_EQ(registry.getTexture(1), 3);
+  EXPECT_EQ(registry.getTexture(1), liquid::rhi::TextureHandle(3));
 }
 
 TEST_F(RenderGraphRegistryTest, AddsRenderPassToRegistry) {
-  registry.addRenderPass(1,
-                         liquid::RenderGraphPassResult(2, {}, {}, 100, 200, 1));
+  registry.addRenderPass(
+      1, liquid::RenderGraphPassResult(liquid::rhi::RenderPassHandle(2), {}, {},
+                                       100, 200, 1));
 
   EXPECT_TRUE(registry.hasRenderPass(1));
-  EXPECT_EQ(registry.getRenderPass(1).getRenderPass(), 2);
+  EXPECT_EQ(registry.getRenderPass(1).getRenderPass(),
+            liquid::rhi::RenderPassHandle(2));
 }
 
 TEST_F(RenderGraphRegistryTest, UpdatesExistingRenderPassInRegistry) {
-  registry.addRenderPass(1,
-                         liquid::RenderGraphPassResult(2, {}, {}, 100, 200, 1));
-  registry.addRenderPass(1,
-                         liquid::RenderGraphPassResult(3, {}, {}, 100, 200, 1));
+  registry.addRenderPass(
+      1, liquid::RenderGraphPassResult(liquid::rhi::RenderPassHandle(2), {}, {},
+                                       100, 200, 1));
+  registry.addRenderPass(
+      1, liquid::RenderGraphPassResult(liquid::rhi::RenderPassHandle(3), {}, {},
+                                       100, 200, 1));
 
   EXPECT_TRUE(registry.hasRenderPass(1));
-  EXPECT_EQ(registry.getRenderPass(1).getRenderPass(), 3);
+  EXPECT_EQ(registry.getRenderPass(1).getRenderPass(),
+            liquid::rhi::RenderPassHandle(3));
 }
 
 TEST_F(RenderGraphRegistryTest, AddsPipelineToRegistry) {
-  registry.addPipeline(1, 2);
+  registry.addPipeline(1, liquid::rhi::PipelineHandle(2));
 
   EXPECT_TRUE(registry.hasPipeline(1));
-  EXPECT_EQ(registry.getPipeline(1), 2);
+  EXPECT_EQ(registry.getPipeline(1), liquid::rhi::PipelineHandle(2));
 }
 
 TEST_F(RenderGraphRegistryTest, UpdatesExistingPipelineInRegistry) {
-  registry.addPipeline(1, 2);
-  registry.addPipeline(1, 3);
+  registry.addPipeline(1, liquid::rhi::PipelineHandle(2));
+  registry.addPipeline(1, liquid::rhi::PipelineHandle(3));
 
   EXPECT_TRUE(registry.hasPipeline(1));
-  EXPECT_EQ(registry.getPipeline(1), 3);
+  EXPECT_EQ(registry.getPipeline(1), liquid::rhi::PipelineHandle(3));
 }

--- a/engine/tests/renderer/ShaderLibrary.test.cpp
+++ b/engine/tests/renderer/ShaderLibrary.test.cpp
@@ -12,9 +12,9 @@ TEST(ShaderLibraryDeathTest, ThrowsErrorIfShaderNotFound) {
 TEST(ShaderLibraryTests, AddsShader) {
   liquid::ShaderLibrary library;
 
-  library.addShader("shader1", 1);
-  library.addShader("shader2", 2);
+  library.addShader("shader1", liquid::rhi::ShaderHandle(1));
+  library.addShader("shader2", liquid::rhi::ShaderHandle(2));
 
-  EXPECT_EQ(library.getShader("shader1"), 1);
-  EXPECT_EQ(library.getShader("shader2"), 2);
+  EXPECT_EQ(library.getShader("shader1"), liquid::rhi::ShaderHandle(1));
+  EXPECT_EQ(library.getShader("shader2"), liquid::rhi::ShaderHandle(2));
 }

--- a/engine/tests/rhi/ResourceRegistry.test.cpp
+++ b/engine/tests/rhi/ResourceRegistry.test.cpp
@@ -7,7 +7,8 @@ struct TestDesc {
   uint32_t value = 0;
 };
 
-using TestMap = liquid::rhi::ResourceRegistryMap<uint32_t, TestDesc>;
+using TestMap =
+    liquid::rhi::ResourceRegistryMap<liquid::rhi::ShaderHandle, TestDesc>;
 
 TEST(ResourceRegistryMapTest, AddsNewResource) {
   TestMap map;

--- a/engine/tests/scene/MeshInstance.test.cpp
+++ b/engine/tests/scene/MeshInstance.test.cpp
@@ -29,8 +29,8 @@ TEST_F(MeshInstanceTest, CreatesVertexAndIndexBuffersOnConstruct) {
   EXPECT_EQ(instance.getMaterials().size(), 2);
 
   for (size_t i = 0; i < 2; ++i) {
-    EXPECT_NE(instance.getVertexBuffers().at(i), 0);
-    EXPECT_NE(instance.getIndexBuffers().at(i), 0);
+    EXPECT_TRUE(liquid::rhi::isHandleValid(instance.getVertexBuffers().at(i)));
+    EXPECT_TRUE(liquid::rhi::isHandleValid(instance.getIndexBuffers().at(i)));
   }
 }
 
@@ -48,11 +48,11 @@ TEST_F(MeshInstanceTest, CreatesWithoutIndexBuffersOnConstruct) {
   EXPECT_EQ(instance.getMaterials().size(), 2);
 
   for (size_t i = 0; i < 2; ++i) {
-    EXPECT_NE(instance.getVertexBuffers().at(i), 0);
+    EXPECT_TRUE(liquid::rhi::isHandleValid(instance.getVertexBuffers().at(i)));
   }
 
-  EXPECT_EQ(instance.getIndexBuffers().at(0), 0);
-  EXPECT_NE(instance.getIndexBuffers().at(1), 0);
+  EXPECT_FALSE(liquid::rhi::isHandleValid(instance.getIndexBuffers().at(0)));
+  EXPECT_TRUE(liquid::rhi::isHandleValid(instance.getIndexBuffers().at(1)));
 }
 
 TEST_F(MeshInstanceTest, SetsMaterial) {


### PR DESCRIPTION
- Use enum classes to create render handle types
- Add utility function to check invalid handles
- Add utility function to convert handle to uint
