### PR TITLE
Add presenter

### DIFF
--- a/engine/src/liquid/renderer/Presenter.h
+++ b/engine/src/liquid/renderer/Presenter.h
@@ -1,0 +1,51 @@
+#pragma once
+
+#include "liquid/rhi/RenderHandle.h"
+#include "liquid/rhi/ResourceRegistry.h"
+#include "liquid/rhi/RenderCommandList.h"
+#include "liquid/rhi/Swapchain.h"
+#include "ShaderLibrary.h"
+
+namespace liquid {
+
+/**
+ * @brief Presents texture to swapchain
+ *        using full screen quad
+ */
+class Presenter {
+public:
+  /**
+   * @brief Create presenter
+   *
+   * @param shaderLibrary Shader library
+   * @param registry Resource registry
+   */
+  Presenter(ShaderLibrary &shaderLibrary, rhi::ResourceRegistry &registry);
+
+  /**
+   * @brief Update framebuffers
+   *
+   * @param swapchain Swapchain
+   */
+  void updateFramebuffers(const rhi::Swapchain &swapchain);
+
+  /**
+   * @brief Present texture to swapchain
+   *
+   * @param commandList Command list
+   * @param handle Texture handle
+   * @param imageIndex Swapchain image index
+   */
+  void present(rhi::RenderCommandList &commandList, rhi::TextureHandle handle,
+               uint32_t imageIndex);
+
+private:
+  rhi::ResourceRegistry &mRegistry;
+  ShaderLibrary &mShaderLibrary;
+  rhi::RenderPassHandle mPresentPass = rhi::RenderPassHandle::Invalid;
+  rhi::PipelineHandle mPresentPipeline = rhi::PipelineHandle::Invalid;
+  std::vector<rhi::FramebufferHandle> mFramebuffers{};
+  glm::uvec2 mExtent{0, 0};
+};
+
+} // namespace liquid

--- a/engine/src/liquid/renderer/Renderer.h
+++ b/engine/src/liquid/renderer/Renderer.h
@@ -31,6 +31,11 @@ struct DefaultGraphResources {
   rhi::TextureHandle depthBuffer;
 
   /**
+   * Depth buffer texture
+   */
+  rhi::TextureHandle imguiColor;
+
+  /**
    * Shadow map texture
    */
   rhi::TextureHandle shadowmap;
@@ -112,11 +117,12 @@ public:
    * @brief Render
    *
    * @param graph Render graph
+   * @param commandList Render command list
    * @param camera Camera entity
    * @param entityContext Entity context
    */
-  void render(rhi::RenderGraph &graph, Entity camera,
-              liquid::EntityContext &entityContext);
+  void render(rhi::RenderGraph &graph, rhi::RenderCommandList &commandList,
+              Entity camera, liquid::EntityContext &entityContext);
 
   /**
    * @brief Wait for device

--- a/engine/src/liquid/rhi/RenderDevice.h
+++ b/engine/src/liquid/rhi/RenderDevice.h
@@ -5,6 +5,8 @@
 #include "DeviceStats.h"
 #include "RenderGraph.h"
 #include "RenderGraphEvaluator.h"
+#include "Swapchain.h"
+#include "RenderFrame.h"
 
 namespace liquid::rhi {
 
@@ -31,27 +33,28 @@ public:
   /**
    * @brief Begin frame
    *
-   * @return Frame index
+   * @return Frame data
    */
-  virtual uint32_t beginFrame() = 0;
+  virtual RenderFrame beginFrame() = 0;
 
   /**
    * @brief End frame
-   */
-  virtual void endFrame() = 0;
-
-  /**
-   * @brief Execute render graph
    *
-   * @param graph Render graph
-   * @param evaluator Render graph evaluator
+   * @param renderFrame Render frame
    */
-  virtual void execute(RenderGraph &graph, RenderGraphEvaluator &evaluator) = 0;
+  virtual void endFrame(const RenderFrame &renderFrame) = 0;
 
   /**
    * @brief Wait for device to be idle
    */
   virtual void waitForIdle() = 0;
+
+  /**
+   * @brief Synchronize resources
+   *
+   * @param registry Resource registry
+   */
+  virtual void synchronize(ResourceRegistry &registry) = 0;
 
   /**
    * @brief Get physical device information
@@ -73,6 +76,13 @@ public:
    * This does not destroy the device
    */
   virtual void destroyResources() = 0;
+
+  /**
+   * @brief Get swapchain
+   *
+   * @return Swapchain
+   */
+  virtual Swapchain getSwapchain() = 0;
 };
 
 } // namespace liquid::rhi

