### PR TITLE
Use resource registry for textures in render graph

### DIFF
--- a/demos/pong-3d/src/main.cpp
+++ b/demos/pong-3d/src/main.cpp
@@ -66,10 +66,19 @@ public:
 
     liquid::SceneRenderer sceneRenderer(entityContext, false);
 
-    graph.create("depthBuffer",
-                 {liquid::AttachmentType::Depth,
-                  liquid::AttachmentSizeMethod::SwapchainRelative, 100, 100, 1,
-                  VK_FORMAT_D32_SFLOAT, liquid::DepthStencilClear{1.0f, 0}});
+    liquid::rhi::TextureDescription desc;
+    desc.usage =
+        liquid::rhi::TextureUsage::Depth | liquid::rhi::TextureUsage::Sampled;
+    desc.sizeMethod = liquid::rhi::TextureSizeMethod::SwapchainRatio;
+    desc.width = 100;
+    desc.height = 100;
+    desc.layers = 1;
+    desc.format = VK_FORMAT_D32_SFLOAT;
+
+    auto depthBuffer = renderer.getRegistry().setTexture(desc);
+
+    graph.import("depthBuffer", depthBuffer,
+                 liquid::DepthStencilClear{1.0f, 0});
 
     graph.addInlinePass<PongScope>(
         "mainPass",

--- a/engine/src/liquid/loaders/GLTFLoader.cpp
+++ b/engine/src/liquid/loaders/GLTFLoader.cpp
@@ -721,12 +721,11 @@ getMaterials(const tinygltf::Model &model, Renderer &renderer) {
     auto &image = model.images.at(gltfTexture.source);
 
     rhi::TextureDescription description;
+    description.usage = rhi::TextureUsage::Color | rhi::TextureUsage::Sampled |
+                        rhi::TextureUsage::TransferDestination;
     description.width = image.width;
     description.height = image.height;
     description.format = VK_FORMAT_R8G8B8A8_SRGB;
-    description.aspectFlags = VK_IMAGE_ASPECT_COLOR_BIT;
-    description.usageFlags =
-        VK_IMAGE_USAGE_SAMPLED_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT;
     description.size = image.width * image.height * 4;
 
     description.data = new char[description.size];

--- a/engine/src/liquid/loaders/ImageTextureLoader.cpp
+++ b/engine/src/liquid/loaders/ImageTextureLoader.cpp
@@ -21,8 +21,9 @@ rhi::TextureHandle ImageTextureLoader::loadFromFile(const String &filename) {
   description.format = VK_FORMAT_R8G8B8A8_SRGB;
   description.width = width;
   description.height = height;
-  description.aspectFlags = VK_IMAGE_ASPECT_COLOR_BIT;
-  description.usageFlags = VK_IMAGE_USAGE_TRANSFER_DST_BIT;
+  description.usage = rhi::TextureUsage::Color |
+                      rhi::TextureUsage::TransferDestination |
+                      rhi::TextureUsage::Sampled;
   description.type = rhi::TextureType::Standard;
   description.size = width * height * channels;
 

--- a/engine/src/liquid/loaders/KtxTextureLoader.cpp
+++ b/engine/src/liquid/loaders/KtxTextureLoader.cpp
@@ -40,9 +40,8 @@ rhi::TextureHandle KtxTextureLoader::loadFromFile(const String &filename) {
   description.layers = ktxTextureData->numLayers *
                        (ktxTextureData->isCubemap ? CUBEMAP_SIDES : 1);
   description.size = ktxTexture_GetDataSizeUncompressed(ktxTextureData);
-  description.usageFlags =
-      VK_IMAGE_USAGE_SAMPLED_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT;
-  description.aspectFlags = VK_IMAGE_ASPECT_COLOR_BIT;
+  description.usage = rhi::TextureUsage::Sampled | rhi::TextureUsage::Color |
+                      rhi::TextureUsage::TransferDestination;
   description.data = new char[description.size];
 
   char *srcData = reinterpret_cast<char *>(ktxTexture_GetData(ktxTextureData));

--- a/engine/src/liquid/renderer/imgui/ImguiRenderer.cpp
+++ b/engine/src/liquid/renderer/imgui/ImguiRenderer.cpp
@@ -245,13 +245,13 @@ void ImguiRenderer::loadFonts() {
 
   rhi::TextureDescription description;
   if (width > 0 || height > 0) {
+    description.usage = rhi::TextureUsage::Color |
+                        rhi::TextureUsage::TransferDestination |
+                        rhi::TextureUsage::Sampled;
     description.size = width * height * 4;
     description.width = width;
     description.height = height;
     description.format = VK_FORMAT_R8G8B8A8_SRGB;
-    description.usageFlags =
-        VK_IMAGE_USAGE_SAMPLED_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT;
-    description.aspectFlags = VK_IMAGE_ASPECT_COLOR_BIT;
     description.data = pixels;
 
     fontTexture = registry.setTexture(description);

--- a/engine/src/liquid/renderer/passes/FullscreenQuadPass.cpp
+++ b/engine/src/liquid/renderer/passes/FullscreenQuadPass.cpp
@@ -29,9 +29,7 @@ void FullscreenQuadPass::execute(rhi::RenderCommandList &commandList,
   commandList.bindPipeline(pipeline);
 
   rhi::Descriptor descriptor;
-  descriptor.bind(
-      0, std::vector<rhi::TextureHandle>{registry.getTexture(inputTexture)},
-      rhi::DescriptorType::CombinedImageSampler);
+  descriptor.bind(0, {inputTexture}, rhi::DescriptorType::CombinedImageSampler);
   commandList.bindDescriptor(pipeline, 0, descriptor);
 
   commandList.draw(3, 0);

--- a/engine/src/liquid/renderer/passes/FullscreenQuadPass.h
+++ b/engine/src/liquid/renderer/passes/FullscreenQuadPass.h
@@ -38,7 +38,7 @@ public:
 
 private:
   GraphResourceId pipelineId = 0;
-  GraphResourceId inputTexture = 0;
+  rhi::TextureHandle inputTexture = rhi::TextureHandle::Invalid;
   ShaderLibrary &shaderLibrary;
   String inputDep;
 };

--- a/engine/src/liquid/renderer/passes/ImguiPass.cpp
+++ b/engine/src/liquid/renderer/passes/ImguiPass.cpp
@@ -46,13 +46,10 @@ void ImguiPass::buildInternal(RenderGraphBuilder &builder) {
 void ImguiPass::execute(rhi::RenderCommandList &commandList,
                         RenderGraphRegistry &registry) {
   const auto &pipeline = registry.getPipeline(pipelineId);
-  auto sceneTexture = registry.hasTexture(sceneTextureId)
-                          ? registry.getTexture(sceneTextureId)
-                          : rhi::TextureHandle::Invalid;
 
   imguiRenderer.beginRendering();
 
-  imguiUpdateFn(sceneTexture);
+  imguiUpdateFn(sceneTextureId);
 
   debugLayer.render();
   imguiRenderer.endRendering();

--- a/engine/src/liquid/renderer/passes/ImguiPass.h
+++ b/engine/src/liquid/renderer/passes/ImguiPass.h
@@ -51,7 +51,7 @@ private:
   ImguiRenderer &imguiRenderer;
   GraphResourceId pipelineId = 0;
   ImguiDebugLayer debugLayer;
-  GraphResourceId sceneTextureId = 0;
+  rhi::TextureHandle sceneTextureId = rhi::TextureHandle::Invalid;
   std::function<void(rhi::TextureHandle)> imguiUpdateFn;
 };
 

--- a/engine/src/liquid/renderer/passes/ScenePass.cpp
+++ b/engine/src/liquid/renderer/passes/ScenePass.cpp
@@ -64,16 +64,12 @@ void ScenePass::execute(rhi::RenderCommandList &commandList,
   sceneDescriptorFragment
       .bind(0, cameraBuffer, rhi::DescriptorType::UniformBuffer)
       .bind(1, renderData->getSceneBuffer(), rhi::DescriptorType::UniformBuffer)
-      .bind(2,
-            std::vector<rhi::TextureHandle>{
-                registry.getTexture(shadowMapTextureId)},
-            rhi::DescriptorType::CombinedImageSampler);
+      .bind(2, {shadowMapTextureId}, rhi::DescriptorType::CombinedImageSampler);
 
   sceneDescriptorFragment
       .bind(3, {iblMaps.at(0), iblMaps.at(1)},
             rhi::DescriptorType::CombinedImageSampler)
-      .bind(4, std::vector<rhi::TextureHandle>{iblMaps.at(2)},
-            rhi::DescriptorType::CombinedImageSampler);
+      .bind(4, {iblMaps.at(2)}, rhi::DescriptorType::CombinedImageSampler);
 
   commandList.bindPipeline(pipeline);
   commandList.bindDescriptor(pipeline, 0, sceneDescriptor);

--- a/engine/src/liquid/renderer/passes/ScenePass.h
+++ b/engine/src/liquid/renderer/passes/ScenePass.h
@@ -50,7 +50,7 @@ private:
 
   GraphResourceId pipelineId = 0;
   GraphResourceId wireframePipelineId = 0;
-  GraphResourceId shadowMapTextureId = 0;
+  rhi::TextureHandle shadowMapTextureId = rhi::TextureHandle::Invalid;
 
   GraphResourceId skinnedPipelineId = 0;
 

--- a/engine/src/liquid/renderer/passes/ShadowPass.h
+++ b/engine/src/liquid/renderer/passes/ShadowPass.h
@@ -42,7 +42,7 @@ public:
 private:
   GraphResourceId pipelineId = 0;
   GraphResourceId skinnedPipelineId = 0;
-  GraphResourceId shadowMapId = 0;
+  rhi::TextureHandle shadowMapId = rhi::TextureHandle::Invalid;
 
   ShaderLibrary &shaderLibrary;
   SceneRenderer sceneRenderer;

--- a/engine/src/liquid/renderer/render-graph/RenderGraph.h
+++ b/engine/src/liquid/renderer/render-graph/RenderGraph.h
@@ -56,12 +56,14 @@ public:
   }
 
   /**
-   * @brief Create texture resource
+   * @brief Import texture
    *
-   * @param name Resource name
-   * @param data Texture data
+   * @param name Name of texture
+   * @param handle Texture handle
+   * @param clearValue Clear value
    */
-  GraphResourceId create(const String &name, const AttachmentData &data);
+  void import(const String &name, rhi::TextureHandle handle,
+              const std::variant<glm::vec4, DepthStencilClear> &clearValue);
 
   /**
    * @brief Compile graph
@@ -93,7 +95,7 @@ public:
    * @param name Resource name
    * @return Resource ID
    */
-  const GraphResourceId getResourceId(const String &name);
+  rhi::TextureHandle getResourceId(const String &name);
 
   /**
    * @brief Check if resource ID exists for name
@@ -103,18 +105,7 @@ public:
    * @retval false Resource ID does not exist
    */
   inline const bool hasResourceId(const String &name) const {
-    return resourceMap.find(name) != resourceMap.end();
-  }
-
-  /**
-   * @brief Check if resource ID has associated texture
-   *
-   * @param id Resource ID
-   * @retval true Texture exists for resource ID
-   * @retval false Texture does not exist for resource ID
-   */
-  inline const bool hasTexture(GraphResourceId id) const {
-    return textures.find(id) != textures.end();
+    return mResourceMap.find(name) != mResourceMap.end();
   }
 
   /**
@@ -122,9 +113,10 @@ public:
    *
    * @return Textures
    */
-  inline const std::unordered_map<GraphResourceId, AttachmentData> &
+  inline const std::unordered_map<rhi::TextureHandle,
+                                  std::variant<glm::vec4, DepthStencilClear>> &
   getTextures() const {
-    return textures;
+    return mTextures;
   }
 
   /**
@@ -141,7 +133,9 @@ public:
    * @retval true Resource is swapchain
    * @retval false Resource is not swapchain
    */
-  inline const bool isSwapchain(GraphResourceId id) const { return id == 0; }
+  inline const bool isSwapchain(rhi::TextureHandle id) const {
+    return id == rhi::TextureHandle(1);
+  }
 
   /**
    * @brief Check if resource is a pipeline
@@ -212,8 +206,13 @@ private:
 
 private:
   std::unordered_map<GraphResourceId, RenderGraphPipelineDescription> pipelines;
-  std::unordered_map<GraphResourceId, AttachmentData> textures;
-  std::unordered_map<String, GraphResourceId> resourceMap{{"SWAPCHAIN", 0}};
+  std::unordered_map<String, rhi::TextureHandle> mResourceMap{
+      {"SWAPCHAIN", rhi::TextureHandle(1)}};
+
+  std::unordered_map<rhi::TextureHandle,
+                     std::variant<glm::vec4, DepthStencilClear>>
+      mTextures;
+
   std::vector<RenderGraphPassBase *> passes;
 
   GraphResourceId lastId = 1;

--- a/engine/src/liquid/renderer/render-graph/RenderGraphAttachmentDescription.h
+++ b/engine/src/liquid/renderer/render-graph/RenderGraphAttachmentDescription.h
@@ -6,23 +6,9 @@ enum class AttachmentLoadOp { Load, Clear, DontCare };
 
 enum class AttachmentStoreOp { Store, DontCare };
 
-enum class AttachmentType { Color, Depth };
-
-enum class AttachmentSizeMethod { Fixed, SwapchainRelative };
-
 struct DepthStencilClear {
   float clearDepth = 0.0f;
   uint32_t clearStencil = 0;
-};
-
-struct AttachmentData {
-  AttachmentType type = AttachmentType::Color;
-  AttachmentSizeMethod sizeMethod = AttachmentSizeMethod::Fixed;
-  uint32_t width = 0;
-  uint32_t height = 0;
-  uint32_t layers = 0;
-  uint32_t format = 0;
-  std::variant<glm::vec4, DepthStencilClear> clearValue;
 };
 
 struct RenderPassAttachment {

--- a/engine/src/liquid/renderer/render-graph/RenderGraphBuilder.cpp
+++ b/engine/src/liquid/renderer/render-graph/RenderGraphBuilder.cpp
@@ -11,24 +11,19 @@ RenderGraphBuilder::RenderGraphBuilder(RenderGraph &graph_,
                                        RenderGraphPassBase *pass_)
     : graph(graph_), pass(pass_) {}
 
-GraphResourceId RenderGraphBuilder::write(const String &name) {
+rhi::TextureHandle RenderGraphBuilder::write(const String &name) {
   LIQUID_ASSERT(graph.hasResourceId(name),
                 "Resource named \"" + name + "\" does not exist");
-  GraphResourceId resourceId = graph.getResourceId(name);
+  auto resourceId = graph.getResourceId(name);
   pass->addOutput(resourceId, {});
 
-  if (graph.isSwapchain(resourceId) ||
-      graph.getTextures().at(resourceId).sizeMethod ==
-          AttachmentSizeMethod::SwapchainRelative) {
-    pass->setSwapchainRelative(true);
-  }
   return resourceId;
 }
 
-GraphResourceId RenderGraphBuilder::read(const String &name) {
+rhi::TextureHandle RenderGraphBuilder::read(const String &name) {
   LIQUID_ASSERT(graph.hasResourceId(name),
                 "Resource named \"" + name + "\" does not exist");
-  GraphResourceId resourceId = graph.getResourceId(name);
+  auto resourceId = graph.getResourceId(name);
   pass->addInput(resourceId);
   return resourceId;
 }

--- a/engine/src/liquid/renderer/render-graph/RenderGraphBuilder.h
+++ b/engine/src/liquid/renderer/render-graph/RenderGraphBuilder.h
@@ -27,7 +27,7 @@ public:
    * @param name Resource name
    * @return ID associated with resource
    */
-  GraphResourceId write(const String &name);
+  rhi::TextureHandle write(const String &name);
 
   /**
    * @brief Read attachment resource
@@ -38,7 +38,7 @@ public:
    * @param name Resource name
    * @return ID associated with resource
    */
-  GraphResourceId read(const String &name);
+  rhi::TextureHandle read(const String &name);
 
   /**
    * @brief Write pipeline resource

--- a/engine/src/liquid/renderer/render-graph/RenderGraphEvaluator.h
+++ b/engine/src/liquid/renderer/render-graph/RenderGraphEvaluator.h
@@ -29,18 +29,6 @@ public:
   RenderGraphEvaluator(rhi::ResourceRegistry &registry);
 
   /**
-   * @brief Compile render graph
-   *
-   * @param graph Render graph
-   * @param swapchainRecreated Compile swapchain related passes
-   * @param extent Swapchain extent
-   * @return Topologically sorted list of passes
-   */
-  std::vector<RenderGraphPassBase *> compile(RenderGraph &graph,
-                                             bool swapchainRecreated,
-                                             const glm::uvec2 &extent);
-
-  /**
    * @brief Build passes
    *
    * @param compiled Compiled passes
@@ -103,32 +91,33 @@ private:
    *
    * @param attachment Attachment description
    * @param texture Texture
+   * @param extent Swapchain extent
    * @return Attachment info
    */
   VulkanAttachmentInfo
   createColorAttachment(const RenderPassAttachment &attachment,
-                        rhi::TextureHandle texture);
+                        rhi::TextureHandle texture, const glm::uvec2 &extent);
 
   /**
    * @brief Create depth attachment
    *
    * @param attachment Attachment description
    * @param texture Texture
+   * @param extent Swapchain extent
    * @return Attachment info
    */
   VulkanAttachmentInfo
   createDepthAttachment(const RenderPassAttachment &attachment,
-                        rhi::TextureHandle texture);
+                        rhi::TextureHandle texture, const glm::uvec2 &extent);
 
   /**
-   * @brief Create texture
+   * @brief Check if pass is has swapchain relative resources
    *
-   * @param data Attachment data
-   * @param extent Swapchain extent
-   * @return Texture
+   * @param pass Render pass
+   * @retval true Has swapchain resources
+   * @retval false Does not have swapchain relative resources
    */
-  rhi::TextureHandle createTexture(const AttachmentData &data,
-                                   const glm::uvec2 &extent);
+  bool hasSwapchainRelativeResources(RenderGraphPassBase *pass);
 
 private:
   rhi::ResourceRegistry &mRegistry;

--- a/engine/src/liquid/renderer/render-graph/RenderGraphPassBase.cpp
+++ b/engine/src/liquid/renderer/render-graph/RenderGraphPassBase.cpp
@@ -13,21 +13,17 @@ void RenderGraphPassBase::build(RenderGraphBuilder &&builder) {
   }
 }
 
-void RenderGraphPassBase::addInput(GraphResourceId resourceId) {
+void RenderGraphPassBase::addInput(rhi::TextureHandle resourceId) {
   inputs.push_back(resourceId);
 }
 
-void RenderGraphPassBase::addOutput(GraphResourceId resourceId,
+void RenderGraphPassBase::addOutput(rhi::TextureHandle resourceId,
                                     const RenderPassAttachment &attachment) {
   outputs.insert({resourceId, attachment});
 }
 
 void RenderGraphPassBase::addResource(GraphResourceId resourceId) {
   resources.push_back(resourceId);
-}
-
-void RenderGraphPassBase::setSwapchainRelative(bool swapchainRelative_) {
-  swapchainRelative = swapchainRelative_;
 }
 
 } // namespace liquid

--- a/engine/src/liquid/renderer/render-graph/RenderGraphPassBase.h
+++ b/engine/src/liquid/renderer/render-graph/RenderGraphPassBase.h
@@ -69,7 +69,7 @@ public:
    *
    * @param resourceId Input resource ID
    */
-  void addInput(GraphResourceId resourceId);
+  void addInput(rhi::TextureHandle resourceId);
 
   /**
    * @brief Add output resource
@@ -77,7 +77,7 @@ public:
    * @param resourceId Output resource ID
    * @param attachment Attachment
    */
-  void addOutput(GraphResourceId resourceId,
+  void addOutput(rhi::TextureHandle resourceId,
                  const RenderPassAttachment &attachment);
 
   /**
@@ -87,19 +87,12 @@ public:
    */
   void addResource(GraphResourceId resourceId);
 
-  /*
-   * @brief Set swapchain relative
-   *
-   * @param swapchainRelative Swapchain relative flag
-   */
-  void setSwapchainRelative(bool swapchainRelative);
-
   /**
    * @brief Get all input resources
    *
    * @return Input resources
    */
-  inline const std::vector<GraphResourceId> &getInputs() const {
+  inline const std::vector<rhi::TextureHandle> &getInputs() const {
     return inputs;
   }
 
@@ -108,7 +101,7 @@ public:
    *
    * @return Output resources
    */
-  inline std::unordered_map<GraphResourceId, RenderPassAttachment> &
+  inline std::unordered_map<rhi::TextureHandle, RenderPassAttachment> &
   getOutputs() {
     return outputs;
   }
@@ -130,14 +123,6 @@ public:
   inline GraphResourceId getRenderPass() const { return renderPass; }
 
   /**
-   * @brief Is swapchain relative
-   *
-   * @retval true Pass is swapchain relative
-   * @retval false Pass is not swapchain relative
-   */
-  inline bool isSwapchainRelative() const { return swapchainRelative; }
-
-  /**
    * @brief Check if pass is dirty and has to be rebuild
    *
    * @retval true Pass is dirty
@@ -146,11 +131,9 @@ public:
   inline bool isDirty() const { return dirty; }
 
 private:
-  std::vector<GraphResourceId> inputs;
+  std::vector<rhi::TextureHandle> inputs;
   std::vector<GraphResourceId> resources;
-  std::unordered_map<GraphResourceId, RenderPassAttachment> outputs;
-
-  bool swapchainRelative = false;
+  std::unordered_map<rhi::TextureHandle, RenderPassAttachment> outputs;
 
   GraphResourceId renderPass;
   String name;

--- a/engine/src/liquid/renderer/render-graph/RenderGraphRegistry.cpp
+++ b/engine/src/liquid/renderer/render-graph/RenderGraphRegistry.cpp
@@ -3,15 +3,6 @@
 
 namespace liquid {
 
-void RenderGraphRegistry::addTexture(GraphResourceId resourceId,
-                                     rhi::TextureHandle texture) {
-  if (textures.find(resourceId) != textures.end()) {
-    textures.at(resourceId) = texture;
-  } else {
-    textures.insert({resourceId, texture});
-  }
-}
-
 void RenderGraphRegistry::addPipeline(GraphResourceId resourceId,
                                       rhi::PipelineHandle pipeline) {
   if (pipelines.find(resourceId) != pipelines.end()) {

--- a/engine/src/liquid/renderer/render-graph/RenderGraphRegistry.h
+++ b/engine/src/liquid/renderer/render-graph/RenderGraphRegistry.h
@@ -10,14 +10,6 @@ namespace liquid {
 class RenderGraphRegistry {
 public:
   /**
-   * @brief Add texture resource
-   *
-   * @param resourceId Resource ID
-   * @param texture Texture
-   */
-  void addTexture(GraphResourceId resourceId, rhi::TextureHandle texture);
-
-  /**
    * @brief Add pipeline resource
    *
    * @param resourceId Resource ID
@@ -33,27 +25,6 @@ public:
    */
   void addRenderPass(GraphResourceId resourceId,
                      RenderGraphPassResult &&renderPass);
-
-  /**
-   * @brief Get texture
-   *
-   * @param resourceId Resource ID
-   * @return Texture
-   */
-  inline rhi::TextureHandle &getTexture(GraphResourceId resourceId) {
-    return textures.at(resourceId);
-  }
-
-  /**
-   * @brief Check if texture resource exists
-   *
-   * @param resourceId Resource ID
-   * @retval true Resource exists
-   * @retval false Resource does not exist
-   */
-  inline bool hasTexture(GraphResourceId resourceId) const {
-    return textures.find(resourceId) != textures.end();
-  }
 
   /**
    * @brief Get pipeline
@@ -98,7 +69,6 @@ public:
   }
 
 private:
-  std::unordered_map<GraphResourceId, rhi::TextureHandle> textures;
   std::unordered_map<GraphResourceId, RenderGraphPassResult> renderPasses;
   std::unordered_map<GraphResourceId, rhi::PipelineHandle> pipelines;
 };

--- a/engine/src/liquid/rhi/TextureDescription.h
+++ b/engine/src/liquid/rhi/TextureDescription.h
@@ -4,16 +4,33 @@ namespace liquid::rhi {
 
 enum class TextureType { Standard, Cubemap };
 
+enum class TextureSizeMethod { Fixed, SwapchainRatio };
+
+enum class TextureUsage : uint8_t {
+  None = 0,
+  Color = 1 << 0,
+  Depth = 1 << 1,
+  Sampled = 1 << 2,
+  TransferDestination = 1 << 3
+};
+
+constexpr TextureUsage operator|(TextureUsage a, TextureUsage b) {
+  return TextureUsage(static_cast<uint8_t>(a) | static_cast<uint8_t>(b));
+}
+
+constexpr TextureUsage operator&(TextureUsage a, TextureUsage b) {
+  return TextureUsage(static_cast<uint8_t>(a) & static_cast<uint8_t>(b));
+}
+
 struct TextureDescription {
   TextureType type = TextureType::Standard;
+  TextureSizeMethod sizeMethod = TextureSizeMethod::Fixed;
+  TextureUsage usage = TextureUsage::None;
   uint32_t format = 0;
   uint32_t width = 0;
   uint32_t height = 0;
   uint32_t depth = 1;
   uint32_t layers = 1;
-  uint32_t usageFlags = 0;
-  uint32_t aspectFlags = 0;
-
   size_t size = 0;
   void *data = nullptr;
 };

--- a/engine/src/liquid/rhi/vulkan/VulkanResourceRegistry.cpp
+++ b/engine/src/liquid/rhi/vulkan/VulkanResourceRegistry.cpp
@@ -29,11 +29,26 @@ void VulkanResourceRegistry::deleteBuffer(BufferHandle handle) {
 
 void VulkanResourceRegistry::setTexture(
     TextureHandle handle, std::unique_ptr<VulkanTexture> &&texture) {
+  if (texture->isSwapchainRelative()) {
+    mSwapchainRelativeTextures.insert(handle);
+  }
+
   mTextures.insert_or_assign(handle, std::move(texture));
 }
 
 void VulkanResourceRegistry::deleteTexture(TextureHandle handle) {
   mTextures.erase(handle);
+}
+
+void VulkanResourceRegistry::deleteDanglingSwapchainRelativeTextures() {
+  for (auto it = mSwapchainRelativeTextures.begin();
+       it != mSwapchainRelativeTextures.end(); ++it) {
+    auto textureIt = mTextures.find(*it);
+    if (textureIt == mTextures.end() ||
+        !textureIt->second->isSwapchainRelative()) {
+      it = mSwapchainRelativeTextures.erase(it);
+    }
+  }
 }
 
 void VulkanResourceRegistry::setRenderPass(

--- a/engine/src/liquid/rhi/vulkan/VulkanResourceRegistry.h
+++ b/engine/src/liquid/rhi/vulkan/VulkanResourceRegistry.h
@@ -98,6 +98,24 @@ public:
   void deleteTexture(TextureHandle handle);
 
   /**
+   * @brief Delete dangling swapchain relative textures
+   *
+   * If a texture does not exist or is not swapchain
+   * relative, remove it from the swapchain relative
+   * textures list
+   */
+  void deleteDanglingSwapchainRelativeTextures();
+
+  /**
+   * @brief Get swapchain relative textures
+   *
+   * @return Swapchain relative textures
+   */
+  inline const std::set<TextureHandle> &getSwapchainRelativeTextures() const {
+    return mSwapchainRelativeTextures;
+  }
+
+  /**
    * @brief Get textures
    *
    * @return List of textures
@@ -180,6 +198,8 @@ private:
   RenderPassMap mRenderPasses;
   FramebufferMap mFramebuffers;
   PipelineMap mPipelines;
+
+  std::set<TextureHandle> mSwapchainRelativeTextures;
 };
 
 } // namespace liquid::rhi

--- a/engine/src/liquid/rhi/vulkan/VulkanTexture.h
+++ b/engine/src/liquid/rhi/vulkan/VulkanTexture.h
@@ -34,10 +34,12 @@ public:
    * @param allocator Vma allocator
    * @param device Vulkan device
    * @param uploadContext Upload context
+   * @param swapchainExtent Swapchain extent
    */
   VulkanTexture(const TextureDescription &description,
                 VulkanResourceAllocator &allocator, VulkanDeviceObject &device,
-                VulkanUploadContext &uploadContext);
+                VulkanUploadContext &uploadContext,
+                const glm::uvec2 &swapchainExtent);
 
   /**
    * @brief Destroy texture
@@ -82,6 +84,25 @@ public:
    */
   inline VkFormat getFormat() const { return mFormat; }
 
+  /**
+   * @brief Check if texture resizes with swapchain
+   *
+   * @retval true Texture resizes with swapchain
+   * @retval false Texture does not resize with swapchain
+   */
+  inline bool isSwapchainRelative() const {
+    return mDescription.sizeMethod == TextureSizeMethod::SwapchainRatio;
+  }
+
+  /**
+   * @brief Get description
+   *
+   * @return Description
+   */
+  inline const TextureDescription &getDescription() const {
+    return mDescription;
+  }
+
 private:
   VkFormat mFormat = VK_FORMAT_MAX_ENUM;
   VkImage mImage = VK_NULL_HANDLE;
@@ -90,6 +111,7 @@ private:
   VmaAllocation mAllocation = VK_NULL_HANDLE;
   VulkanResourceAllocator &mAllocator;
   VulkanDeviceObject &mDevice;
+  TextureDescription mDescription;
 };
 
 } // namespace liquid::rhi

--- a/engine/tests/renderer/RenderGraph.test.cpp
+++ b/engine/tests/renderer/RenderGraph.test.cpp
@@ -33,17 +33,17 @@ TEST_F(RenderGraphTest, TopologicallySortRenderGraph) {
   // |   +---+   +---+               |
   // +-------------------------------+
 
-  graph.create("a-b", {});
-  graph.create("a-d", {});
-  graph.create("d-b", {});
-  graph.create("b-c", {});
-  graph.create("b-g", {});
-  graph.create("h-c", {});
-  graph.create("c-e", {});
-  graph.create("d-e", {});
-  graph.create("d-g", {});
-  graph.create("e-f", {});
-  graph.create("f-g", {});
+  graph.import("a-b", liquid::rhi::TextureHandle{2}, {});
+  graph.import("a-d", liquid::rhi::TextureHandle{3}, {});
+  graph.import("d-b", liquid::rhi::TextureHandle{4}, {});
+  graph.import("b-c", liquid::rhi::TextureHandle{5}, {});
+  graph.import("b-g", liquid::rhi::TextureHandle{6}, {});
+  graph.import("h-c", liquid::rhi::TextureHandle{7}, {});
+  graph.import("c-e", liquid::rhi::TextureHandle{8}, {});
+  graph.import("d-e", liquid::rhi::TextureHandle{9}, {});
+  graph.import("d-g", liquid::rhi::TextureHandle{10}, {});
+  graph.import("e-f", liquid::rhi::TextureHandle{11}, {});
+  graph.import("f-g", liquid::rhi::TextureHandle{12}, {});
 
   // A
   graph.addInlinePass<EmptyScope>(
@@ -143,7 +143,9 @@ TEST_F(RenderGraphTest, TopologicallySortRenderGraph) {
 }
 
 TEST_F(RenderGraphTest, SetsPassLoadOperations) {
-  auto resourceId = graph.create("a-b", {});
+  liquid::rhi::TextureHandle resourceId{2};
+  graph.import("a-b", resourceId, {});
+
   graph.addInlinePass<EmptyScope>(
       "A", [](auto &builder, auto &scope) { builder.write("a-b"); },
       noopExecutor);
@@ -168,10 +170,10 @@ TEST_F(RenderGraphTest, SetPassClearValues) {
   constexpr liquid::DepthStencilClear DEPTH_CLEAR{1.0f, 5};
 
   graph.setSwapchainColor(SWAPCHAIN_CLEAR);
-  liquid::AttachmentData data;
-  data.clearValue = DEPTH_CLEAR;
 
-  auto depthId = graph.create("depthBuffer", data);
+  liquid::rhi::TextureHandle depthId{2};
+
+  graph.import("depthBuffer", depthId, DEPTH_CLEAR);
   auto swapchainId = graph.getResourceId("SWAPCHAIN");
   graph.addInlinePass<EmptyScope>(
       "a-b",
@@ -203,7 +205,8 @@ TEST_F(RenderGraphTest, SetPassClearValues) {
 }
 
 TEST_F(RenderGraphTest, CompilationRemovesLonelyNodes) {
-  graph.create("a-b", {});
+  liquid::rhi::TextureHandle handle{2};
+  graph.import("a-b", handle, {});
 
   graph.addInlinePass<EmptyScope>(
       "A", [](auto &builder, auto &scope) { builder.write("a-b"); },
@@ -225,7 +228,8 @@ TEST_F(RenderGraphTest, CompilationRemovesLonelyNodes) {
 TEST_F(RenderGraphDeathTest, BuildOnlyCalledOnce) {
   std::set_terminate([]() { FAIL(); });
 
-  graph.create("a-b", {});
+  liquid::rhi::TextureHandle handle{2};
+  graph.import("a-b", handle, {});
 
   graph.addInlinePass<EmptyScope>(
       "A", [](auto &builder, auto &scope) { builder.write("a-b"); },
@@ -241,7 +245,8 @@ TEST_F(RenderGraphDeathTest, BuildOnlyCalledOnce) {
 }
 
 TEST_F(RenderGraphDeathTest, CompilationFailsIfMultipleNodesHaveTheSameName) {
-  graph.create("a-b", {});
+  liquid::rhi::TextureHandle handle{2};
+  graph.import("a-b", handle, {});
 
   graph.addInlinePass<EmptyScope>(
       "A", [](auto &builder, auto &scope) { builder.write("a-b"); },

--- a/engine/tests/renderer/RenderGraphRegistry.test.cpp
+++ b/engine/tests/renderer/RenderGraphRegistry.test.cpp
@@ -8,21 +8,6 @@ public:
   liquid::RenderGraphRegistry registry;
 };
 
-TEST_F(RenderGraphRegistryTest, AddsTextureToRegistry) {
-  registry.addTexture(1, liquid::rhi::TextureHandle(2));
-
-  EXPECT_TRUE(registry.hasTexture(1));
-  EXPECT_EQ(registry.getTexture(1), liquid::rhi::TextureHandle(2));
-}
-
-TEST_F(RenderGraphRegistryTest, UpdatesExistingTextureInRegistry) {
-  registry.addTexture(1, liquid::rhi::TextureHandle(2));
-  registry.addTexture(1, liquid::rhi::TextureHandle(3));
-
-  EXPECT_TRUE(registry.hasTexture(1));
-  EXPECT_EQ(registry.getTexture(1), liquid::rhi::TextureHandle(3));
-}
-
 TEST_F(RenderGraphRegistryTest, AddsRenderPassToRegistry) {
   registry.addRenderPass(
       1, liquid::RenderGraphPassResult(liquid::rhi::RenderPassHandle(2), {}, {},


### PR DESCRIPTION
- Allow any texture to be swapchain relative
- Import existing textures to render graph
- Recreate swapchain relative textures automatically