### PR TITLE
Preload assets on start

### DIFF
--- a/engine/src/liquid/asset/AssetManager.cpp
+++ b/engine/src/liquid/asset/AssetManager.cpp
@@ -39,4 +39,51 @@ Result<bool> AssetManager::checkAssetFile(InputBinaryStream &file,
   return Result<bool>::Ok(true);
 }
 
+void AssetManager::preloadAssets() {
+  LIQUID_PROFILE_EVENT("AssetManager::preloadAssets");
+  for (const auto &entry :
+       std::filesystem::recursive_directory_iterator(mAssetsPath)) {
+    if (!entry.is_regular_file()) {
+      continue;
+    }
+
+    if (mRegistry.getAssetType(entry.path()) != AssetType::None) {
+      continue;
+    }
+
+    const auto &ext = entry.path().extension().string();
+
+    if (ext == ".ktx2") {
+      loadTextureFromFile(entry.path());
+      continue;
+    }
+
+    InputBinaryStream stream(entry.path());
+    AssetFileHeader header;
+    String magic(ASSET_FILE_MAGIC_LENGTH, '$');
+    stream.read(magic.data(), ASSET_FILE_MAGIC_LENGTH);
+
+    if (magic != header.magic) {
+      continue;
+    }
+
+    stream.read(header.version);
+    stream.read(header.type);
+
+    if (header.type == AssetType::Material) {
+      loadMaterialDataFromInputStream(stream, entry.path());
+    } else if (header.type == AssetType::Mesh) {
+      loadMeshDataFromInputStream(stream, entry.path());
+    } else if (header.type == AssetType::SkinnedMesh) {
+      loadSkinnedMeshDataFromInputStream(stream, entry.path());
+    } else if (header.type == AssetType::Skeleton) {
+      loadSkeletonDataFromInputStream(stream, entry.path());
+    } else if (header.type == AssetType::Animation) {
+      loadAnimationDataFromInputStream(stream, entry.path());
+    } else if (header.type == AssetType::Prefab) {
+      loadPrefabDataFromInputStream(stream, entry.path());
+    }
+  }
+}
+
 } // namespace liquid

--- a/engine/src/liquid/asset/AssetManager.h
+++ b/engine/src/liquid/asset/AssetManager.h
@@ -170,6 +170,20 @@ public:
    */
   inline AssetRegistry &getRegistry() { return mRegistry; }
 