--- a/engine/src/liquid/rhi/RenderFrame.h
+++ b/engine/src/liquid/rhi/RenderFrame.h
@@ -1,0 +1,25 @@
+#pragma once
+
+namespace liquid::rhi {
+
+/**
+ * @brief Rendering frame details
+ */
+struct RenderFrame {
+  /**
+   * @brief Frame index
+   */
+  uint32_t frameIndex = std::numeric_limits<uint32_t>::max();
+
+  /**
+   * @brief Swapchain image index
+   */
+  uint32_t swapchainImageIndex = std::numeric_limits<uint32_t>::max();
+
+  /**
+   * @brief Command list
+   */
+  RenderCommandList &commandList;
+};
+
+} // namespace liquid::rhi

--- a/engine/src/liquid/rhi/RenderGraph.cpp
+++ b/engine/src/liquid/rhi/RenderGraph.cpp
@@ -131,4 +131,11 @@ std::vector<size_t> RenderGraph::compile() {
   return sortedPasses;
 }
 
+void RenderGraph::setFramebufferExtent(glm::uvec2 framebufferExtent) {
+  mFramebufferExtent = framebufferExtent;
+  mDirty = true;
+}
+
+void RenderGraph::updateDirtyFlag() { mDirty = false; }
+
 } // namespace liquid::rhi

--- a/engine/src/liquid/rhi/RenderGraph.h
+++ b/engine/src/liquid/rhi/RenderGraph.h
@@ -18,13 +18,6 @@ public:
   RenderGraphPass &addPass(StringView name);
 
   /**
-   * @brief Get swapchain handle
-   *
-   * @return Swapchain handle
-   */
-  inline TextureHandle getSwapchain() const { return mSwapchain; }
-
-  /**
    * @brief Compile pass
    *
    * @return List of indexes that point to passes
@@ -39,19 +32,38 @@ public:
   inline std::vector<RenderGraphPass> &getPasses() { return mPasses; }
 
   /**
-   * @brief Check if texture is swapchain
+   * @brief Set framebuffer extent
    *
-   * @param handle Texture handle
-   * @retval true Texture is swapchain
-   * @retval false Texture is not swapchain
+   * @param framebufferExtent Framebuffer extent
    */
-  inline bool isSwapchain(TextureHandle handle) const {
-    return handle == mSwapchain;
+  void setFramebufferExtent(glm::uvec2 framebufferExtent);
+
+  /**
+   * @brief Get framebuffer extent
+   *
+   * @return Framebuffer extent
+   */
+  inline const glm::uvec2 &getFramebufferExtent() const {
+    return mFramebufferExtent;
   }
+
+  /**
+   * @brief Check if recreate is necessary
+   *
+   * @retval true Passes have changed
+   * @retval false Passes have not changed
+   */
+  inline bool isDirty() const { return mDirty; }
+
+  /**
+   * @brief Update dirty flag
+   */
+  void updateDirtyFlag();
 
 private:
   std::vector<RenderGraphPass> mPasses;
-  TextureHandle mSwapchain{1};
+  glm::uvec2 mFramebufferExtent{};
+  bool mDirty = false;
 };
 
 } // namespace liquid::rhi

--- a/engine/src/liquid/rhi/RenderGraphEvaluator.h
+++ b/engine/src/liquid/rhi/RenderGraphEvaluator.h
@@ -33,13 +33,8 @@ public:
    *
    * @param sorted Topologically sorted passes
    * @param graph Render graph
