### PR TITLE
Split imgui CPU logic from GPU command buffers

### DIFF
--- a/demos/pong-3d/src/main.cpp
+++ b/demos/pong-3d/src/main.cpp
@@ -56,7 +56,7 @@ public:
   }
 
   int run() {
-    liquid::MainLoop mainLoop(renderer, window);
+    liquid::MainLoop mainLoop(window, renderer.getStatsManager());
 
     liquid::RenderGraph graph;
 
@@ -113,18 +113,21 @@ public:
           sceneRenderer.render(commandList, pipeline);
         });
 
-    graph.addPass<liquid::ImguiPass>(
-        "imguiPass", renderer.getImguiRenderer(), renderer.getShaderLibrary(),
-        renderer.getRenderDevice()->getPhysicalDevice().getDeviceInfo(),
-        renderer.getStatsManager(), renderer.getDebugManager(), "SWAPCHAIN",
-        [](const auto &sceneTexture) {});
+    graph.addPass<liquid::ImguiPass>("imguiPass", renderer.getImguiRenderer(),
+                                     renderer.getShaderLibrary(), "SWAPCHAIN");
 
-    return mainLoop.run(graph, [=](double dt) mutable {
+    mainLoop.setUpdateFn([=](float dt) mutable {
       updateGameLogic(0.15f);
       updateScene(0.15f);
 
       return true;
     });
+
+    mainLoop.setRenderFn([this, &graph]() { renderer.render(graph); });
+
+    mainLoop.run();
+    renderer.wait();
+    return 0;
   }
 
 private:

--- a/engine/src/liquid/loop/MainLoop.h
+++ b/engine/src/liquid/loop/MainLoop.h
@@ -4,17 +4,42 @@
 
 namespace liquid {
 
-class Renderer;
 class Window;
+class StatsManager;
 
 class MainLoop {
 public:
-  MainLoop(Renderer &renderer, Window &window);
+  /**
+   * @brief Create main loop
+   *
+   * @param window Window
+   * @param statsManager Stats manager
+   */
+  MainLoop(Window &window, StatsManager &statsManager);
 
-  int run(RenderGraph &graph, const std::function<bool(float)> &update);
+  /**
+   * @brief Run main loop
+   */
+  void run();
+
+  /**
+   * @brief Set update function
+   *
+   * @param updateFn Update function
+   */
+  void setUpdateFn(const std::function<bool(float)> &updateFn);
+
+  /**
+   * @brief Set render function
+   *
+   * @param renderFn Render function
+   */
+  void setRenderFn(const std::function<void()> &renderFn);
 
 private:
-  Renderer &mRenderer;
   Window &mWindow;
+  StatsManager &mStatsManager;
+  std::function<bool(float)> mUpdateFn;
+  std::function<void()> mRenderFn;
 };
 } // namespace liquid

--- a/engine/src/liquid/renderer/Renderer.cpp
+++ b/engine/src/liquid/renderer/Renderer.cpp
@@ -83,9 +83,8 @@ void Renderer::loadShaders() {
           {Engine::getAssetsPath() + "/shaders/fullscreenQuad.frag.spv"}));
 }
 
-RenderGraph Renderer::createRenderGraph(
-    const SharedPtr<RenderData> &renderData, const String &imguiDep,
-    const std::function<void(rhi::TextureHandle)> &imUpdate) {
+RenderGraph Renderer::createRenderGraph(const SharedPtr<RenderData> &renderData,
+                                        const String &imguiDep) {
   RenderGraph graph;
   constexpr uint32_t NUM_LIGHTS = 16;
   constexpr uint32_t SHADOWMAP_DIMENSIONS = 2048;
@@ -131,9 +130,7 @@ RenderGraph Renderer::createRenderGraph(
                            renderData, mDebugManager);
   graph.addPass<EnvironmentPass>("environmentPass", mEntityContext,
                                  mShaderLibrary, renderData);
-  graph.addPass<ImguiPass>("imgui", mImguiRenderer, mShaderLibrary,
-                           mDevice->getPhysicalDevice().getDeviceInfo(),
-                           mStatsManager, mDebugManager, imguiDep, imUpdate);
+  graph.addPass<ImguiPass>("imgui", mImguiRenderer, mShaderLibrary, imguiDep);
 
   return graph;
 }

--- a/engine/src/liquid/renderer/Renderer.h
+++ b/engine/src/liquid/renderer/Renderer.h
@@ -49,10 +49,8 @@ public:
   inline rhi::VulkanRenderDevice *getRenderDevice() { return mDevice; }
   inline ImguiRenderer &getImguiRenderer() { return mImguiRenderer; }
 
-  RenderGraph
-  createRenderGraph(const SharedPtr<RenderData> &renderData,
-                    const String &imguiDep,
-                    const std::function<void(rhi::TextureHandle)> &imUpdate);
+  RenderGraph createRenderGraph(const SharedPtr<RenderData> &renderData,
+                                const String &imguiDep);
 
   void render(RenderGraph &graph);
 

--- a/engine/src/liquid/renderer/imgui/ImguiRenderer.h
+++ b/engine/src/liquid/renderer/imgui/ImguiRenderer.h
@@ -18,12 +18,20 @@ class ImguiRenderer {
     rhi::BufferHandle indexBuffer = rhi::BufferHandle::Invalid;
     void *indexBufferData = nullptr;
     size_t indexBufferSize = 0;
-
-    bool firstTime = true;
   };
 
 public:
+  /**
+   * @brief Create imgui renderer
+   *
+   * @param window Window
+   * @param registry Resource registry
+   */
   ImguiRenderer(Window &window, rhi::ResourceRegistry &registry);
+
+  /**
+   * @brief Destroy imgui renderer
+   */
   ~ImguiRenderer();
 
   ImguiRenderer(const ImguiRenderer &rhs) = delete;
@@ -31,23 +39,48 @@ public:
   ImguiRenderer &operator=(const ImguiRenderer &rhs) = delete;
   ImguiRenderer &operator=(ImguiRenderer &&rhs) = delete;
 
-  static void beginRendering();
-  static void endRendering();
+  /**
+   * @brief Begin imgui rendering
+   */
+  void beginRendering();
 
+  /**
+   * @brief End imgui rendering
+   *
+   * Prepares all the buffers for drawing
+   */
+  void endRendering();
+
+  /**
+   * @brief Send imgui data to command list
+   *
+   * @param commandList Command list
+   * @param pipeline Pipeline
+   */
   void draw(rhi::RenderCommandList &commandList, rhi::PipelineHandle pipeline);
 
 private:
+  /**
+   * @brief Load fonts
+   */
   void loadFonts();
 
-  void setupRenderStates(ImDrawData *draw_data,
-                         rhi::RenderCommandList &commandList, int fbWidth,
-                         int fbHeight, rhi::PipelineHandle pipeline);
+  /**
+   * @brief Setup remder states
+   *
+   * @param data Imgui data
+   * @param commandList Command list
+   * @param fbWidth Framebuffer width
+   * @param fbHeight Framebuffer height
+   * @param pipeline Pipeline
+   */
+  void setupRenderStates(ImDrawData *data, rhi::RenderCommandList &commandList,
+                         int fbWidth, int fbHeight,
+                         rhi::PipelineHandle pipeline);
 
 private:
   rhi::ResourceRegistry &mRegistry;
-
   rhi::TextureHandle mFontTexture = rhi::TextureHandle::Invalid;
-
   std::vector<FrameData> mFrameData;
   uint32_t mCurrentFrame = 0;
 };

