### PR TITLE
Simplify registry operations

### DIFF
--- a/demos/pong-3d/src/main.cpp
+++ b/demos/pong-3d/src/main.cpp
@@ -29,9 +29,9 @@ public:
       : window("Pong 3D", 800, 600), backend(window),
         renderer(entityContext, window, backend.getOrCreateDevice()),
         vertexShader(
-            renderer.getRegistry().addShader({"basic-shader.vert.spv"})),
+            renderer.getRegistry().setShader({"basic-shader.vert.spv"})),
         fragmentShader(
-            renderer.getRegistry().addShader({"basic-shader.frag.spv"})),
+            renderer.getRegistry().setShader({"basic-shader.frag.spv"})),
         material(renderer.createMaterial({}, {}, liquid::CullMode::None)),
         camera(new liquid::Camera(&renderer.getRegistry())) {
 

--- a/editor/src/editor-scene/EditorGrid.cpp
+++ b/editor/src/editor-scene/EditorGrid.cpp
@@ -5,7 +5,7 @@ namespace liquidator {
 
 EditorGrid::EditorGrid(liquid::rhi::ResourceRegistry &registry_)
     : registry(registry_) {
-  buffer = registry.addBuffer(
+  buffer = registry.setBuffer(
       {liquid::rhi::BufferType::Uniform, sizeof(EditorGridData), &data});
   updateUniformBuffer();
 }
@@ -21,8 +21,9 @@ void EditorGrid::setAxisLinesFlag(bool flag) {
 }
 
 void EditorGrid::updateUniformBuffer() {
-  registry.updateBuffer(buffer, {liquid::rhi::BufferType::Uniform,
-                                 sizeof(EditorGridData), &data});
+  registry.setBuffer(
+      {liquid::rhi::BufferType::Uniform, sizeof(EditorGridData), &data},
+      buffer);
 }
 
 } // namespace liquidator

--- a/editor/src/main.cpp
+++ b/editor/src/main.cpp
@@ -42,17 +42,17 @@ int main() {
   liquid::PhysicsSystem physicsSystem(context);
 
   renderer.getShaderLibrary().addShader(
-      "editor-grid.vert", renderer.getRegistry().addShader(
+      "editor-grid.vert", renderer.getRegistry().setShader(
                               {"assets/shaders/editor-grid.vert.spv"}));
   renderer.getShaderLibrary().addShader(
-      "editor-grid.frag", renderer.getRegistry().addShader(
+      "editor-grid.frag", renderer.getRegistry().setShader(
                               {"assets/shaders/editor-grid.frag.spv"}));
 
   renderer.getShaderLibrary().addShader(
-      "skeleton-lines.vert", renderer.getRegistry().addShader(
+      "skeleton-lines.vert", renderer.getRegistry().setShader(
                                  {"assets/shaders/skeleton-lines.vert.spv"}));
   renderer.getShaderLibrary().addShader(
-      "skeleton-lines.frag", renderer.getRegistry().addShader(
+      "skeleton-lines.frag", renderer.getRegistry().setShader(
                                  {"assets/shaders/skeleton-lines.frag.spv"}));
 
   liquid::MainLoop mainLoop(renderer, window);

--- a/engine/src/liquid/loaders/GLTFLoader.cpp
+++ b/engine/src/liquid/loaders/GLTFLoader.cpp
@@ -732,7 +732,7 @@ getMaterials(const tinygltf::Model &model, Renderer &renderer) {
     description.data = new char[description.size];
     memcpy(description.data, image.image.data(), description.size);
 
-    textures.push_back(renderer.getRegistry().addTexture(description));
+    textures.push_back(renderer.getRegistry().setTexture(description));
   }
 
   for (auto &gltfMaterial : model.materials) {

--- a/engine/src/liquid/loaders/ImageTextureLoader.cpp
+++ b/engine/src/liquid/loaders/ImageTextureLoader.cpp
@@ -26,7 +26,7 @@ rhi::TextureHandle ImageTextureLoader::loadFromFile(const String &filename) {
   description.type = rhi::TextureType::Standard;
   description.size = width * height * channels;
 
-  return registry.addTexture(description);
+  return registry.setTexture(description);
 }
 
 } // namespace liquid

--- a/engine/src/liquid/loaders/KtxTextureLoader.cpp
+++ b/engine/src/liquid/loaders/KtxTextureLoader.cpp
@@ -65,7 +65,7 @@ rhi::TextureHandle KtxTextureLoader::loadFromFile(const String &filename) {
 
   ktxTexture_Destroy(ktxTextureData);
 
-  return registry.addTexture(description);
+  return registry.setTexture(description);
 }
 
 } // namespace liquid

--- a/engine/src/liquid/renderer/Material.cpp
+++ b/engine/src/liquid/renderer/Material.cpp
@@ -17,7 +17,7 @@ Material::Material(const std::vector<rhi::TextureHandle> &textures_,
 
   if (!properties.empty()) {
     auto size = updateBufferData();
-    uniformBuffer = registry.addBuffer({rhi::BufferType::Uniform, size, data});
+    uniformBuffer = registry.setBuffer({rhi::BufferType::Uniform, size, data});
     descriptor.bind(0, uniformBuffer, rhi::DescriptorType::UniformBuffer);
   }
 
@@ -42,7 +42,8 @@ void Material::updateProperty(const String &name, const Property &value) {
 
   properties.at(index) = value;
   auto size = updateBufferData();
-  registry.updateBuffer(uniformBuffer, {rhi::BufferType::Uniform, size, data});
+  uniformBuffer =
+      registry.setBuffer({rhi::BufferType::Uniform, size, data}, uniformBuffer);
 }
 
 size_t Material::updateBufferData() {

--- a/engine/src/liquid/renderer/RenderData.cpp
+++ b/engine/src/liquid/renderer/RenderData.cpp
@@ -10,7 +10,7 @@ RenderData::RenderData(EntityContext &entityContext_, Scene *scene_,
       shadowMaterials(shadowMaterials_), registry(registry_) {
 
   sceneBuffer =
-      registry.addBuffer({rhi::BufferType::Uniform, sizeof(SceneBufferObject)});
+      registry.setBuffer({rhi::BufferType::Uniform, sizeof(SceneBufferObject)});
 }
 
 void RenderData::update() {
@@ -54,8 +54,9 @@ void RenderData::update() {
       });
 
   sceneData.numLights.x = static_cast<uint32_t>(i);
-  registry.updateBuffer(sceneBuffer, {rhi::BufferType::Uniform,
-                                      sizeof(SceneBufferObject), &sceneData});
+  registry.setBuffer(
+      {rhi::BufferType::Uniform, sizeof(SceneBufferObject), &sceneData},
+      sceneBuffer);
 }
 
 std::array<rhi::TextureHandle, 3> RenderData::getEnvironmentTextures() const {

--- a/engine/src/liquid/renderer/Renderer.cpp
+++ b/engine/src/liquid/renderer/Renderer.cpp
@@ -39,47 +39,47 @@ void Renderer::render(RenderGraph &graph) {
 
 void Renderer::loadShaders() {
   mShaderLibrary.addShader("__engine.geometry.default.vertex",
-                           mRegistry.addShader({Engine::getAssetsPath() +
+                           mRegistry.setShader({Engine::getAssetsPath() +
                                                 "/shaders/geometry.vert.spv"}));
   mShaderLibrary.addShader(
       "__engine.geometry.skinned.vertex",
-      mRegistry.addShader(
+      mRegistry.setShader(
           {Engine::getAssetsPath() + "/shaders/skinnedGeometry.vert.spv"}));
   mShaderLibrary.addShader(
       "__engine.pbr.default.fragment",
-      mRegistry.addShader({Engine::getAssetsPath() + "/shaders/pbr.frag.spv"}));
+      mRegistry.setShader({Engine::getAssetsPath() + "/shaders/pbr.frag.spv"}));
   mShaderLibrary.addShader("__engine.skybox.default.vertex",
-                           mRegistry.addShader({Engine::getAssetsPath() +
+                           mRegistry.setShader({Engine::getAssetsPath() +
                                                 "/shaders/skybox.vert.spv"}));
   mShaderLibrary.addShader("__engine.skybox.default.fragment",
-                           mRegistry.addShader({Engine::getAssetsPath() +
+                           mRegistry.setShader({Engine::getAssetsPath() +
                                                 "/shaders/skybox.frag.spv"}));
   mShaderLibrary.addShader(
       "__engine.shadowmap.default.vertex",
-      mRegistry.addShader(
+      mRegistry.setShader(
           {Engine::getAssetsPath() + "/shaders/shadowmap.vert.spv"}));
   mShaderLibrary.addShader(
       "__engine.shadowmap.skinned.vertex",
-      mRegistry.addShader(
+      mRegistry.setShader(
           {Engine::getAssetsPath() + "/shaders/skinnedShadowmap.vert.spv"}));
 
   mShaderLibrary.addShader(
       "__engine.shadowmap.default.fragment",
-      mRegistry.addShader(
+      mRegistry.setShader(
           {Engine::getAssetsPath() + "/shaders/shadowmap.frag.spv"}));
   mShaderLibrary.addShader("__engine.imgui.default.vertex",
-                           mRegistry.addShader({Engine::getAssetsPath() +
+                           mRegistry.setShader({Engine::getAssetsPath() +
                                                 "/shaders/imgui.vert.spv"}));
   mShaderLibrary.addShader("__engine.imgui.default.fragment",
-                           mRegistry.addShader({Engine::getAssetsPath() +
+                           mRegistry.setShader({Engine::getAssetsPath() +
                                                 "/shaders/imgui.frag.spv"}));
   mShaderLibrary.addShader(
       "__engine.fullscreenQuad.default.vertex",
-      mRegistry.addShader(
+      mRegistry.setShader(
           {Engine::getAssetsPath() + "/shaders/fullscreenQuad.vert.spv"}));
   mShaderLibrary.addShader(
       "__engine.fullscreenQuad.default.fragment",
-      mRegistry.addShader(
+      mRegistry.setShader(
           {Engine::getAssetsPath() + "/shaders/fullscreenQuad.frag.spv"}));
 }
 

--- a/engine/src/liquid/renderer/imgui/ImguiRenderer.cpp
+++ b/engine/src/liquid/renderer/imgui/ImguiRenderer.cpp
@@ -116,25 +116,15 @@ void ImguiRenderer::draw(rhi::RenderCommandList &commandList,
       ibDst += cmd_list->IdxBuffer.Size;
     }
 
-    if (registry.getBufferMap().hasDescription(frameObj.vertexBuffer)) {
-      registry.updateBuffer(frameObj.vertexBuffer,
-                            {rhi::BufferType::Vertex, frameObj.vertexBufferSize,
-                             frameObj.vertexBufferData});
-    } else {
-      frameObj.vertexBuffer = registry.addBuffer({rhi::BufferType::Vertex,
-                                                  frameObj.vertexBufferSize,
-                                                  frameObj.vertexBufferData});
-    }
+    frameObj.vertexBuffer =
+        registry.setBuffer({rhi::BufferType::Vertex, frameObj.vertexBufferSize,
+                            frameObj.vertexBufferData},
+                           frameObj.vertexBuffer);
 
-    if (registry.getBufferMap().hasDescription(frameObj.indexBuffer)) {
-      registry.updateBuffer(frameObj.indexBuffer,
-                            {rhi::BufferType::Index, frameObj.indexBufferSize,
-                             frameObj.indexBufferData});
-    } else {
-      frameObj.indexBuffer =
-          registry.addBuffer({rhi::BufferType::Index, frameObj.indexBufferSize,
-                              frameObj.indexBufferData});
-    }
+    frameObj.indexBuffer =
+        registry.setBuffer({rhi::BufferType::Index, frameObj.indexBufferSize,
+                            frameObj.indexBufferData},
+                           frameObj.indexBuffer);
   }
 
   // @temporary
@@ -264,7 +254,7 @@ void ImguiRenderer::loadFonts() {
     description.aspectFlags = VK_IMAGE_ASPECT_COLOR_BIT;
     description.data = pixels;
 
-    fontTexture = registry.addTexture(description);
+    fontTexture = registry.setTexture(description);
   }
 
   io.Fonts->SetTexID(

--- a/engine/src/liquid/renderer/render-graph/RenderGraphEvaluator.cpp
+++ b/engine/src/liquid/renderer/render-graph/RenderGraphEvaluator.cpp
@@ -140,11 +140,9 @@ void RenderGraphEvaluator::buildPass(RenderGraphPassBase *pass,
       renderPass = graph.getResourceRegistry()
                        .getRenderPass(pass->getRenderPass())
                        .getRenderPass();
-
-      mRegistry.updateRenderPass(renderPass, renderPassDesc);
-    } else {
-      renderPass = mRegistry.addRenderPass(renderPassDesc);
     }
+
+    renderPass = mRegistry.setRenderPass(renderPassDesc, renderPass);
 
     std::vector<rhi::FramebufferHandle> framebuffers(
         framebufferAttachments.size(), rhi::FramebufferHandle::Invalid);
@@ -162,10 +160,9 @@ void RenderGraphEvaluator::buildPass(RenderGraphPassBase *pass,
                                  .getRenderPass(pass->getRenderPass())
                                  .getFramebuffers()
                                  .at(i);
-        mRegistry.updateFramebuffer(framebuffers.at(i), framebufferDesc);
-      } else {
-        framebuffers.at(i) = mRegistry.addFramebuffer(framebufferDesc);
       }
+      framebuffers.at(i) =
+          mRegistry.setFramebuffer(framebufferDesc, framebuffers.at(i));
     }
 
     if (framebuffers.size() > 0) {
@@ -203,11 +200,9 @@ void RenderGraphEvaluator::buildPass(RenderGraphPassBase *pass,
       rhi::PipelineHandle handle = rhi::PipelineHandle::Invalid;
       if (hasPipeline) {
         handle = graph.getResourceRegistry().getPipeline(resource);
-        mRegistry.updatePipeline(handle, description);
-      } else {
-        handle = mRegistry.addPipeline(description);
       }
 
+      handle = mRegistry.setPipeline(description, handle);
       graph.getResourceRegistry().addPipeline(resource, handle);
     }
   }
@@ -343,7 +338,7 @@ RenderGraphEvaluator::createTexture(const AttachmentData &data,
     description.aspectFlags = VK_IMAGE_ASPECT_DEPTH_BIT;
   }
 
-  return mRegistry.addTexture(description);
+  return mRegistry.setTexture(description);
 }
 
 } // namespace liquid

--- a/engine/src/liquid/rhi/ResourceRegistry.cpp
+++ b/engine/src/liquid/rhi/ResourceRegistry.cpp
@@ -3,46 +3,38 @@
 
 namespace liquid::rhi {
 
-ShaderHandle ResourceRegistry::addShader(const ShaderDescription &description) {
-  return mShaders.addDescription(description);
+ShaderHandle ResourceRegistry::setShader(const ShaderDescription &description,
+                                         ShaderHandle handle) {
+  return mShaders.setDescription(description, handle);
 }
 
 void ResourceRegistry::deleteShader(ShaderHandle handle) {
   mShaders.deleteDescription(handle);
 }
 
-BufferHandle ResourceRegistry::addBuffer(const BufferDescription &description) {
-  return mBuffers.addDescription(description);
+BufferHandle ResourceRegistry::setBuffer(const BufferDescription &description,
+                                         BufferHandle handle) {
+  return mBuffers.setDescription(description, handle);
 }
 
 void ResourceRegistry::deleteBuffer(BufferHandle handle) {
   mBuffers.deleteDescription(handle);
 }
 
-void ResourceRegistry::updateBuffer(BufferHandle handle,
-                                    const BufferDescription &description) {
-  LIQUID_ASSERT(rhi::isHandleValid(handle), "Buffer does not exist");
-  mBuffers.updateDescription(handle, description);
-}
-
 TextureHandle
-ResourceRegistry::addTexture(const TextureDescription &description) {
-  return mTextures.addDescription(description);
+ResourceRegistry::setTexture(const TextureDescription &description,
+                             TextureHandle handle) {
+  return mTextures.setDescription(description, handle);
 }
 
 void ResourceRegistry::deleteTexture(TextureHandle handle) {
   mTextures.deleteDescription(handle);
 }
 
-rhi::RenderPassHandle
-ResourceRegistry::addRenderPass(const RenderPassDescription &description) {
-  return mRenderPasses.addDescription(description);
-}
-
-void ResourceRegistry::updateRenderPass(
-    rhi::RenderPassHandle handle, const RenderPassDescription &description) {
-  LIQUID_ASSERT(rhi::isHandleValid(handle), "Render pass does not exist");
-  mRenderPasses.updateDescription(handle, description);
+RenderPassHandle
+ResourceRegistry::setRenderPass(const RenderPassDescription &description,
+                                RenderPassHandle handle) {
+  return mRenderPasses.setDescription(description, handle);
 }
 
 void ResourceRegistry::deleteRenderPass(rhi::RenderPassHandle handle) {
@@ -50,14 +42,9 @@ void ResourceRegistry::deleteRenderPass(rhi::RenderPassHandle handle) {
 }
 
 FramebufferHandle
-ResourceRegistry::addFramebuffer(const FramebufferDescription &description) {
-  return mFramebuffers.addDescription(description);
-}
-
-void ResourceRegistry::updateFramebuffer(
-    FramebufferHandle handle, const FramebufferDescription &description) {
-  LIQUID_ASSERT(rhi::isHandleValid(handle), "Framebuffer does not exist");
-  mFramebuffers.updateDescription(handle, description);
+ResourceRegistry::setFramebuffer(const FramebufferDescription &description,
+                                 FramebufferHandle handle) {
+  return mFramebuffers.setDescription(description, handle);
 }
 
 void ResourceRegistry::deleteFramebuffer(FramebufferHandle handle) {
@@ -65,14 +52,9 @@ void ResourceRegistry::deleteFramebuffer(FramebufferHandle handle) {
 }
 
 PipelineHandle
-ResourceRegistry::addPipeline(const PipelineDescription &description) {
-  return mPipelines.addDescription(description);
-}
-
-void ResourceRegistry::updatePipeline(PipelineHandle handle,
-                                      const PipelineDescription &description) {
-  LIQUID_ASSERT(rhi::isHandleValid(handle), "Pipeline does not exist");
-  mPipelines.updateDescription(handle, description);
+ResourceRegistry::setPipeline(const PipelineDescription &description,
+                              PipelineHandle handle) {
+  return mPipelines.setDescription(description, handle);
 }
 
 void ResourceRegistry::deletePipeline(PipelineHandle handle) {

--- a/engine/src/liquid/rhi/vulkan/VulkanCommandBuffer.cpp
+++ b/engine/src/liquid/rhi/vulkan/VulkanCommandBuffer.cpp
@@ -58,7 +58,7 @@ void VulkanCommandBuffer::bindDescriptor(PipelineHandle pipeline,
 }
 
 void VulkanCommandBuffer::bindVertexBuffer(BufferHandle buffer) {
-  const auto &vulkanBuffer = mRegistry.getBuffer(buffer);
+  const auto &vulkanBuffer = mRegistry.getBuffers().at(buffer);
   std::array<VkDeviceSize, 1> offsets{0};
   std::array<VkBuffer, 1> buffers{vulkanBuffer->getBuffer()};
 
@@ -67,7 +67,7 @@ void VulkanCommandBuffer::bindVertexBuffer(BufferHandle buffer) {
 
 void VulkanCommandBuffer::bindIndexBuffer(BufferHandle buffer,
                                           VkIndexType indexType) {
-  const auto &vulkanBuffer = mRegistry.getBuffer(buffer);
+  const auto &vulkanBuffer = mRegistry.getBuffers().at(buffer);
 
   vkCmdBindIndexBuffer(mCommandBuffer, vulkanBuffer->getBuffer(), 0, indexType);
 }

--- a/engine/src/liquid/rhi/vulkan/VulkanDescriptorManager.cpp
+++ b/engine/src/liquid/rhi/vulkan/VulkanDescriptorManager.cpp
@@ -64,8 +64,8 @@ VulkanDescriptorManager::createDescriptorSet(const Descriptor &descriptor,
         VulkanMapping::getDescriptorType(binding.second.type);
 
     if (binding.second.type == DescriptorType::UniformBuffer) {
-      const auto &vkBuffer =
-          mRegistry.getBuffer(std::get<BufferHandle>(binding.second.data));
+      const auto &vkBuffer = mRegistry.getBuffers().at(
+          std::get<BufferHandle>(binding.second.data));
       bufferInfos.push_back(VkDescriptorBufferInfo{vkBuffer->getBuffer(), 0,
                                                    vkBuffer->getSize()});
 

--- a/engine/src/liquid/rhi/vulkan/VulkanPipeline.cpp
+++ b/engine/src/liquid/rhi/vulkan/VulkanPipeline.cpp
@@ -15,8 +15,8 @@ VulkanPipeline::VulkanPipeline(const PipelineDescription &description,
     : mDevice(device) {
 
   std::array<VulkanShader *, 2> shaders{
-      registry.getShader(description.vertexShader).get(),
-      registry.getShader(description.fragmentShader).get(),
+      registry.getShaders().at(description.vertexShader).get(),
+      registry.getShaders().at(description.fragmentShader).get(),
   };
 
   std::array<VkPipelineShaderStageCreateInfo, 2> stages{};

--- a/engine/src/liquid/rhi/vulkan/VulkanRenderDevice.h
+++ b/engine/src/liquid/rhi/vulkan/VulkanRenderDevice.h
@@ -81,13 +81,6 @@ private:
    */
   void synchronize(ResourceRegistry &registry);
 
-  /**
-   * @brief Synchronize resource deletes
-   *
-   * @param registry Resource registry
-   */
-  void synchronizeDeletes(ResourceRegistry &registry);
-
 private:
   VulkanRenderBackend &mBackend;
   VulkanPhysicalDevice mPhysicalDevice;

--- a/engine/src/liquid/rhi/vulkan/VulkanResourceRegistry.cpp
+++ b/engine/src/liquid/rhi/vulkan/VulkanResourceRegistry.cpp
@@ -9,75 +9,60 @@
 
 namespace liquid::rhi {
 
-void VulkanResourceRegistry::addShader(ShaderHandle handle,
+void VulkanResourceRegistry::setShader(ShaderHandle handle,
                                        std::unique_ptr<VulkanShader> &&shader) {
-  mShaders.insert({handle, std::move(shader)});
+  mShaders.insert_or_assign(handle, std::move(shader));
 }
 
-void VulkanResourceRegistry::removeShader(ShaderHandle handle) {
+void VulkanResourceRegistry::deleteShader(ShaderHandle handle) {
   mShaders.erase(handle);
 }
 
-void VulkanResourceRegistry::addBuffer(BufferHandle handle,
+void VulkanResourceRegistry::setBuffer(BufferHandle handle,
                                        std::unique_ptr<VulkanBuffer> &&buffer) {
-  mBuffers.insert({handle, std::move(buffer)});
+  mBuffers.insert_or_assign(handle, std::move(buffer));
 }
 
-void VulkanResourceRegistry::removeBuffer(BufferHandle handle) {
+void VulkanResourceRegistry::deleteBuffer(BufferHandle handle) {
   mBuffers.erase(handle);
 }
 
-void VulkanResourceRegistry::updateBuffer(
-    BufferHandle handle, std::unique_ptr<VulkanBuffer> &&buffer) {
-  mBuffers.at(handle) = std::move(buffer);
-}
-
-void VulkanResourceRegistry::addTexture(
+void VulkanResourceRegistry::setTexture(
     TextureHandle handle, std::unique_ptr<VulkanTexture> &&texture) {
-  mTextures.insert({handle, std::move(texture)});
+  mTextures.insert_or_assign(handle, std::move(texture));
 }
 
-void VulkanResourceRegistry::removeTexture(TextureHandle handle) {
+void VulkanResourceRegistry::deleteTexture(TextureHandle handle) {
   mTextures.erase(handle);
 }
 
-void VulkanResourceRegistry::updateTexture(
-    TextureHandle handle, std::unique_ptr<VulkanTexture> &&texture) {
-  mTextures.at(handle) = std::move(texture);
-}
-
-void VulkanResourceRegistry::addRenderPass(
+void VulkanResourceRegistry::setRenderPass(
     rhi::RenderPassHandle handle,
     std::unique_ptr<VulkanRenderPass> &&renderPass) {
-  mRenderPasses.insert({handle, std::move(renderPass)});
+  mRenderPasses.insert_or_assign(handle, std::move(renderPass));
 }
 
-void VulkanResourceRegistry::updateRenderPass(
-    rhi::RenderPassHandle handle,
-    std::unique_ptr<VulkanRenderPass> &&renderPass) {
-  mRenderPasses.at(handle) = std::move(renderPass);
+void VulkanResourceRegistry::deleteRenderPass(RenderPassHandle handle) {
+  mRenderPasses.erase(handle);
 }
 
-void VulkanResourceRegistry::addFramebuffer(
+void VulkanResourceRegistry::setFramebuffer(
     FramebufferHandle handle,
     std::unique_ptr<VulkanFramebuffer> &&framebuffer) {
-  mFramebuffers.insert({handle, std::move(framebuffer)});
+  mFramebuffers.insert_or_assign(handle, std::move(framebuffer));
 }
 
-void VulkanResourceRegistry::updateFramebuffer(
-    rhi::FramebufferHandle handle,
-    std::unique_ptr<VulkanFramebuffer> &&framebuffer) {
-  mFramebuffers.at(handle) = std::move(framebuffer);
+void VulkanResourceRegistry::deleteFramebuffer(FramebufferHandle handle) {
+  mFramebuffers.erase(handle);
 }
 
-void VulkanResourceRegistry::addPipeline(
+void VulkanResourceRegistry::setPipeline(
     PipelineHandle handle, std::unique_ptr<VulkanPipeline> &&pipeline) {
-  mPipelines.insert({handle, std::move(pipeline)});
+  mPipelines.insert_or_assign(handle, std::move(pipeline));
 }
 
-void VulkanResourceRegistry::updatePipeline(
-    rhi::PipelineHandle handle, std::unique_ptr<VulkanPipeline> &&pipeline) {
-  mPipelines.at(handle) = std::move(pipeline);
+void VulkanResourceRegistry::deletePipeline(PipelineHandle handle) {
+  mPipelines.erase(handle);
 }
 
 } // namespace liquid::rhi

--- a/engine/src/liquid/rhi/vulkan/VulkanResourceRegistry.h
+++ b/engine/src/liquid/rhi/vulkan/VulkanResourceRegistry.h
@@ -27,64 +27,51 @@ class VulkanResourceRegistry {
 
 public:
   /**
-   * @brief Add shader
+   * @brief Set shader
    *
    * @param handle Shader handle
    * @param shader Vulkan shader
    */
-  void addShader(ShaderHandle handle, std::unique_ptr<VulkanShader> &&shader);
+  void setShader(ShaderHandle handle, std::unique_ptr<VulkanShader> &&shader);
 
   /**
-   * @brief Remove shader
+   * @brief Delete shader
    *
    * @param handle Shader handle
    */
-  void removeShader(ShaderHandle handle);
+  void deleteShader(ShaderHandle handle);
 
   /**
-   * @brief Get shader
+   * @brief Get shaders
    *
-   * @param handle Shader handle
-   * @return Vulkan shader
+   * @return List of shaders
    */
-  inline const std::unique_ptr<VulkanShader> &
-  getShader(ShaderHandle handle) const {
-    return mShaders.at(handle);
-  }
+  inline const ShaderMap &getShaders() const { return mShaders; }
 
   /**
-   * @brief Add buffer
+   * @brief Set buffer
    *
    * @param handle Buffer handle
    * @param buffer Vulkan buffer
    */
-  void addBuffer(BufferHandle handle, std::unique_ptr<VulkanBuffer> &&buffer);
+  void setBuffer(BufferHandle handle, std::unique_ptr<VulkanBuffer> &&buffer);
 
   /**
-   * @brief Remove buffer
+   * @brief Delete buffer
    *
    * @param handle Buffer handle
    */
-  void removeBuffer(BufferHandle handle);
+  void deleteBuffer(BufferHandle handle);
 
   /**
-   * @brief Update buffer
+   * @brief Check if buffer exists
    *
    * @param handle Buffer handle
-   * @param buffer Vulkan buffer
+   * @retval true Buffer exists
+   * @retval false Buffer does not exist
    */
-  void updateBuffer(BufferHandle handle,
-                    std::unique_ptr<VulkanBuffer> &&buffer);
-
-  /**
-   * @brief Get buffer
-   *
-   * @param handle Buffer handle
-   * @return Vulkan buffer
-   */
-  inline const std::unique_ptr<VulkanBuffer> &
-  getBuffer(BufferHandle handle) const {
-    return mBuffers.at(handle);
+  inline bool hasBuffer(BufferHandle handle) const {
+    return mBuffers.find(handle) != mBuffers.end();
   }
 
   /**
@@ -95,20 +82,20 @@ public:
   inline const BufferMap &getBuffers() const { return mBuffers; }
 
   /**
-   * @brief Add texture
+   * @brief Set texture
    *
    * @param handle Texture handle
    * @param texture Vulkan texture
    */
-  void addTexture(TextureHandle handle,
+  void setTexture(TextureHandle handle,
                   std::unique_ptr<VulkanTexture> &&texture);
 
   /**
-   * @brief Remove texture
+   * @brief Delete texture
    *
    * @param handle Texture handle
    */
-  void removeTexture(TextureHandle handle);
+  void deleteTexture(TextureHandle handle);
 
   /**
    * @brief Get textures
@@ -118,31 +105,20 @@ public:
   inline const TextureMap &getTextures() const { return mTextures; }
 
   /**
-   * @brief Update texture
-   *
-   * @param handle Texture handle
-   * @param texture Vulkan texture
-   */
-  void updateTexture(TextureHandle handle,
-                     std::unique_ptr<VulkanTexture> &&texture);
-
-  /**
-   * @brief Add render pass
+   * @brief Set render pass
    *
    * @param handle Render pass handle
    * @param renderPass Vulkan render pass
    */
-  void addRenderPass(rhi::RenderPassHandle handle,
+  void setRenderPass(rhi::RenderPassHandle handle,
                      std::unique_ptr<VulkanRenderPass> &&renderPass);
 
   /**
-   * @brief Update render pass
+   * @brief Delete render pass
    *
    * @param handle Render pass handle
-   * @param renderPass Vulkan render pass
    */
-  void updateRenderPass(rhi::RenderPassHandle handle,
-                        std::unique_ptr<VulkanRenderPass> &&renderPass);
+  void deleteRenderPass(rhi::RenderPassHandle handle);
 
   /**
    * @brief Get render passes
@@ -152,22 +128,20 @@ public:
   inline const RenderPassMap &getRenderPasses() const { return mRenderPasses; }
 
   /**
-   * @brief Add framebuffer
+   * @brief Set framebuffer
    *
    * @param handle Framebuffer handle
    * @param framebuffer Vulkan framebuffer
    */
-  void addFramebuffer(FramebufferHandle handle,
+  void setFramebuffer(FramebufferHandle handle,
                       std::unique_ptr<VulkanFramebuffer> &&framebuffer);
 
   /**
-   * @brief Update framebuffer
+   * @brief Delete framebuffer
    *
    * @param handle Framebuffer handle
-   * @param framebuffer Vulkan framebuffer
    */
-  void updateFramebuffer(rhi::FramebufferHandle handle,
-                         std::unique_ptr<VulkanFramebuffer> &&framebuffer);
+  void deleteFramebuffer(rhi::FramebufferHandle handle);
 
   /**
    * @brief Get framebuffers
@@ -177,22 +151,20 @@ public:
   inline const FramebufferMap &getFramebuffers() const { return mFramebuffers; }
 
   /**
-   * @brief Add pipeline
+   * @brief Set pipeline
    *
    * @param handle Pipeline handle
    * @param pipeline Vulkan pipeline
    */
-  void addPipeline(PipelineHandle handle,
+  void setPipeline(PipelineHandle handle,
                    std::unique_ptr<VulkanPipeline> &&pipeline);
 
   /**
-   * @brief Update pipeline
+   * @brief Delete pipeline
    *
    * @param handle Pipeline handle
-   * @param pipeline Vulkan pipeline
    */
-  void updatePipeline(rhi::PipelineHandle handle,
-                      std::unique_ptr<VulkanPipeline> &&pipeline);
+  void deletePipeline(rhi::PipelineHandle handle);
 
   /**
    * @brief Get pipelines

--- a/engine/src/liquid/scene/Camera.cpp
+++ b/engine/src/liquid/scene/Camera.cpp
@@ -5,7 +5,7 @@ namespace liquid {
 
 Camera::Camera(rhi::ResourceRegistry *registry_) : registry(registry_) {
   uniformBuffer =
-      registry->addBuffer({rhi::BufferType::Uniform, sizeof(CameraData)});
+      registry->setBuffer({rhi::BufferType::Uniform, sizeof(CameraData)});
 }
 
 void Camera::setPerspective(float fovY, float aspectRatio, float near,
@@ -17,16 +17,16 @@ void Camera::setPerspective(float fovY, float aspectRatio, float near,
 
   updateProjectionViewMatrix();
 
-  registry->updateBuffer(uniformBuffer,
-                         {rhi::BufferType::Uniform, sizeof(CameraData), &data});
+  registry->setBuffer({rhi::BufferType::Uniform, sizeof(CameraData), &data},
+                      uniformBuffer);
 }
 
 void Camera::lookAt(glm::vec3 position, glm::vec3 direction, glm::vec3 up) {
   data.viewMatrix = glm::lookAt(position, direction, up);
   updateProjectionViewMatrix();
 
-  registry->updateBuffer(uniformBuffer,
-                         {rhi::BufferType::Uniform, sizeof(CameraData), &data});
+  registry->setBuffer({rhi::BufferType::Uniform, sizeof(CameraData), &data},
+                      uniformBuffer);
 }
 
 void Camera::updateProjectionViewMatrix() {

--- a/engine/src/liquid/scene/MeshInstance.h
+++ b/engine/src/liquid/scene/MeshInstance.h
@@ -24,14 +24,14 @@ public:
           geometry.getVertices().size() * sizeof(typename Mesh::Vertex);
 
       auto vertexBuffer =
-          registry.addBuffer({rhi::BufferType::Vertex, bufferSize,
+          registry.setBuffer({rhi::BufferType::Vertex, bufferSize,
                               (void *)geometry.getVertices().data()});
 
       if (geometry.getIndices().size() > 0) {
         size_t bufferSize = geometry.getIndices().size() * sizeof(uint32_t);
 
         auto indexBuffer =
-            registry.addBuffer({rhi::BufferType::Index,
+            registry.setBuffer({rhi::BufferType::Index,
                                 geometry.getIndices().size() * sizeof(uint32_t),
                                 (void *)geometry.getIndices().data()});
         indexBuffers.push_back(indexBuffer);

--- a/engine/src/liquid/scene/Skeleton.cpp
+++ b/engine/src/liquid/scene/Skeleton.cpp
@@ -26,7 +26,7 @@ Skeleton::Skeleton(std::vector<glm::vec3> &&positions,
   jointWorldTransforms.resize(numJoints, glm::mat4{1.0f});
   jointFinalTransforms.resize(numJoints, glm::mat4{1.0f});
 
-  buffer = registry->addBuffer(
+  buffer = registry->setBuffer(
       {rhi::BufferType::Uniform, sizeof(glm::mat4) * numJoints});
 
   // Debug data
@@ -39,7 +39,7 @@ Skeleton::Skeleton(std::vector<glm::vec3> &&positions,
 
   debugBoneTransforms.resize(numDebugBones, glm::mat4{1.0f});
 
-  debugBuffer = registry->addBuffer(
+  debugBuffer = registry->setBuffer(
       {rhi::BufferType::Uniform, sizeof(glm::mat4) * numDebugBones});
 }
 
@@ -83,9 +83,9 @@ void Skeleton::update() {
         jointWorldTransforms.at(i) * jointInverseBindMatrices.at(i);
   }
 
-  registry->updateBuffer(buffer, {rhi::BufferType::Uniform,
-                                  sizeof(glm::mat4) * numJoints,
-                                  jointFinalTransforms.data()});
+  registry->setBuffer({rhi::BufferType::Uniform, sizeof(glm::mat4) * numJoints,
+                       jointFinalTransforms.data()},
+                      buffer);
 }
 
 void Skeleton::updateDebug() {
@@ -95,9 +95,10 @@ void Skeleton::updateDebug() {
     debugBoneTransforms.at(i) = jointWorldTransforms.at(debugBones.at(i));
   }
 
-  registry->updateBuffer(debugBuffer, {rhi::BufferType::Uniform,
-                                       sizeof(glm::mat4) * debugBones.size(),
-                                       debugBoneTransforms.data()});
+  registry->setBuffer({rhi::BufferType::Uniform,
+                       sizeof(glm::mat4) * debugBones.size(),
+                       debugBoneTransforms.data()},
+                      buffer);
 }
 
 } // namespace liquid


### PR DESCRIPTION
- Replace create and update with set operation that does both
- Use std::set to make sure that staged handles are always unique