### PR TITLE
Use storage buffers for transforms and skeletons

### DIFF
--- a/demos/pong-3d/src/main.cpp
+++ b/demos/pong-3d/src/main.cpp
@@ -67,7 +67,7 @@ public:
 
     liquid::rhi::RenderGraph graph;
 
-    liquid::SceneRenderer sceneRenderer(entityContext, false);
+    liquid::SceneRenderer sceneRenderer(entityContext);
 
     liquid::rhi::TextureDescription desc;
     desc.usage =

--- a/engine/assets/shaders/pbr.frag
+++ b/engine/assets/shaders/pbr.frag
@@ -11,7 +11,7 @@ layout(location = 9) in mat4 inModelMatrix;
 
 layout(location = 0) out vec4 outColor;
 
-layout(set = 1, binding = 0) uniform CameraData {
+layout(set = 2, binding = 0) uniform CameraData {
   mat4 proj;
   mat4 view;
   mat4 viewProj;
@@ -25,18 +25,18 @@ struct LightData {
   mat4 lightSpaceMatrix;
 };
 
-layout(std140, set = 1, binding = 1) uniform SceneData {
+layout(std140, set = 2, binding = 1) uniform SceneData {
   LightData lights[16];
   uvec4 numLights;
   uvec4 hasIBL;
 }
 uSceneData;
 
-layout(set = 1, binding = 2) uniform sampler2DArray uShadowmap;
-layout(set = 1, binding = 3) uniform samplerCube uIblMaps[2];
-layout(set = 1, binding = 4) uniform sampler2D uBrdfLUT;
+layout(set = 2, binding = 2) uniform sampler2DArray uShadowmap;
+layout(set = 2, binding = 3) uniform samplerCube uIblMaps[2];
+layout(set = 2, binding = 4) uniform sampler2D uBrdfLUT;
 
-layout(std140, set = 2, binding = 0) uniform MaterialDataRaw {
+layout(std140, set = 3, binding = 0) uniform MaterialDataRaw {
   int baseColorTexture[1];
   int baseColorTextureCoord[1];
   vec4 baseColorFactor;
@@ -87,7 +87,7 @@ MaterialData uMaterialData = MaterialData(
     uMaterialDataRaw.occlusionStrength[0], uMaterialDataRaw.emissiveTexture[0],
     uMaterialDataRaw.emissiveTextureCoord[0], uMaterialDataRaw.emissiveFactor);
 
-layout(set = 2, binding = 1) uniform sampler2D uTextures[8];
+layout(set = 3, binding = 1) uniform sampler2D uTextures[8];
 
 const float PI = 3.141592653589793;
 const mat4 DEPTH_BIAS = mat4(0.5, 0.0, 0.0, 0.0, 0.0, 0.5, 0.0, 0.0, 0.0, 0.0,

--- a/engine/assets/shaders/shadowmap.vert
+++ b/engine/assets/shaders/shadowmap.vert
@@ -1,4 +1,4 @@
-#version 450
+#version 460
 #extension GL_ARB_separate_shader_objects : enable
 #extension GL_ARB_shader_viewport_layer_array : enable
 
@@ -10,11 +10,18 @@ layout(std140, set = 0, binding = 0) uniform MaterialData {
 }
 uMaterialData;
 
-layout(push_constant) uniform TransfromConstant { mat4 modelMatrix; }
-pcTransform;
+struct ObjectItem {
+  mat4 modelMatrix;
+};
+
+layout(std140, set = 1, binding = 0) readonly buffer ObjectData {
+  ObjectItem items[];
+}
+uObjectData;
 
 void main() {
-  gl_Position = uMaterialData.lightMatrix * pcTransform.modelMatrix *
-                vec4(inPosition, 1.0);
+  mat4 modelMatrix = uObjectData.items[gl_BaseInstance].modelMatrix;
+
+  gl_Position = uMaterialData.lightMatrix * modelMatrix * vec4(inPosition, 1.0);
   gl_Layer = uMaterialData.lightIndex[0];
 }

--- a/engine/src/liquid/core/Base.h
+++ b/engine/src/liquid/core/Base.h
@@ -34,6 +34,7 @@
 #include <list>
 #include <type_traits>
 #include <variant>
+#include <random>
 
 #define GLM_FORCE_DEPTH_ZERO_TO_ONE
 #include <glm/glm.hpp>

--- a/engine/src/liquid/renderer/RenderStorage.cpp
+++ b/engine/src/liquid/renderer/RenderStorage.cpp
@@ -1,0 +1,65 @@
+#include "liquid/core/Base.h"
+
+#include "liquid/rhi/RenderHandle.h"
+#include "liquid/rhi/ResourceRegistry.h"
+#include "RenderStorage.h"
+
+namespace liquid {
+
+RenderStorage::RenderStorage(size_t reservedSpace)
+    : mReservedSpace(reservedSpace) {
+  mMeshTransformMatrices.reserve(mReservedSpace);
+  mSkinnedMeshTransformMatrices.reserve(mReservedSpace);
+
+  mSkeletonVector.reset(new glm::mat4[mReservedSpace * MAX_NUM_JOINTS]);
+}
+
+void RenderStorage::updateBuffers(rhi::ResourceRegistry &registry) {
+  mMeshTransformsBuffer = registry.setBuffer(
+      {
+          rhi::BufferType::Storage,
+          mReservedSpace * sizeof(glm::mat4),
+          mMeshTransformMatrices.data(),
+      },
+      mMeshTransformsBuffer);
+
+  mSkinnedMeshTransformsBuffer = registry.setBuffer(
+      {
+          rhi::BufferType::Storage,
+          mReservedSpace * sizeof(glm::mat4),
+          mSkinnedMeshTransformMatrices.data(),
+      },
+      mSkinnedMeshTransformsBuffer);
+
+  mSkeletonsBuffer = registry.setBuffer(
+      {
+          rhi::BufferType::Storage,
+          mReservedSpace * MAX_NUM_JOINTS * sizeof(glm::mat4),
+          mSkeletonVector.get(),
+      },
+      mSkeletonsBuffer);
+}
+
+void RenderStorage::addMeshData(const glm::mat4 &transform) {
+  mMeshTransformMatrices.push_back(transform);
+}
+
+void RenderStorage::addSkinnedMeshData(const glm::mat4 &transform,
+                                       const std::vector<glm::mat4> &skeleton) {
+  mSkinnedMeshTransformMatrices.push_back(transform);
+
+  auto *currentSkeleton =
+      mSkeletonVector.get() + (mLastSkeleton * MAX_NUM_JOINTS);
+  size_t dataSize = std::min(skeleton.size(), MAX_NUM_JOINTS);
+  memcpy(currentSkeleton, skeleton.data(), dataSize * sizeof(glm::mat4));
+
+  mLastSkeleton++;
+}
+
+void RenderStorage::clear() {
+  mMeshTransformMatrices.clear();
+  mSkinnedMeshTransformMatrices.clear();
+  mLastSkeleton = 0;
+}
+
+} // namespace liquid

--- a/engine/src/liquid/renderer/RenderStorage.h
+++ b/engine/src/liquid/renderer/RenderStorage.h
@@ -1,0 +1,85 @@
+#pragma once
+
+namespace liquid {
+
+class RenderStorage {
+  static constexpr size_t DEFAULT_RESERVED_SPACE = 10000;
+  static constexpr size_t MAX_NUM_JOINTS = 32;
+
+public:
+  /**
+   * @brief Create render storage
+   *
+   * @param reservedSpace Reserved space for buffer data
+   */
+  RenderStorage(size_t reservedSpace = DEFAULT_RESERVED_SPACE);
+
+  /**
+   * @brief Update storage buffers
+   *
+   * @param registry Resource registry
+   */
+  void updateBuffers(rhi::ResourceRegistry &registry);
+
+  /**
+   * @brief Get mesh transforms buffer
+   *
+   * @return Mesh transforms buffer
+   */
+  inline rhi::BufferHandle getMeshTransformsBuffer() const {
+    return mMeshTransformsBuffer;
+  }
+
+  /**
+   * @brief Get skinned mesh transforms buffer
+   *
+   * @return Skinned mesh transforms buffer
+   */
+  inline rhi::BufferHandle getSkinnedMeshTransformsBuffer() const {
+    return mSkinnedMeshTransformsBuffer;
+  }
+
+  /**
+   * @brief Get skeletons buffer
+   *
+   * @return Skeletons buffer
+   */
+  inline rhi::BufferHandle getSkeletonsBuffer() const {
+    return mSkeletonsBuffer;
+  }
+
+  /**
+   * @brief Add mesh data
+   *
+   * @param transform Mesh world transform
+   */
+  void addMeshData(const glm::mat4 &transform);
+
+  /**
+   * @brief Add skinned mesh data
+   *
+   * @param transform Skinned mesh world transform
+   * @param skeleton Skeleton joint transforms
+   */
+  void addSkinnedMeshData(const glm::mat4 &transform,
+                          const std::vector<glm::mat4> &skeleton);
+
+  /**
+   * @brief Clear intermediary buffers
+   */
+  void clear();
+
+private:
+  std::vector<glm::mat4> mMeshTransformMatrices;
+  std::vector<glm::mat4> mSkinnedMeshTransformMatrices;
+  std::unique_ptr<glm::mat4> mSkeletonVector;
+  size_t mLastSkeleton = 0;
+
+  rhi::BufferHandle mMeshTransformsBuffer = rhi::BufferHandle::Invalid;
+  rhi::BufferHandle mSkinnedMeshTransformsBuffer = rhi::BufferHandle::Invalid;
+  rhi::BufferHandle mSkeletonsBuffer = rhi::BufferHandle::Invalid;
+
+  size_t mReservedSpace = 0;
+};
+
+} // namespace liquid

--- a/engine/src/liquid/renderer/Renderer.h
+++ b/engine/src/liquid/renderer/Renderer.h
@@ -1,13 +1,14 @@
 #pragma once
 
+#include "liquid/rhi/RenderDevice.h"
 #include "RenderData.h"
 #include "ShaderLibrary.h"
 #include "MaterialPBR.h"
 #include "SceneRenderer.h"
+#include "RenderStorage.h"
 #include "imgui/ImguiRenderer.h"
 
 #include "liquid/entity/EntityContext.h"
-#include "liquid/rhi/RenderDevice.h"
 
 #include "liquid/scene/Camera.h"
 #include "liquid/scene/Scene.h"
@@ -69,6 +70,8 @@ public:
 private:
   void loadShaders();
 
+  void updateStorageBuffers();
+
 private:
   EntityContext &mEntityContext;
   rhi::ResourceRegistry mRegistry;
@@ -80,6 +83,7 @@ private:
   SceneRenderer mSceneRenderer;
 
   std::vector<SharedPtr<Material>> mShadowMaterials;
+  RenderStorage mRenderStorage;
 };
 
 } // namespace liquid

--- a/engine/src/liquid/renderer/SceneRenderer.h
+++ b/engine/src/liquid/renderer/SceneRenderer.h
@@ -2,23 +2,31 @@
 
 #include "liquid/entity/EntityContext.h"
 #include "liquid/rhi/RenderCommandList.h"
+#include "RenderStorage.h"
 
 namespace liquid {
 
 class SceneRenderer {
 public:
-  SceneRenderer(EntityContext &entityContext, bool bindMaterialData = false);
+  SceneRenderer(EntityContext &entityContext);
 
+  /**
+   * @deprecated This function is used in Pong3D demo
+   *             because the demo uses custom render
+   *             passes
+   */
   void render(rhi::RenderCommandList &commandList, rhi::PipelineHandle pipeline,
               bool bindMaterialData = false);
 
+  void render(rhi::RenderCommandList &commandList, rhi::PipelineHandle pipeline,
+              RenderStorage &renderStorage, bool bindMaterialData = false);
+
   void renderSkinned(rhi::RenderCommandList &commandList,
-                     rhi::PipelineHandle pipeline, uint32_t desciptorSet,
+                     rhi::PipelineHandle pipeline, RenderStorage &renderStorage,
                      bool bindMaterialData = true);
 
 private:
   EntityContext &mEntityContext;
-  bool mBindMaterialData;
 };
 
 } // namespace liquid

--- a/engine/src/liquid/rhi/BufferDescription.h
+++ b/engine/src/liquid/rhi/BufferDescription.h
@@ -2,7 +2,7 @@
 
 namespace liquid::rhi {
 
-enum class BufferType { Vertex, Index, Uniform, Transfer };
+enum class BufferType { Vertex, Index, Uniform, Storage, Transfer };
 
 struct BufferDescription {
   BufferType type = rhi::BufferType::Vertex;

--- a/engine/src/liquid/rhi/Descriptor.cpp
+++ b/engine/src/liquid/rhi/Descriptor.cpp
@@ -22,9 +22,10 @@ Descriptor &Descriptor::bind(uint32_t binding,
 
 Descriptor &Descriptor::bind(uint32_t binding, BufferHandle buffer,
                              DescriptorType type) {
-  LIQUID_ASSERT(type == DescriptorType::UniformBuffer,
+  LIQUID_ASSERT(type == DescriptorType::UniformBuffer ||
+                    type == DescriptorType::StorageBuffer,
                 "Descriptor type for binding " + std::to_string(binding) +
-                    " must be uniform buffer");
+                    " must be uniform or storage buffer");
 
   bindings.insert({binding, DescriptorBinding{type, buffer}});
   std::stringstream ss;

--- a/engine/src/liquid/rhi/Descriptor.h
+++ b/engine/src/liquid/rhi/Descriptor.h
@@ -6,6 +6,7 @@ namespace liquid::rhi {
 
 enum class DescriptorType {
   UniformBuffer,
+  StorageBuffer,
   CombinedImageSampler,
 };
 

--- a/engine/src/liquid/rhi/RenderCommandList.h
+++ b/engine/src/liquid/rhi/RenderCommandList.h
@@ -104,7 +104,7 @@ public:
    *
    * @param buffer Vertex buffer
    */
-  void bindVertexBuffer(BufferHandle buffer) {
+  inline void bindVertexBuffer(BufferHandle buffer) {
     mNativeRenderCommandList->bindVertexBuffer(buffer);
   }
 
@@ -114,7 +114,7 @@ public:
    * @param buffer Index buffer
    * @param indexType Index buffer data type
    */
-  void bindIndexBuffer(BufferHandle buffer, VkIndexType indexType) {
+  inline void bindIndexBuffer(BufferHandle buffer, VkIndexType indexType) {
     mNativeRenderCommandList->bindIndexBuffer(buffer, indexType);
   }
 
@@ -127,8 +127,9 @@ public:
    * @param size Size
    * @param data Data
    */
-  void pushConstants(PipelineHandle pipeline, VkShaderStageFlags stageFlags,
-                     uint32_t offset, uint32_t size, void *data) {
+  inline void pushConstants(PipelineHandle pipeline,
+                            VkShaderStageFlags stageFlags, uint32_t offset,
+                            uint32_t size, void *data) {
     mNativeRenderCommandList->pushConstants(pipeline, stageFlags, offset, size,
                                             data);
   }
@@ -138,9 +139,13 @@ public:
    *
    * @param vertexCount Vertex count
    * @param firstVertex First vertex
+   * @param instanceCount Instance count
+   * @param firstInstance First instance
    */
-  void draw(uint32_t vertexCount, uint32_t firstVertex) {
-    mNativeRenderCommandList->draw(vertexCount, firstVertex);
+  inline void draw(uint32_t vertexCount, uint32_t firstVertex,
+                   uint32_t instanceCount = 1, uint32_t firstInstance = 0) {
+    mNativeRenderCommandList->draw(vertexCount, firstVertex, instanceCount,
+                                   firstInstance);
   }
 
   /**
@@ -149,10 +154,14 @@ public:
    * @param indexCount Index count
    * @param firstIndex Offset of first index
    * @param vertexOffset Vertex offset
+   * @param instanceCount Instance count
+   * @param firstInstance First instance
    */
-  void drawIndexed(uint32_t indexCount, uint32_t firstIndex,
-                   int32_t vertexOffset) {
-    mNativeRenderCommandList->drawIndexed(indexCount, firstIndex, vertexOffset);
+  inline void drawIndexed(uint32_t indexCount, uint32_t firstIndex,
+                          int32_t vertexOffset, uint32_t instanceCount = 1,
+                          uint32_t firstInstance = 0) {
+    mNativeRenderCommandList->drawIndexed(indexCount, firstIndex, vertexOffset,
+                                          instanceCount, firstInstance);
   }
 
   /**
@@ -162,8 +171,8 @@ public:
    * @param size Viewport size
    * @param depthRange Viewport depth range
    */
-  void setViewport(const glm::vec2 &offset, const glm::vec2 &size,
-                   const glm::vec2 &depthRange) {
+  inline void setViewport(const glm::vec2 &offset, const glm::vec2 &size,
+                          const glm::vec2 &depthRange) {
     mNativeRenderCommandList->setViewport(offset, size, depthRange);
   }
 
@@ -173,7 +182,7 @@ public:
    * @param offset Scissor offset
    * @param size Scissor size
    */
-  void setScissor(const glm::ivec2 &offset, const glm::uvec2 &size) {
+  inline void setScissor(const glm::ivec2 &offset, const glm::uvec2 &size) {
     mNativeRenderCommandList->setScissor(offset, size);
   }
 

--- a/engine/src/liquid/rhi/base/NativeRenderCommandListInterface.h
+++ b/engine/src/liquid/rhi/base/NativeRenderCommandListInterface.h
@@ -77,8 +77,11 @@ public:
    *
    * @param vertexCount Vertex count
    * @param firstVertex First vertex
+   * @param instanceCount Instance count
+   * @param firstInstance First instance
    */
-  virtual void draw(uint32_t vertexCount, uint32_t firstVertex) = 0;
+  virtual void draw(uint32_t vertexCount, uint32_t firstVertex,
+                    uint32_t instanceCount, uint32_t firstInstance) = 0;
 
   /**
    * @brief Draw indexed
@@ -86,9 +89,12 @@ public:
    * @param indexCount Index count
    * @param firstIndex Offset of first index
    * @param vertexOffset Vertex offset
+   * @param instanceCount Instance count
+   * @param firstInstance First instance
    */
   virtual void drawIndexed(uint32_t indexCount, uint32_t firstIndex,
-                           int32_t vertexOffset) = 0;
+                           int32_t vertexOffset, uint32_t instanceCount,
+                           uint32_t firstInstance) = 0;
 
   /**
    * @brief Set viewport

--- a/engine/src/liquid/rhi/vulkan/VulkanBuffer.cpp
+++ b/engine/src/liquid/rhi/vulkan/VulkanBuffer.cpp
@@ -40,6 +40,8 @@ void VulkanBuffer::createBuffer(const BufferDescription &description) {
     bufferUsage = VK_BUFFER_USAGE_INDEX_BUFFER_BIT;
   } else if (description.type == rhi::BufferType::Uniform) {
     bufferUsage = VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT;
+  } else if (description.type == rhi::BufferType::Storage) {
+    bufferUsage = VK_BUFFER_USAGE_STORAGE_BUFFER_BIT;
   } else if (description.type == rhi::BufferType::Transfer) {
     bufferUsage = VK_BUFFER_USAGE_TRANSFER_SRC_BIT;
     memoryUsage = VMA_MEMORY_USAGE_CPU_ONLY;

--- a/engine/src/liquid/rhi/vulkan/VulkanCommandBuffer.cpp
+++ b/engine/src/liquid/rhi/vulkan/VulkanCommandBuffer.cpp
@@ -92,14 +92,19 @@ void VulkanCommandBuffer::pushConstants(PipelineHandle pipeline,
   mStats.addCommandCall();
 }
 
-void VulkanCommandBuffer::draw(uint32_t vertexCount, uint32_t firstVertex) {
-  vkCmdDraw(mCommandBuffer, vertexCount, 1, firstVertex, 0);
+void VulkanCommandBuffer::draw(uint32_t vertexCount, uint32_t firstVertex,
+                               uint32_t instanceCount, uint32_t firstInstance) {
+  vkCmdDraw(mCommandBuffer, vertexCount, instanceCount, firstVertex,
+            firstInstance);
   mStats.addDrawCall(vertexCount / 3);
 }
 
 void VulkanCommandBuffer::drawIndexed(uint32_t indexCount, uint32_t firstIndex,
-                                      int32_t vertexOffset) {
-  vkCmdDrawIndexed(mCommandBuffer, indexCount, 1, firstIndex, vertexOffset, 0);
+                                      int32_t vertexOffset,
+                                      uint32_t instanceCount,
+                                      uint32_t firstInstance) {
+  vkCmdDrawIndexed(mCommandBuffer, indexCount, instanceCount, firstIndex,
+                   vertexOffset, firstInstance);
   mStats.addDrawCall(indexCount / 3);
 }
 

--- a/engine/src/liquid/rhi/vulkan/VulkanCommandBuffer.h
+++ b/engine/src/liquid/rhi/vulkan/VulkanCommandBuffer.h
@@ -99,8 +99,11 @@ public:
    *
    * @param vertexCount Vertex count
    * @param firstVertex First vertex
+   * @param instanceCount Instance count
+   * @param firstInstance First instance
    */
-  void draw(uint32_t vertexCount, uint32_t firstVertex) override;
+  void draw(uint32_t vertexCount, uint32_t firstVertex, uint32_t instanceCount,
+            uint32_t firstInstance) override;
 
   /**
    * @brief Draw indexed
@@ -108,9 +111,12 @@ public:
    * @param indexCount Index count
    * @param firstIndex Offset of first index
    * @param vertexOffset Vertex offset
+   * @param instanceCount Instance count
+   * @param firstInstance First instance
    */
   void drawIndexed(uint32_t indexCount, uint32_t firstIndex,
-                   int32_t vertexOffset) override;
+                   int32_t vertexOffset, uint32_t instanceCount,
+                   uint32_t firstInstance) override;
 
   /**
    * @brief Set viewport

--- a/engine/src/liquid/rhi/vulkan/VulkanDescriptorManager.cpp
+++ b/engine/src/liquid/rhi/vulkan/VulkanDescriptorManager.cpp
@@ -63,7 +63,8 @@ VulkanDescriptorManager::createDescriptorSet(const Descriptor &descriptor,
     write.descriptorType =
         VulkanMapping::getDescriptorType(binding.second.type);
 
-    if (binding.second.type == DescriptorType::UniformBuffer) {
+    if (binding.second.type == DescriptorType::UniformBuffer ||
+        binding.second.type == DescriptorType::StorageBuffer) {
       const auto &vkBuffer = mRegistry.getBuffers().at(
           std::get<BufferHandle>(binding.second.data));
       bufferInfos.push_back(VkDescriptorBufferInfo{vkBuffer->getBuffer(), 0,
@@ -73,7 +74,6 @@ VulkanDescriptorManager::createDescriptorSet(const Descriptor &descriptor,
       write.pBufferInfo = &bufferObj;
       write.descriptorCount = 1;
       writes.push_back(write);
-
     } else if (binding.second.type == DescriptorType::CombinedImageSampler) {
       imageInfos.push_back({});
       auto &imageInfoObjects = imageInfos.at(imageInfos.size() - 1);
@@ -126,14 +126,17 @@ VulkanDescriptorManager::allocateDescriptorSet(VkDescriptorSetLayout layout) {
 }
 
 void VulkanDescriptorManager::createDescriptorPool() {
-  constexpr uint32_t NUM_UNIFORM_BUFFERS = 1500;
+  constexpr uint32_t NUM_UNIFORM_BUFFERS = 15000;
+  constexpr uint32_t NUM_STORAGE_BUFFERS = 500;
   constexpr uint32_t NUM_SAMPLERS = 500;
-  constexpr uint32_t NUM_DESCRIPTORS = 2000;
+  constexpr uint32_t NUM_DESCRIPTORS = 20000;
   constexpr uint32_t MAX_TEXTURE_DESCRIPTORS = 8;
 
-  std::array<VkDescriptorPoolSize, 2> poolSizes{
+  std::array<VkDescriptorPoolSize, 3> poolSizes{
       VkDescriptorPoolSize{VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER,
                            NUM_UNIFORM_BUFFERS},
+      VkDescriptorPoolSize{VK_DESCRIPTOR_TYPE_STORAGE_BUFFER,
+                           NUM_STORAGE_BUFFERS},
       VkDescriptorPoolSize{VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER,
                            MAX_TEXTURE_DESCRIPTORS * NUM_SAMPLERS}};
 

--- a/engine/src/liquid/rhi/vulkan/VulkanMapping.cpp
+++ b/engine/src/liquid/rhi/vulkan/VulkanMapping.cpp
@@ -169,6 +169,8 @@ VulkanMapping::getDescriptorType(DescriptorType descriptorType) {
     return VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
   case DescriptorType::UniformBuffer:
     return VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER;
+  case DescriptorType::StorageBuffer:
+    return VK_DESCRIPTOR_TYPE_STORAGE_BUFFER;
   default:
     return VK_DESCRIPTOR_TYPE_MAX_ENUM;
   }

--- a/engine/src/liquid/rhi/vulkan/VulkanShader.cpp
+++ b/engine/src/liquid/rhi/vulkan/VulkanShader.cpp
@@ -10,7 +10,7 @@ namespace liquid::rhi {
 
 VulkanShader::VulkanShader(const ShaderDescription &description,
                            VulkanDeviceObject &device)
-    : mDevice(device) {
+    : mDevice(device), mPath(description.path) {
   const auto &shaderBytes = VulkanShader::readShaderFile(description.path);
 
   VkShaderModuleCreateInfo createInfo{};

--- a/engine/src/liquid/rhi/vulkan/VulkanShader.h
+++ b/engine/src/liquid/rhi/vulkan/VulkanShader.h
@@ -82,6 +82,7 @@ private:
   VkShaderStageFlagBits mStage = VK_SHADER_STAGE_FLAG_BITS_MAX_ENUM;
 
   ReflectionData mReflectionData{};
+  String mPath;
 };
 
 } // namespace liquid::rhi

--- a/engine/src/liquid/scene/Skeleton.cpp
+++ b/engine/src/liquid/scene/Skeleton.cpp
@@ -26,9 +26,6 @@ Skeleton::Skeleton(const std::vector<glm::vec3> &positions,
   mJointWorldTransforms.resize(mNumJoints, glm::mat4{1.0f});
   mJointFinalTransforms.resize(mNumJoints, glm::mat4{1.0f});
 
-  mBuffer = registry->setBuffer(
-      {rhi::BufferType::Uniform, sizeof(glm::mat4) * mNumJoints});
-
   // Debug data
   for (JointId joint = 0; joint < static_cast<uint32_t>(mNumJoints); ++joint) {
     mDebugBones.push_back(mJointParents.at(joint));
@@ -82,11 +79,6 @@ void Skeleton::update() {
     mJointFinalTransforms.at(i) =
         mJointWorldTransforms.at(i) * mJointInverseBindMatrices.at(i);
   }
-
-  mRegistry->setBuffer({rhi::BufferType::Uniform,
-                        sizeof(glm::mat4) * mNumJoints,
-                        mJointFinalTransforms.data()},
-                       mBuffer);
 }
 
 void Skeleton::updateDebug() {

--- a/engine/src/liquid/scene/Skeleton.h
+++ b/engine/src/liquid/scene/Skeleton.h
@@ -145,11 +145,13 @@ public:
   }
 
   /**
-   * @brief Get buffer
+   * @brief Get joint final transforms
    *
-   * @return Buffer
+   * @return Joint final transforms
    */
-  inline rhi::BufferHandle getBuffer() const { return mBuffer; }
+  inline const std::vector<glm::mat4> &getJointFinalTransforms() const {
+    return mJointFinalTransforms;
+  }
 
   /**
    * @brief Get debug buffer
@@ -204,7 +206,6 @@ private:
   std::vector<glm::mat4> mJointFinalTransforms;
 
   std::vector<String> mJointNames;
-  rhi::BufferHandle mBuffer;
 
   std::vector<JointId> mDebugBones;
   std::vector<glm::mat4> mDebugBoneTransforms;

--- a/engine/tests/renderer/Descriptor.test.cpp
+++ b/engine/tests/renderer/Descriptor.test.cpp
@@ -47,11 +47,11 @@ TEST_F(DescriptorTest, CreatesHashFromBindings) {
   descriptor.bind(0, {tex1, tex2},
                   liquid::rhi::DescriptorType::CombinedImageSampler);
   descriptor.bind(1, buffer1, liquid::rhi::DescriptorType::UniformBuffer);
-  descriptor.bind(2, buffer2, liquid::rhi::DescriptorType::UniformBuffer);
+  descriptor.bind(2, buffer2, liquid::rhi::DescriptorType::StorageBuffer);
 
   std::stringstream ss;
-  ss << "b:0;t:1;d:" << 1 << ";d:" << 2 << ";|b:1;t:0;d:" << 1
-     << "|b:2;t:0;d:" << 2 << "|";
+  ss << "b:0;t:2;d:" << 1 << ";d:" << 2 << ";|b:1;t:0;d:" << 1
+     << "|b:2;t:1;d:" << 2 << "|";
 
   EXPECT_EQ(descriptor.getHashCode(), ss.str());
 }

--- a/engine/tests/scene/Skeleton.test.cpp
+++ b/engine/tests/scene/Skeleton.test.cpp
@@ -125,16 +125,6 @@ TEST_F(SkeletonTest, CreatesDebugParametersOnConstruct) {
   EXPECT_EQ(skeleton.getNumDebugBones(), 4);
 }
 
-TEST_F(SkeletonTest, CreatesUniformBufferOnConstruct) {
-  auto &&skeleton = createSkeleton(5);
-
-  const auto &description =
-      registry.getBufferMap().getDescription(skeleton.getBuffer());
-
-  EXPECT_EQ(description.type, liquid::rhi::BufferType::Uniform);
-  EXPECT_EQ(description.size, sizeof(glm::mat4) * 5);
-}
-
 TEST_F(SkeletonTest, CreatesDebugUniformBufferOnConstruct) {
   auto &&skeleton = createSkeleton(5);
 


### PR DESCRIPTION
- Create storage buffers for transforms and transforms
- Pass index of the the buffer in push constants
- Map storage buffers before looping
- Create descriptors from storage buffers
- Update shaders to use storage buffers
- Use base instance index as index for storage buffers
- Update GLSL version to 460
- Remove push constants