--- a/engine/src/liquid/renderer/passes/ImguiPass.cpp
+++ b/engine/src/liquid/renderer/passes/ImguiPass.cpp
@@ -6,17 +6,12 @@ namespace liquid {
 
 ImguiPass::ImguiPass(const String &name, GraphResourceId renderPassId,
                      ImguiRenderer &imguiRenderer, ShaderLibrary &shaderLibrary,
-                     const PhysicalDeviceInformation &deviceInfo,
-                     StatsManager &statsManager, DebugManager &debugManager,
-                     const String &previousColor,
-                     const std::function<void(rhi::TextureHandle)> &imUpdate)
+                     const String &previousColor)
     : RenderGraphPassBase(name, renderPassId), mImguiRenderer(imguiRenderer),
-      mShaderLibrary(shaderLibrary),
-      mDebugLayer(deviceInfo, statsManager, debugManager),
-      mPreviousColor(previousColor), mImguiUpdateFn(imUpdate) {}
+      mShaderLibrary(shaderLibrary), mPreviousColor(previousColor) {}
 
 void ImguiPass::buildInternal(RenderGraphBuilder &builder) {
-  mSceneTextureId = builder.read(mPreviousColor);
+  builder.read(mPreviousColor);
   builder.write("SWAPCHAIN");
 
   mPipelineId = builder.create(RenderGraphPipelineDescription{
@@ -44,16 +39,7 @@ void ImguiPass::buildInternal(RenderGraphBuilder &builder) {
 
 void ImguiPass::execute(rhi::RenderCommandList &commandList,
                         RenderGraphRegistry &registry) {
-  const auto &pipeline = registry.getPipeline(mPipelineId);
-
-  mImguiRenderer.beginRendering();
-
-  mImguiUpdateFn(mSceneTextureId);
-
-  mDebugLayer.render();
-  mImguiRenderer.endRendering();
-
-  mImguiRenderer.draw(commandList, pipeline);
+  mImguiRenderer.draw(commandList, registry.getPipeline(mPipelineId));
 }
 
 } // namespace liquid

--- a/engine/src/liquid/renderer/passes/ImguiPass.h
+++ b/engine/src/liquid/renderer/passes/ImguiPass.h
@@ -19,16 +19,11 @@ public:
    * @param renderPassId Pass resource ID
    * @param imguiRenderer Imgui renderer
    * @param shaderLibrary Shader library
-   * @param debugManager Debug manager
    * @param previousColor Previous color attachment name
-   * @param imUpdate Imgui update
    */
   ImguiPass(const String &name, GraphResourceId renderPassId,
             ImguiRenderer &imguiRenderer, ShaderLibrary &shaderLibrary,
-            const PhysicalDeviceInformation &deviceInfo,
-            StatsManager &statsManager, DebugManager &debugManager,
-            const String &previousColor,
-            const std::function<void(rhi::TextureHandle)> &imUpdate);
+            const String &previousColor);
   /**
    * @brief Build pass
    *
@@ -50,9 +45,6 @@ private:
   String mPreviousColor;
   ImguiRenderer &mImguiRenderer;
   GraphResourceId mPipelineId = 0;
-  ImguiDebugLayer mDebugLayer;
-  rhi::TextureHandle mSceneTextureId = rhi::TextureHandle::Invalid;
-  std::function<void(rhi::TextureHandle)> mImguiUpdateFn;
 };
 
 } // namespace liquid


### PR DESCRIPTION
- Remove renderer from main loop
- Pass updater and renderer as lambda functions
- Render imgui logic from main loop directly
- Only send command buffer data to render device from imgui pass
- Render debug layer explicitly
- Remove debug layer from imgui pass
- Increase number of frames in flight to three in imgui renderer