+  /**
+   * @brief Get assets path
+   *
+   * @return Assets path
+   */
+  inline const std::filesystem::path &getAssetsPath() const {
+    return mAssetsPath;
+  }
+
+  /**
+   * @brief Preload all assets in assets directory
+   */
+  void preloadAssets();
+
 private:
   /**
    * @brief Get relative path of the asset
@@ -205,6 +219,73 @@ private:
                               const std::filesystem::path &filePath,
                               AssetType assetType);
 
+private:
+  /**
+   * @brief Load material from input stream
+   *
+   * @param stream Input stream
+   * @param filePath Path to asset
+   * @return Material asset handle
+   */
+  Result<MaterialAssetHandle>
+  loadMaterialDataFromInputStream(InputBinaryStream &stream,
+                                  const std::filesystem::path &filePath);
+
+  /**
+   * @brief Load mesh from input stream
+   *
+   * @param stream Input stream
+   * @param filePath Path to asset
+   * @return Mesh asset handle
+   */
+  Result<MeshAssetHandle>
+  loadMeshDataFromInputStream(InputBinaryStream &stream,
+                              const std::filesystem::path &filePath);
+
+  /**
+   * @brief Load skinned mesh from input stream
+   *
+   * @param stream Input stream
+   * @param filePath Path to asset
+   * @return Skinned mesh asset handle
+   */
+  Result<SkinnedMeshAssetHandle>
+  loadSkinnedMeshDataFromInputStream(InputBinaryStream &stream,
+                                     const std::filesystem::path &filePath);
+
+  /**
+   * @brief Load skeleton from input stream
+   *
+   * @param stream Input stream
+   * @param filePath Path to asset
+   * @return Skeleton asset handle
+   */
+  Result<SkeletonAssetHandle>
+  loadSkeletonDataFromInputStream(InputBinaryStream &stream,
+                                  const std::filesystem::path &filePath);
+  /**
+   * @brief Load animation from input stream
+   *
+   * @param stream Input stream
+   * @param filePath Path to asset
+   * @return Animation asset handle
+   */
+  Result<AnimationAssetHandle>
+  loadAnimationDataFromInputStream(InputBinaryStream &stream,
+                                   const std::filesystem::path &filePath);
+
+  /**
+   * @brief Load prefab from input stream
+   *
+   * @param stream Input stream
+   * @param filePath Path to asset
+   * @return Prefab asset handle
+   */
+  Result<PrefabAssetHandle>
+  loadPrefabDataFromInputStream(InputBinaryStream &stream,
+                                const std::filesystem::path &filePath);
+
+private:
   /**
    * @brief Get or load texture from path
    *

--- a/engine/src/liquid/asset/AssetManagerPrefab.cpp
+++ b/engine/src/liquid/asset/AssetManagerPrefab.cpp
@@ -12,7 +12,8 @@ namespace liquid {
 Result<std::filesystem::path>
 AssetManager::createPrefabFromAsset(const AssetData<PrefabAsset> &asset) {
   String extension = ".lqprefab";
-  std::filesystem::path assetPath = (mAssetsPath / (asset.name + extension));
+  std::filesystem::path assetPath =
+      (mAssetsPath / (asset.name + extension)).make_preferred();
   OutputBinaryStream file(assetPath);
 
   if (!file.good()) {
@@ -31,32 +32,55 @@ AssetManager::createPrefabFromAsset(const AssetData<PrefabAsset> &asset) {
   uint32_t numMeshes = static_cast<uint32_t>(asset.data.meshes.size());
   file.write(numMeshes);
 
+  std::map<MeshAssetHandle, uint32_t> localMeshMap;
+  uint32_t lastMeshId = 0;
+
   for (auto &component : asset.data.meshes) {
     auto &mesh = mRegistry.getMeshes().getAsset(component.value);
     auto path = std::filesystem::relative(mesh.path, mAssetsPath).string();
     std::replace(path.begin(), path.end(), '\\', '/');
     file.write(path);
+
+    if (localMeshMap.find(component.value) == localMeshMap.end()) {
+      localMeshMap.insert_or_assign(component.value, lastMeshId++);
+    }
   }
 
   uint32_t numSkinnedMeshes =
       static_cast<uint32_t>(asset.data.skinnedMeshes.size());
   file.write(numSkinnedMeshes);
 
+  std::map<SkinnedMeshAssetHandle, uint32_t> localSkinnedMeshMap;
+  uint32_t lastSkinnedMeshId = 0;
+
   for (auto &component : asset.data.skinnedMeshes) {
     auto &mesh = mRegistry.getSkinnedMeshes().getAsset(component.value);
     auto path = std::filesystem::relative(mesh.path, mAssetsPath).string();
     std::replace(path.begin(), path.end(), '\\', '/');
     file.write(path);
+
+    if (localSkinnedMeshMap.find(component.value) ==
+        localSkinnedMeshMap.end()) {
+      localSkinnedMeshMap.insert_or_assign(component.value,
+                                           lastSkinnedMeshId++);
+    }
   }
 
   uint32_t numSkeletons = static_cast<uint32_t>(asset.data.skeletons.size());
   file.write(numSkeletons);
+
+  std::map<SkeletonAssetHandle, uint32_t> localSkeletonMap;
+  uint32_t lastSkeletonId = 0;
 
   for (auto &component : asset.data.skeletons) {
     auto &skeleton = mRegistry.getSkeletons().getAsset(component.value);
     auto path = std::filesystem::relative(skeleton.path, mAssetsPath).string();
     std::replace(path.begin(), path.end(), '\\', '/');
     file.write(path);
+
+    if (localSkeletonMap.find(component.value) == localSkeletonMap.end()) {
+      localSkeletonMap.insert_or_assign(component.value, lastSkeletonId++);
+    }
   }
 
   uint32_t numAnimations = 0;
@@ -65,8 +89,8 @@ AssetManager::createPrefabFromAsset(const AssetData<PrefabAsset> &asset) {
   }
   file.write(numAnimations);
 
-  std::map<AnimationAssetHandle, uint32_t> localMap;
-  uint32_t lastId = 0;
+  std::map<AnimationAssetHandle, uint32_t> localAnimationMap;
+  uint32_t lastAnimationId = 0;
 
   for (auto &component : asset.data.animators) {
     for (auto &handle : component.value.animations) {
@@ -76,72 +100,89 @@ AssetManager::createPrefabFromAsset(const AssetData<PrefabAsset> &asset) {
       std::replace(path.begin(), path.end(), '\\', '/');
       file.write(path);
 
-      if (localMap.find(handle) == localMap.end()) {
-        localMap.insert_or_assign(handle, lastId++);
+      if (localAnimationMap.find(handle) == localAnimationMap.end()) {
+        localAnimationMap.insert_or_assign(handle, lastAnimationId++);
       }
     }
   }
 
   // Load component data
-  uint32_t dummySize = 0;
+
   // Size for transforms
+  uint32_t dummySize = 0;
   file.write(dummySize);
 
-  // Size for meshes
-  file.write(dummySize);
+  {
+    auto numComponents = static_cast<uint32_t>(asset.data.meshes.size());
+    file.write(numComponents);
+    for (auto &component : asset.data.meshes) {
+      file.write(component.entity);
+      file.write(localMeshMap.at(component.value));
+    }
+  }
 
-  // Size for skinned meshes
-  file.write(dummySize);
+  {
+    auto numComponents = static_cast<uint32_t>(asset.data.skinnedMeshes.size());
+    file.write(numComponents);
+    for (auto &component : asset.data.skinnedMeshes) {
+      file.write(component.entity);
+      file.write(localSkinnedMeshMap.at(component.value));
+    }
+  }
 
-  // Size for skeletons
-  file.write(dummySize);
+  {
+    auto numComponents = static_cast<uint32_t>(asset.data.skeletons.size());
+    file.write(numComponents);
+    for (auto &component : asset.data.skeletons) {
+      file.write(component.entity);
+      file.write(localSkeletonMap.at(component.value));
+    }
+  }
 
-  auto numAnimators = static_cast<uint32_t>(asset.data.animators.size());
-  file.write(numAnimators);
+  {
+    auto numComponents = static_cast<uint32_t>(asset.data.animators.size());
+    file.write(numComponents);
 
-  for (auto &animator : asset.data.animators) {
-    file.write(animator.entity);
+    for (auto &animator : asset.data.animators) {
+      file.write(animator.entity);
 
-    auto numAnimations =
-        static_cast<uint32_t>(animator.value.animations.size());
-    file.write(numAnimations);
-    for (auto &handle : animator.value.animations) {
-      file.write(localMap.at(handle));
+      auto numAnimations =
+          static_cast<uint32_t>(animator.value.animations.size());
+      file.write(numAnimations);
+      for (auto &handle : animator.value.animations) {
+        file.write(localAnimationMap.at(handle));
+      }
     }
   }
 
   return Result<std::filesystem::path>::Ok(assetPath);
 }
 
-Result<PrefabAssetHandle>
-AssetManager::loadPrefabFromFile(const std::filesystem::path &filePath) {
-  InputBinaryStream file(filePath);
-
-  const auto &header = checkAssetFile(file, filePath, AssetType::Prefab);
-  if (header.hasError()) {
-    return Result<PrefabAssetHandle>::Error(header.getError());
-  }
+Result<PrefabAssetHandle> AssetManager::loadPrefabDataFromInputStream(
+    InputBinaryStream &stream, const std::filesystem::path &filePath) {
 
   std::vector<String> warnings;
+  auto assetName = std::filesystem::relative(filePath, mAssetsPath).string();
 
   AssetData<PrefabAsset> prefab{};
   prefab.path = filePath;
-  prefab.name = filePath.filename().string();
+  prefab.name = assetName;
   prefab.type = AssetType::Prefab;
 
+  std::vector<MeshAssetHandle> localMeshMap;
+
   {
-    auto &component = prefab.data.meshes;
     uint32_t numAssets = 0;
-    file.read(numAssets);
+    stream.read(numAssets);
     std::vector<liquid::String> actual(numAssets);
-    file.read(actual);
-    component.resize(numAssets);
+    stream.read(actual);
+    localMeshMap.resize(numAssets);
 
     for (uint32_t i = 0; i < numAssets; ++i) {
       auto assetPathStr = actual.at(i);
       const auto &res = getOrLoadMeshFromPath(assetPathStr);
       if (res.hasData()) {
-        component.at(i).value = res.getData();
+        localMeshMap.at(i) = res.getData();
         warnings.insert(warnings.end(), res.getWarnings().begin(),
                         res.getWarnings().end());
       } else {
@@ -150,20 +191,19 @@ AssetManager::loadPrefabFromFile(const std::filesystem::path &filePath) {
     }
   }
 
+  std::vector<SkinnedMeshAssetHandle> localSkinnedMeshMap;
   {
-    auto &component = prefab.data.skinnedMeshes;
-
     uint32_t numAssets = 0;
-    file.read(numAssets);
+    stream.read(numAssets);
     std::vector<liquid::String> actual(numAssets);
-    file.read(actual);
-    component.resize(numAssets);
+    stream.read(actual);
+    localSkinnedMeshMap.resize(numAssets);
 
     for (uint32_t i = 0; i < numAssets; ++i) {
       auto assetPathStr = actual.at(i);
       const auto &res = getOrLoadSkinnedMeshFromPath(assetPathStr);
       if (res.hasData()) {
-        component.at(i).value = res.getData();
+        localSkinnedMeshMap.at(i) = res.getData();
         warnings.insert(warnings.end(), res.getWarnings().begin(),
                         res.getWarnings().end());
       } else {
@@ -172,19 +212,19 @@ AssetManager::loadPrefabFromFile(const std::filesystem::path &filePath) {
     }
   }
 
+  std::vector<SkeletonAssetHandle> localSkeletonMap;
   {
-    auto &component = prefab.data.skeletons;
-
     uint32_t numAssets = 0;
-    file.read(numAssets);
+    stream.read(numAssets);
     std::vector<liquid::String> actual(numAssets);
-    file.read(actual);
-    component.resize(numAssets);
+    stream.read(actual);
+    localSkeletonMap.resize(numAssets);
+
     for (uint32_t i = 0; i < numAssets; ++i) {
       auto assetPathStr = actual.at(i);
       const auto &res = getOrLoadSkeletonFromPath(assetPathStr);
       if (res.hasData()) {
-        component.at(i).value = res.getData();
+        localSkeletonMap.at(i) = res.getData();
         warnings.insert(warnings.end(), res.getWarnings().begin(),
                         res.getWarnings().end());
       } else {
@@ -193,21 +233,21 @@ AssetManager::loadPrefabFromFile(const std::filesystem::path &filePath) {
     }
   }
 
-  std::vector<AnimationAssetHandle> localMap;
+  std::vector<AnimationAssetHandle> localAnimationMap;
   {
     auto &map = mRegistry.getAnimations();
 
     uint32_t numAssets = 0;
-    file.read(numAssets);
+    stream.read(numAssets);
     std::vector<liquid::String> actual(numAssets);
-    file.read(actual);
-    localMap.resize(numAssets);
+    stream.read(actual);
+    localAnimationMap.resize(numAssets);
 
     for (uint32_t i = 0; i < numAssets; ++i) {
       auto assetPathStr = actual.at(i);
       const auto &res = getOrLoadAnimationFromPath(assetPathStr);
       if (res.hasData()) {
-        localMap.at(i) = res.getData();
+        localAnimationMap.at(i) = res.getData();
         warnings.insert(warnings.end(), res.getWarnings().begin(),
                         res.getWarnings().end());
 
@@ -218,39 +258,106 @@ AssetManager::loadPrefabFromFile(const std::filesystem::path &filePath) {
   }
 
   uint32_t dummy = 0;
-  file.read(dummy);
-  file.read(dummy);
-  file.read(dummy);
-  file.read(dummy);
+  stream.read(dummy);
 
   {
     uint32_t numComponents = 0;
-    file.read(numComponents);
+    stream.read(numComponents);
+
+    prefab.data.meshes.resize(numComponents);
+
+    auto &map = mRegistry.getMeshes();
+    for (uint32_t i = 0; i < numComponents; ++i) {
+      uint32_t entity = 0;
+      stream.read(entity);
+
+      uint32_t meshIndex = 0;
+      stream.read(meshIndex);
+
+      prefab.data.meshes.at(i).entity = entity;
+      prefab.data.meshes.at(i).value = localMeshMap.at(meshIndex);
+    }
+  }
+
+  {
+    uint32_t numComponents = 0;
+    stream.read(numComponents);
+
+    prefab.data.skinnedMeshes.resize(numComponents);
+
+    auto &map = mRegistry.getSkinnedMeshes();
+    for (uint32_t i = 0; i < numComponents; ++i) {
+      uint32_t entity = 0;
+      stream.read(entity);
+
+      uint32_t meshIndex = 0;
+      stream.read(meshIndex);
+
+      prefab.data.skinnedMeshes.at(i).entity = entity;
+      prefab.data.skinnedMeshes.at(i).value = localSkinnedMeshMap.at(meshIndex);
+    }
+  }
+
+  {
+    uint32_t numComponents = 0;
+    stream.read(numComponents);
+
+    prefab.data.skeletons.resize(numComponents);
+
+    auto &map = mRegistry.getSkeletons();
+    for (uint32_t i = 0; i < numComponents; ++i) {
+      uint32_t entity = 0;
+      stream.read(entity);
+
+      uint32_t meshIndex = 0;
+      stream.read(meshIndex);
+
+      prefab.data.skeletons.at(i).entity = entity;
+      prefab.data.skeletons.at(i).value = localSkeletonMap.at(meshIndex);
+    }
+  }
+
+  {
+    uint32_t numComponents = 0;
+    stream.read(numComponents);
     auto &map = mRegistry.getAnimations();
 
     prefab.data.animators.resize(numComponents);
 
     for (uint32_t i = 0; i < numComponents; ++i) {
       uint32_t entity = 0;
-      file.read(entity);
+      stream.read(entity);
 
       uint32_t numAnimations = 0;
-      file.read(numAnimations);
+      stream.read(numAnimations);
 
       std::vector<uint32_t> animations(numAnimations);
-      file.read(animations);
+      stream.read(animations);
 
+      prefab.data.animators.at(i).entity = entity;
       prefab.data.animators.at(i).value.animations.resize(numAnimations);
 
       for (size_t j = 0; j < animations.size(); ++j) {
         prefab.data.animators.at(i).value.animations.at(j) =
-            localMap.at(animations.at(j));
+            localAnimationMap.at(animations.at(j));
       }
     }
   }
 
   return Result<PrefabAssetHandle>::Ok(mRegistry.getPrefabs().addAsset(prefab),
                                        warnings);
+}
+
+Result<PrefabAssetHandle>
+AssetManager::loadPrefabFromFile(const std::filesystem::path &filePath) {
+  InputBinaryStream stream(filePath);
+
+  const auto &header = checkAssetFile(stream, filePath, AssetType::Prefab);
+  if (header.hasError()) {
+    return Result<PrefabAssetHandle>::Error(header.getError());
+  }
+
+  return loadPrefabDataFromInputStream(stream, filePath);
 }
 
 } // namespace liquid

--- a/engine/src/liquid/asset/AssetRegistry.cpp
+++ b/engine/src/liquid/asset/AssetRegistry.cpp
@@ -10,6 +10,7 @@ AssetRegistry::~AssetRegistry() {
 }
 
 void AssetRegistry::syncWithDeviceRegistry(rhi::ResourceRegistry &registry) {
+  LIQUID_PROFILE_EVENT("AssetRegistry::syncWithDeviceRegistry");
   for (auto &[_, texture] : mTextures.getAssets()) {
     if (texture.data.deviceHandle == rhi::TextureHandle::Invalid) {
       rhi::TextureDescription description;
@@ -28,6 +29,53 @@ void AssetRegistry::syncWithDeviceRegistry(rhi::ResourceRegistry &registry) {
       texture.data.deviceHandle = registry.setTexture(description);
     }
   }
+}
+
+AssetType AssetRegistry::getAssetType(const std::filesystem::path &filePath) {
+  LIQUID_PROFILE_EVENT("AssetRegistry::getAssetType");
+  for (auto &[_, asset] : mTextures.getAssets()) {
+    if (asset.path == filePath) {
+      return AssetType::Texture;
+    }
+  }
+
+  for (auto &[_, asset] : mMaterials.getAssets()) {
+    if (asset.path == filePath) {
+      return AssetType::Material;
+    }
+  }
+
+  for (auto &[_, asset] : mMeshes.getAssets()) {
+    if (asset.path == filePath) {
+      return AssetType::Mesh;
+    }
+  }
+
+  for (auto &[_, asset] : mSkinnedMeshes.getAssets()) {
+    if (asset.path == filePath) {
+      return AssetType::SkinnedMesh;
+    }
+  }
+
+  for (auto &[_, asset] : mSkeletons.getAssets()) {
+    if (asset.path == filePath) {
+      return AssetType::Skeleton;
+    }
+  }
+
+  for (auto &[_, asset] : mAnimations.getAssets()) {
+    if (asset.path == filePath) {
+      return AssetType::Animation;
+    }
+  }
+
+  for (auto &[_, asset] : mPrefabs.getAssets()) {
+    if (asset.path == filePath) {
+      return AssetType::Prefab;
+    }
+  }
+
+  return AssetType::None;
 }
 
 } // namespace liquid

--- a/engine/src/liquid/asset/AssetRegistry.h
+++ b/engine/src/liquid/asset/AssetRegistry.h
@@ -95,6 +95,15 @@ public:
    */
   inline PrefabMap &getPrefabs() { return mPrefabs; }
 
+  /**
+   * @brief Get asset type located at path
+   *
+   * @param filePath Path to asset
+   * @retval AssetType::None Asset does not exist
+   * @return Asset type
+   */
+  AssetType getAssetType(const std::filesystem::path &filePath);
+
 private:
   TextureMap mTextures;
   MaterialMap mMaterials;


### PR DESCRIPTION
- Create unique directory for the prefab
- Load entity/component data with prefab
- Use relative paths for asset names in gltf importer
- Do not preload assets if they are already loaded
- Allow loading assets from input stream directly