-   * @param swapchainRecreated Rebuild swapchain related passes
-   * @param numSwapchainImages Number of swapchain images
-   * @param extent Swapchain extent
    */
-  void build(std::vector<size_t> &sorted, RenderGraph &graph,
-             bool swapchainRecreated, uint32_t numSwapchainImages,
-             const glm::uvec2 &extent);
+  void build(std::vector<size_t> &sorted, RenderGraph &graph);
 
   /**
    * @brief Execute render graph
@@ -47,18 +42,9 @@ public:
    * @param commandList Command list
    * @param passes Topologically sorted passes
    * @param graph Render graph
-   * @param imageIdx Swapchain image index
    */
   void execute(RenderCommandList &commandList,
-               const std::vector<size_t> &passes, RenderGraph &graph,
-               uint32_t imageIdx);
-
-  /**
-   * @brief Get resource registry
-   *
-   * @return Resouce registry
-   */
-  inline ResourceRegistry &getRegistry() { return mRegistry; }
+               const std::vector<size_t> &passes, RenderGraph &graph);
 
 private:
   /**
@@ -67,24 +53,8 @@ private:
    * @param index Render pass index
    * @param graph Render graph
    * @param force Force build even if the pass resources exist
-   * @param numSwapchainImages Number of swapchain images
-   * @param extent Swapchain extent
    */
-  void buildPass(size_t index, RenderGraph &graph, bool force,
-                 uint32_t numSwapchainImages, const glm::uvec2 &extent);
-
-  /**
-   * @brief Create swapchain attachment
-   *
-   * @param attachment Attachment description
-   * @param numSwapchainAttachments Number of swapchain attachments
-   * @param extent Swapchain extent
-   * @return Attachment info
-   */
-  RenderPassAttachmentInfo
-  createSwapchainAttachment(const AttachmentData &attachment,
-                            uint32_t numSwapchainAttachments,
-                            const glm::uvec2 &extent);
+  void buildPass(size_t index, RenderGraph &graph, bool force);
 
   /**
    * @brief Create color attachment

--- a/engine/src/liquid/rhi/RenderGraphPass.h
+++ b/engine/src/liquid/rhi/RenderGraphPass.h
@@ -124,13 +124,11 @@ public:
   }
 
   /**
-   * @brief Get framebuffers
+   * @brief Get framebuffer
    *
-   * @return Framebuffers
+   * @return Framebuffer
    */
-  inline const std::vector<FramebufferHandle> &getFramebuffers() const {
-    return mFramebuffers;
-  }
+  inline FramebufferHandle getFramebuffer() const { return mFramebuffer; }
 
   /**
    * @brief Get dimensions
@@ -147,7 +145,7 @@ private:
   ExecutorFn mExecutor;
 
   rhi::RenderPassHandle mRenderPass = rhi::RenderPassHandle::Invalid;
-  std::vector<FramebufferHandle> mFramebuffers;
+  FramebufferHandle mFramebuffer = rhi::FramebufferHandle::Invalid;
   glm::uvec3 mDimensions{};
 
   String mName;

--- a/engine/src/liquid/rhi/Swapchain.h
+++ b/engine/src/liquid/rhi/Swapchain.h
@@ -1,0 +1,20 @@
+#pragma once
+
+namespace liquid::rhi {
+
+/**
+ * @brief Platform agnostic swapchain details
+ */
+struct Swapchain {
+  /**
+   * @brief Swapchain textures
+   */
+  std::vector<TextureHandle> textures{};
+
+  /**
+   * @brief Swapchain extent
+   */
+  glm::uvec2 extent{};
+};
+
+} // namespace liquid::rhi

--- a/engine/src/liquid/rhi/TextureDescription.h
+++ b/engine/src/liquid/rhi/TextureDescription.h
@@ -4,7 +4,7 @@ namespace liquid::rhi {
 
 enum class TextureType { Standard, Cubemap };
 
-enum class TextureSizeMethod { Fixed, SwapchainRatio };
+enum class TextureSizeMethod { Fixed, FramebufferRatio };
 
 enum class TextureUsage : uint8_t {
   None = 0,

--- a/engine/src/liquid/rhi/vulkan/VulkanCommandBuffer.h
+++ b/engine/src/liquid/rhi/vulkan/VulkanCommandBuffer.h
@@ -149,13 +149,6 @@ public:
    */
   void setScissor(const glm::ivec2 &offset, const glm::uvec2 &size) override;
 
-  /**
-   * @brief Get Vulkan command buffer handle
-   *
-   * @return Vulkan command buffer handle
-   */
-  inline VkCommandBuffer getVulkanHandle() { return mCommandBuffer; }
-
 private:
   VkCommandBuffer mCommandBuffer = VK_NULL_HANDLE;
 

--- a/engine/src/liquid/rhi/vulkan/VulkanRenderBackend.h
+++ b/engine/src/liquid/rhi/vulkan/VulkanRenderBackend.h
@@ -8,12 +8,6 @@
 
 #include "liquid/window/Window.h"
 
-#ifdef LIQUID_DEBUG
-constexpr bool ENABLE_VALIDATIONS_DEFAULT = true;
-#else
-constexpr bool ENABLE_VALIDATIONS_DEFAULT = false;
-#endif
-
 namespace liquid::rhi {
 
 class VulkanRenderDevice;
@@ -32,8 +26,7 @@ public:
    * @param window Window
    * @param enableValidations Enable validations
    */
-  VulkanRenderBackend(Window &window,
-                      bool enableValidations = ENABLE_VALIDATIONS_DEFAULT);
+  VulkanRenderBackend(Window &window, bool enableValidations = true);
 
   VulkanRenderBackend(const VulkanRenderBackend &) = delete;
   VulkanRenderBackend &operator=(const VulkanRenderBackend &) = delete;

--- a/engine/src/liquid/rhi/vulkan/VulkanRenderDevice.h
+++ b/engine/src/liquid/rhi/vulkan/VulkanRenderDevice.h
@@ -37,20 +37,14 @@ public:
    *
    * @return Frame index
    */
-  uint32_t beginFrame() override;
+  RenderFrame beginFrame() override;
 
   /**
    * @brief End frame
-   */
-  void endFrame() override;
-
-  /**
-   * @brief Execute render graph
    *
-   * @param graph Render graph
-   * @param evaluator Render graph evaluator
+   * @param renderFrame Render frame
    */
-  void execute(RenderGraph &graph, RenderGraphEvaluator &evaluator) override;
+  void endFrame(const RenderFrame &renderFrame) override;
 
   /**
    * @brief Wait for idle
@@ -67,6 +61,20 @@ public:
   }
 
   /**
+   * @brief Destroy all resources in the device
+   *
+   * This does not destroy the device
+   */
+  void destroyResources() override;
+
+  /**
+   * @brief Get swapchain
+   *
+   * @return Swapchain
+   */
+  Swapchain getSwapchain() override;
+
+  /**
    * @brief Get device stats
    *
    * @return Device stats
@@ -74,11 +82,11 @@ public:
   const DeviceStats &getDeviceStats() const override { return mStats; }
 
   /**
-   * @brief Destroy all resources in the device
+   * @brief Synchronize resources
    *
-   * This does not destroy the device
+   * @param registry Resource registry
    */
-  void destroyResources() override;
+  void synchronize(ResourceRegistry &registry) override;
 
 private:
   /**
@@ -87,18 +95,9 @@ private:
   void recreateSwapchain();
 
   /**
-   * @brief Synchronize swapchain images
-   *
-   * @param prevNumSwapchainImages Previous swapchain image count
+   * @brief Update framebuffer relative textures
    */
-  void synchronizeSwapchain(size_t prevNumSwapchainImages);
-
-  /**
-   * @brief Synchronize resources
-   *
-   * @param registry Resource registry
-   */
-  void synchronize(ResourceRegistry &registry);
+  void updateFramebufferRelativeTextures();
 
 private:
   DeviceStats mStats;

--- a/engine/src/liquid/rhi/vulkan/VulkanResourceRegistry.cpp
+++ b/engine/src/liquid/rhi/vulkan/VulkanResourceRegistry.cpp
@@ -29,7 +29,7 @@ void VulkanResourceRegistry::deleteBuffer(BufferHandle handle) {
 
 void VulkanResourceRegistry::setTexture(
     TextureHandle handle, std::unique_ptr<VulkanTexture> &&texture) {
-  if (texture->isSwapchainRelative()) {
+  if (texture->isFramebufferRelative()) {
     mSwapchainRelativeTextures.insert(handle);
   }
 
@@ -45,7 +45,7 @@ void VulkanResourceRegistry::deleteDanglingSwapchainRelativeTextures() {
        it != mSwapchainRelativeTextures.end(); ++it) {
     auto textureIt = mTextures.find(*it);
     if (textureIt == mTextures.end() ||
-        !textureIt->second->isSwapchainRelative()) {
+        !textureIt->second->isFramebufferRelative()) {
       it = mSwapchainRelativeTextures.erase(it);
     }
   }

--- a/engine/src/liquid/rhi/vulkan/VulkanTexture.cpp
+++ b/engine/src/liquid/rhi/vulkan/VulkanTexture.cpp
@@ -49,7 +49,7 @@ VulkanTexture::VulkanTexture(const TextureDescription &description,
   static constexpr uint32_t HUNDRED_PERCENT = 100;
 
   VkExtent3D extent{};
-  if (isSwapchainRelative()) {
+  if (isFramebufferRelative()) {
     extent.width = description.width * swapchainExtent.x / HUNDRED_PERCENT;
     extent.height = description.height * swapchainExtent.y / HUNDRED_PERCENT;
   } else {

--- a/engine/src/liquid/rhi/vulkan/VulkanTexture.h
+++ b/engine/src/liquid/rhi/vulkan/VulkanTexture.h
@@ -90,13 +90,13 @@ public:
   inline VkFormat getFormat() const { return mFormat; }
 
   /**
-   * @brief Check if texture resizes with swapchain
+   * @brief Check if texture resizes with framebuffer
    *
-   * @retval true Texture resizes with swapchain
-   * @retval false Texture does not resize with swapchain
+   * @retval true Texture resizes with framebuffer
+   * @retval false Texture does not resize with framebuffer
    */
-  inline bool isSwapchainRelative() const {
-    return mDescription.sizeMethod == TextureSizeMethod::SwapchainRatio;
+  inline bool isFramebufferRelative() const {
+    return mDescription.sizeMethod == TextureSizeMethod::FramebufferRatio;
   }
 
   /**

--- a/engine/tests/rhi/RenderGraph.test.cpp
+++ b/engine/tests/rhi/RenderGraph.test.cpp
@@ -41,7 +41,7 @@ TEST_F(RenderGraphTest, TopologicallySortRenderGraph) {
       {"b-g", TextureHandle(6)},  {"h-c", TextureHandle(7)},
       {"c-e", TextureHandle(8)},  {"d-e", TextureHandle(9)},
       {"d-g", TextureHandle(10)}, {"e-f", TextureHandle(11)},
-      {"f-g", TextureHandle(12)}};
+      {"f-g", TextureHandle(12)}, {"final-color", TextureHandle(13)}};
 
   {
     auto &pass = graph.addPass("A");
@@ -90,7 +90,7 @@ TEST_F(RenderGraphTest, TopologicallySortRenderGraph) {
     pass.read(handles.at("f-g"));
     pass.read(handles.at("d-g"));
     pass.read(handles.at("b-g"));
-    pass.write(graph.getSwapchain(), glm::vec4());
+    pass.write(handles.at("final-color"), glm::vec4());
   }
 
   {


### PR DESCRIPTION
- Create texture handles during swapchain creation
- Retrieve swapchain details from device
- Retrieve command list and image index when beginning the frame
- Remove swapchain from render graph
- Remove execute function from render device
- Add presenter that draws any image using a full screen quad
- Enable validation warnings in all environments
- Set framebuffer size in render graph
- Simplify graph evaluator build function
- Rename SwapchainRatio to FramebufferRatio
- Add resize handler to resize the render graph in all screens