### PR TITLE
Add barriers around render passes

### DIFF
--- a/editor/src/screens/EditorScreen.cpp
+++ b/editor/src/screens/EditorScreen.cpp
@@ -126,12 +126,13 @@ void EditorScreen::start(const Project &project) {
     graph.setFramebufferExtent({width, height});
   });
 
-  constexpr glm::vec4 BLUEISH_CLEAR_VALUE{0.19f, 0.21f, 0.26f, 1.0f};
-  auto &pass = editorRenderer.attach(graph);
-  pass.read(scenePassGroup.sceneColor);
-  pass.write(scenePassGroup.sceneColor, BLUEISH_CLEAR_VALUE);
-  pass.write(scenePassGroup.depthBuffer,
-             liquid::rhi::DepthStencilClear{1.0f, 0});
+  {
+    constexpr glm::vec4 BLUEISH_CLEAR_VALUE{0.19f, 0.21f, 0.26f, 1.0f};
+    auto &pass = editorRenderer.attach(graph);
+    pass.write(scenePassGroup.sceneColor, BLUEISH_CLEAR_VALUE);
+    pass.write(scenePassGroup.depthBuffer,
+               liquid::rhi::DepthStencilClear{1.0f, 0});
+  }
 
   mainLoop.setUpdateFn([&editorCamera, &animationSystem, &physicsSystem,
                         &entityManager, &aspectRatioUpdater, &skeletonUpdater,

--- a/engine/src/liquid/renderer/Presenter.cpp
+++ b/engine/src/liquid/renderer/Presenter.cpp
@@ -80,6 +80,20 @@ void Presenter::updateFramebuffers(const rhi::Swapchain &swapchain) {
 
 void Presenter::present(rhi::RenderCommandList &commandList,
                         rhi::TextureHandle handle, uint32_t imageIndex) {
+
+  {
+    rhi::ImageBarrier imageBarrier;
+    imageBarrier.srcLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
+    imageBarrier.dstLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
+    imageBarrier.srcAccess = VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT;
+    imageBarrier.dstAccess = VK_ACCESS_SHADER_READ_BIT;
+    imageBarrier.texture = handle;
+
+    commandList.pipelineBarrier(VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT,
+                                VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT, {},
+                                {imageBarrier});
+  }
+
   commandList.beginRenderPass(
       mPresentPass, mFramebuffers.at(imageIndex % mFramebuffers.size()), {0, 0},
       mExtent);
@@ -96,6 +110,19 @@ void Presenter::present(rhi::RenderCommandList &commandList,
   commandList.draw(3, 0);
 
   commandList.endRenderPass();
+
+  {
+    rhi::ImageBarrier imageBarrier;
+    imageBarrier.srcLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
+    imageBarrier.dstLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
+    imageBarrier.texture = handle;
+    imageBarrier.srcAccess = VK_ACCESS_SHADER_READ_BIT;
+    imageBarrier.dstAccess = VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT;
+
+    commandList.pipelineBarrier(VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT,
+                                VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT,
+                                {}, {imageBarrier});
+  }
 }
 
 } // namespace liquid

--- a/engine/src/liquid/renderer/Renderer.cpp
+++ b/engine/src/liquid/renderer/Renderer.cpp
@@ -22,12 +22,12 @@ Renderer::Renderer(AssetRegistry &assetRegistry, Window &window,
 void Renderer::render(rhi::RenderGraph &graph,
                       rhi::RenderCommandList &commandList) {
 
-  auto &&compiled = graph.compile();
+  graph.compile(mRegistry);
 
-  mGraphEvaluator.build(compiled, graph);
+  mGraphEvaluator.build(graph);
 
   mDevice->synchronize(mRegistry);
-  mGraphEvaluator.execute(commandList, compiled, graph);
+  mGraphEvaluator.execute(commandList, graph);
 }
 
 } // namespace liquid

--- a/engine/src/liquid/rhi/PipelineBarrier.h
+++ b/engine/src/liquid/rhi/PipelineBarrier.h
@@ -1,0 +1,53 @@
+#pragma once
+
+#include <vulkan/vulkan.h>
+#include "RenderHandle.h"
+
+namespace liquid::rhi {
+
+/**
+ * @brief Memory barrier
+ */
+struct MemoryBarrier {
+  /**
+   * @brief Source access flags
+   */
+  VkAccessFlags srcAccess = VK_ACCESS_NONE_KHR;
+
+  /**
+   * @brief Destination access flags
+   */
+  VkAccessFlags dstAccess = VK_ACCESS_NONE_KHR;
+};
+
+/**
+ * @brief Image barrier
+ */
+struct ImageBarrier {
+  /**
+   * @brief Source access flags
+   */
+  VkAccessFlags srcAccess = VK_ACCESS_NONE_KHR;
+
+  /**
+   * @brief Destination access flags
+   */
+  VkAccessFlags dstAccess = VK_ACCESS_NONE_KHR;
+
+  /**
+   * @brief Source image layout
+   */
+  VkImageLayout srcLayout = VK_IMAGE_LAYOUT_MAX_ENUM;
+
+  /**
+   * @brief Destination image layout
+   */
+  VkImageLayout dstLayout = VK_IMAGE_LAYOUT_MAX_ENUM;
+
+  /**
+   * @brief Texture
+   */
+  TextureHandle texture = TextureHandle::Invalid;
+};
+
+} // namespace liquid::rhi

--- a/engine/src/liquid/rhi/RenderCommandList.h
+++ b/engine/src/liquid/rhi/RenderCommandList.h
@@ -192,6 +192,22 @@ public:
     mNativeRenderCommandList->setScissor(offset, size);
   }
 
+  /**
+   * @brief Pipeline barrier
+   *
+   * @param srcStage Source pipeline stage
+   * @param dstStage Destination pipeline stage
+   * @param memoryBarriers Memory barriers
+   * @param imageBarriers Image barriers
+   */
+  void pipelineBarrier(VkPipelineStageFlags srcStage,
+                       VkPipelineStageFlags dstStage,
+                       const std::vector<MemoryBarrier> &memoryBarriers,
+                       const std::vector<ImageBarrier> &imageBarriers) {
+    mNativeRenderCommandList->pipelineBarrier(srcStage, dstStage,
+                                              memoryBarriers, imageBarriers);
+  }
+
 private:
   std::unique_ptr<NativeRenderCommandListInterface> mNativeRenderCommandList;
 };

--- a/engine/src/liquid/rhi/RenderGraph.h
+++ b/engine/src/liquid/rhi/RenderGraph.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "RenderGraphPass.h"
+#include "ResourceRegistry.h"
 
 namespace liquid::rhi {
 
@@ -18,11 +19,14 @@ public:
   RenderGraphPass &addPass(StringView name);
 
   /**
-   * @brief Compile pass
+   * @brief Compile render graph
    *
-   * @return List of indexes that point to passes
+   * Topologically sorts and updates render
+   * passes in place
+   *
+   * @param resourceRegistry Resource registry
    */
-  std::vector<size_t> compile();
+  void compile(ResourceRegistry &resourceRegistry);
 
   /**
    * @brief Get passes
@@ -30,6 +34,15 @@ public:
    * @return Render graph passes
    */
   inline std::vector<RenderGraphPass> &getPasses() { return mPasses; }
+
+  /**
+   * @brief Get compiled passes
+   *
+   * @return Compiled render graph passes
+   */
+  inline std::vector<RenderGraphPass> &getCompiledPasses() {
+    return mCompiledPasses;
+  }
 
   /**
    * @brief Set framebuffer extent
@@ -62,8 +75,10 @@ public:
 
 private:
   std::vector<RenderGraphPass> mPasses;
+  std::vector<RenderGraphPass> mCompiledPasses;
+
   glm::uvec2 mFramebufferExtent{};
-  bool mDirty = false;
+  bool mDirty = true;
 };
 
 } // namespace liquid::rhi

--- a/engine/src/liquid/rhi/RenderGraphEvaluator.h
+++ b/engine/src/liquid/rhi/RenderGraphEvaluator.h
@@ -29,22 +29,19 @@ public:
   RenderGraphEvaluator(ResourceRegistry &registry);
 
   /**
-   * @brief Build passes
+   * @brief Build render graph
    *
-   * @param sorted Topologically sorted passes
    * @param graph Render graph
    */
-  void build(std::vector<size_t> &sorted, RenderGraph &graph);
+  void build(RenderGraph &graph);
 
   /**
    * @brief Execute render graph
    *
    * @param commandList Command list
-   * @param passes Topologically sorted passes
    * @param graph Render graph
    */
-  void execute(RenderCommandList &commandList,
-               const std::vector<size_t> &passes, RenderGraph &graph);
+  void execute(RenderCommandList &commandList, RenderGraph &graph);
 
 private:
   /**
@@ -57,28 +54,16 @@ private:
   void buildPass(size_t index, RenderGraph &graph, bool force);
 
   /**
-   * @brief Create color attachment
+   * @brief Create attachment
    *
    * @param attachment Attachment description
-   * @param texture Texture
+   * @param renderTarget Render target data
    * @param extent Swapchain extent
    * @return Attachment info
    */
-  RenderPassAttachmentInfo
-  createColorAttachment(const AttachmentData &attachment, TextureHandle texture,
-                        const glm::uvec2 &extent);
-
-  /**
-   * @brief Create depth attachment
-   *
-   * @param attachment Attachment description
-   * @param texture Texture
-   * @param extent Swapchain extent
-   * @return Attachment info
-   */
-  RenderPassAttachmentInfo
-  createDepthAttachment(const AttachmentData &attachment, TextureHandle texture,
-                        const glm::uvec2 &extent);
+  RenderPassAttachmentInfo createAttachment(const AttachmentData &attachment,
+                                            RenderTargetData &renderTarget,
+                                            const glm::uvec2 &extent);
 
   /**
    * @brief Check if pass is has swapchain relative resources

--- a/engine/src/liquid/rhi/RenderGraphPass.cpp
+++ b/engine/src/liquid/rhi/RenderGraphPass.cpp
@@ -7,11 +7,13 @@ RenderGraphPass::RenderGraphPass(StringView name) : mName(name) {}
 
 void RenderGraphPass::write(TextureHandle handle,
                             const AttachmentClearValue &clearValue) {
-  mOutputs.push_back(handle);
+  mOutputs.push_back({handle});
   mAttachments.push_back({clearValue});
 }
 
-void RenderGraphPass::read(TextureHandle handle) { mInputs.push_back(handle); }
+void RenderGraphPass::read(TextureHandle handle) {
+  mInputs.push_back({handle});
+}
 
 void RenderGraphPass::setExecutor(const ExecutorFn &executor) {
   mExecutor = executor;

--- a/engine/src/liquid/rhi/RenderGraphPass.h
+++ b/engine/src/liquid/rhi/RenderGraphPass.h
@@ -31,6 +31,56 @@ struct AttachmentData {
 };
 
 /**
+ * @brief Render target data
+ */
+struct RenderTargetData {
+  /**
+   * Texture
+   */
+  TextureHandle texture = TextureHandle::Invalid;
+
+  /**
+   * Source image layout
+   */
+  VkImageLayout srcLayout = VK_IMAGE_LAYOUT_MAX_ENUM;
+
+  /**
+   * Destination image layout
+   */
+  VkImageLayout dstLayout = VK_IMAGE_LAYOUT_MAX_ENUM;
+};
+
+/**
+ * @brief Render graph pass barrier
+ */
+struct RenderGraphPassBarrier {
+  /**
+   * Barrier active
+   */
+  bool enabled = false;
+
+  /**
+   * Source pipeline stage
+   */
+  VkPipelineStageFlags srcStage = VK_PIPELINE_STAGE_NONE_KHR;
+
+  /**
+   * Destination pipeline stage
+   */
+  VkPipelineStageFlags dstStage = VK_PIPELINE_STAGE_NONE_KHR;
+
+  /**
+   * Memory barriers
+   */
+  std::vector<MemoryBarrier> memoryBarriers;
+
+  /**
+   * Image barriers
+   */
+  std::vector<ImageBarrier> imageBarriers;
+};
+
+/**
  * @brief Render graph pass
  */
 class RenderGraphPass {
@@ -45,6 +95,41 @@ public:
    * @param name Pass name
    */
   RenderGraphPass(StringView name);
+
+  /**
+   * @brief Copy another render pass into this
+   *
+   * @param rhs Render pass to copy
+   */
+  RenderGraphPass(const RenderGraphPass &rhs) = default;
+
+  /**
+   * @brief Copy another render pass into this
+   *
+   * @param rhs Render pass to copy
+   * @return This render pass
+   */
+  RenderGraphPass &operator=(const RenderGraphPass &rhs) = default;
+
+  /**
+   * @brief Move another render pass into this
+   *
+   * @param rhs Render pass to move
+   */
+  RenderGraphPass(RenderGraphPass &&rhs) = default;
+
+  /**
+   * @brief Move another render pass into this
+   *
+   * @param rhs Render pass to move
+   * @return This render pass
+   */
+  RenderGraphPass &operator=(RenderGraphPass &&rhs) = default;
+
+  /**
+   * @brief Destroy render pass
+   */
+  ~RenderGraphPass() = default;
 
   /**
    * @brief Execute pass
@@ -92,16 +177,18 @@ public:
   /**
    * @brief Get input textures
    *
-   * @return Input textures
+   * @return Input render targets
    */
-  inline const std::vector<TextureHandle> &getInputs() const { return mInputs; }
+  inline const std::vector<RenderTargetData> &getInputs() const {
+    return mInputs;
+  }
 
   /**
    * @brief Get output textures
    *
-   * @return Output textures
+   * @return Output render targets
    */
-  inline const std::vector<TextureHandle> &getOutputs() const {
+  inline const std::vector<RenderTargetData> &getOutputs() const {
     return mOutputs;
   }
 
@@ -137,11 +224,33 @@ public:
    */
   inline const glm::uvec3 &getDimensions() const { return mDimensions; }
 
+  /**
+   * @brief Get pass pre barrier
+   *
+   * @return Pass pre barrier
+   */
+  inline const RenderGraphPassBarrier &getPreBarrier() const {
+    return mPreBarrier;
+  }
+
+  /**
+   * @brief Get pass pre barrier
+   *
+   * @return Pass pre barrier
+   */
+  inline const RenderGraphPassBarrier &getPostBarrier() const {
+    return mPostBarrier;
+  }
+
 private:
   std::vector<AttachmentData> mAttachments;
-  std::vector<TextureHandle> mOutputs;
-  std::vector<TextureHandle> mInputs;
+  std::vector<RenderTargetData> mOutputs;
+  std::vector<RenderTargetData> mInputs;
   std::vector<PipelineHandle> mPipelines;
+
+  RenderGraphPassBarrier mPreBarrier;
+  RenderGraphPassBarrier mPostBarrier;
+
   ExecutorFn mExecutor;
 
   rhi::RenderPassHandle mRenderPass = rhi::RenderPassHandle::Invalid;

--- a/engine/src/liquid/rhi/RenderPassDescription.h
+++ b/engine/src/liquid/rhi/RenderPassDescription.h
@@ -46,6 +46,11 @@ struct RenderPassAttachmentDescription {
   TextureHandle texture = TextureHandle::Invalid;
 
   /**
+   * Attachment image initial layout
+   */
+  VkImageLayout initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+
+  /**
    * Attachment image layout
    */
   VkImageLayout layout = VK_IMAGE_LAYOUT_MAX_ENUM;

--- a/engine/src/liquid/rhi/base/NativeRenderCommandListInterface.h
+++ b/engine/src/liquid/rhi/base/NativeRenderCommandListInterface.h
@@ -2,6 +2,7 @@
 
 #include "liquid/rhi/Descriptor.h"
 #include "liquid/rhi/RenderHandle.h"
+#include "liquid/rhi/PipelineBarrier.h"
 
 #include <vulkan/vulkan.hpp>
 
@@ -135,6 +136,19 @@ public:
    * @param size Scissor size
    */
   virtual void setScissor(const glm::ivec2 &offset, const glm::uvec2 &size) = 0;
+
+  /**
+   * @brief Pipeline barrier
+   *
+   * @param srcStage Source pipeline stage
+   * @param dstStage Destination pipeline stage
+   * @param memoryBarriers Memory barriers
+   * @param imageBarriers Image barriers
+   */
+  virtual void
+  pipelineBarrier(VkPipelineStageFlags srcStage, VkPipelineStageFlags dstStage,
+                  const std::vector<MemoryBarrier> &memoryBarriers,
+                  const std::vector<ImageBarrier> &imageBarriers) = 0;
 };
 
 } // namespace liquid::rhi

--- a/engine/src/liquid/rhi/vulkan/VulkanCommandBuffer.h
+++ b/engine/src/liquid/rhi/vulkan/VulkanCommandBuffer.h
@@ -149,6 +149,19 @@ public:
    */
   void setScissor(const glm::ivec2 &offset, const glm::uvec2 &size) override;
 
+  /**
+   * @brief Pipeline barrier
+   *
+   * @param srcStage Source pipeline stage
+   * @param dstStage Destination pipeline stage
+   * @param memoryBarriers Memory barriers
+   * @param imageBarriers Image barriers
+   */
+  void pipelineBarrier(VkPipelineStageFlags srcStage,
+                       VkPipelineStageFlags dstStage,
+                       const std::vector<MemoryBarrier> &memoryBarriers,
+                       const std::vector<ImageBarrier> &imageBarriers) override;
+
 private:
   VkCommandBuffer mCommandBuffer = VK_NULL_HANDLE;
 

--- a/engine/src/liquid/rhi/vulkan/VulkanRenderPass.cpp
+++ b/engine/src/liquid/rhi/vulkan/VulkanRenderPass.cpp
@@ -48,7 +48,7 @@ VulkanRenderPass::VulkanRenderPass(const RenderPassDescription &description,
       mClearValues.at(i).color.float32[3] =
           std::get<glm::vec4>(desc.clearValue).w;
 
-      attachment.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+      attachment.initialLayout = desc.initialLayout;
       attachment.finalLayout = desc.layout != VK_IMAGE_LAYOUT_MAX_ENUM
                                    ? desc.layout
                                    : VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
@@ -62,7 +62,7 @@ VulkanRenderPass::VulkanRenderPass(const RenderPassDescription &description,
       mClearValues.at(i).depthStencil.stencil =
           std::get<DepthStencilClear>(desc.clearValue).clearStencil;
 
-      attachment.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+      attachment.initialLayout = desc.initialLayout;
       attachment.finalLayout = VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL;
       ref.layout = VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL;
       depthReference.emplace(ref);

--- a/engine/src/liquid/rhi/vulkan/VulkanTexture.cpp
+++ b/engine/src/liquid/rhi/vulkan/VulkanTexture.cpp
@@ -59,16 +59,15 @@ VulkanTexture::VulkanTexture(const TextureDescription &description,
   extent.depth = description.depth;
 
   VkImageUsageFlags usageFlags = 0;
-  VkImageAspectFlags aspectFlags = 0;
 
   if ((description.usage & TextureUsage::Color) == TextureUsage::Color) {
     usageFlags |= VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT;
-    aspectFlags = VK_IMAGE_ASPECT_COLOR_BIT;
+    mAspectFlags = VK_IMAGE_ASPECT_COLOR_BIT;
   }
 
   if ((description.usage & TextureUsage::Depth) == TextureUsage::Depth) {
     usageFlags |= VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT;
-    aspectFlags = VK_IMAGE_ASPECT_DEPTH_BIT;
+    mAspectFlags = VK_IMAGE_ASPECT_DEPTH_BIT;
   }
 
   if ((description.usage & TextureUsage::Sampled) == TextureUsage::Sampled) {
@@ -111,7 +110,7 @@ VulkanTexture::VulkanTexture(const TextureDescription &description,
   imageViewCreateInfo.subresourceRange.baseArrayLayer = 0;
   imageViewCreateInfo.subresourceRange.layerCount = description.layers;
   imageViewCreateInfo.subresourceRange.levelCount = 1;
-  imageViewCreateInfo.subresourceRange.aspectMask = aspectFlags;
+  imageViewCreateInfo.subresourceRange.aspectMask = mAspectFlags;
   checkForVulkanError(
       vkCreateImageView(mDevice, &imageViewCreateInfo, nullptr, &mImageView),
       "Failed to create image view");
@@ -134,10 +133,10 @@ VulkanTexture::VulkanTexture(const TextureDescription &description,
         {rhi::BufferType::Transfer, description.size, description.data},
         mAllocator);
 
-    uploadContext.submit([extent, this, &stagingBuffer, &description,
-                          aspectFlags](VkCommandBuffer commandBuffer) {
+    uploadContext.submit([extent, this, &stagingBuffer,
+                          &description](VkCommandBuffer commandBuffer) {
       VkImageSubresourceRange range{};
-      range.aspectMask = aspectFlags;
+      range.aspectMask = mAspectFlags;
       range.baseMipLevel = 0;
       range.levelCount = 1;
       range.baseArrayLayer = 0;

--- a/engine/src/liquid/rhi/vulkan/VulkanTexture.h
+++ b/engine/src/liquid/rhi/vulkan/VulkanTexture.h
@@ -90,6 +90,13 @@ public:
   inline VkFormat getFormat() const { return mFormat; }
 
   /**
+   * @brief Get image aspect flags
+   *
+   * @return Image aspect flags
+   */
+  inline VkImageAspectFlags getImageAspectFlags() const { return mAspectFlags; }
+
+  /**
    * @brief Check if texture resizes with framebuffer
    *
    * @retval true Texture resizes with framebuffer
@@ -114,6 +121,7 @@ private:
   VkImageView mImageView = VK_NULL_HANDLE;
   VkSampler mSampler = VK_NULL_HANDLE;
   VmaAllocation mAllocation = VK_NULL_HANDLE;
+  VkImageAspectFlags mAspectFlags = VK_IMAGE_ASPECT_FLAG_BITS_MAX_ENUM;
   VulkanResourceAllocator &mAllocator;
   VulkanDeviceObject &mDevice;
   TextureDescription mDescription;

--- a/engine/src/liquid/rhi/vulkan/VulkanValidator.cpp
+++ b/engine/src/liquid/rhi/vulkan/VulkanValidator.cpp
@@ -19,6 +19,8 @@ VulkanValidator::VulkanValidator() {
       VK_DEBUG_UTILS_MESSAGE_TYPE_PERFORMANCE_BIT_EXT;
   mMessengerCreateInfo.pfnUserCallback = VulkanValidator::debugCallback;
   mMessengerCreateInfo.pUserData = nullptr;
+  mMessengerCreateInfo.flags = 0;
+  mMessengerCreateInfo.pNext = nullptr;
 }
 
 void VulkanValidator::detachFromInstance(VkInstance instance) {

--- a/engine/tests/rhi/RenderGraph.test.cpp
+++ b/engine/tests/rhi/RenderGraph.test.cpp
@@ -5,6 +5,7 @@
 
 class RenderGraphTest : public ::testing::Test {
 public:
+  liquid::rhi::ResourceRegistry resourceRegistry;
   liquid::rhi::RenderGraph graph;
 };
 
@@ -14,6 +15,21 @@ TEST_F(RenderGraphTest, AddsPass) {
   auto &pass = graph.addPass("Test");
   EXPECT_EQ(pass.getName(), "Test");
   EXPECT_EQ(graph.getPasses().at(0).getName(), "Test");
+  EXPECT_TRUE(graph.getCompiledPasses().empty());
+}
+
+TEST_F(RenderGraphTest, CompilationDoesNotMutateDefinedPasses) {
+  auto &pass = graph.addPass("Test");
+  auto &pass1 = graph.addPass("Test2");
+  auto &pass2 = graph.addPass("Test3");
+
+  graph.compile(resourceRegistry);
+
+  EXPECT_EQ(graph.getCompiledPasses().size(), 0);
+  EXPECT_EQ(graph.getPasses().size(), 3);
+  EXPECT_EQ(graph.getPasses().at(0).getName(), "Test");
+  EXPECT_EQ(graph.getPasses().at(1).getName(), "Test2");
+  EXPECT_EQ(graph.getPasses().at(2).getName(), "Test3");
 }
 
 TEST_F(RenderGraphTest, TopologicallySortRenderGraph) {
@@ -33,15 +49,19 @@ TEST_F(RenderGraphTest, TopologicallySortRenderGraph) {
   // |   +---+   +---+               |
   // +-------------------------------+
 
-  using TextureHandle = liquid::rhi::TextureHandle;
-
   std::unordered_map<liquid::String, liquid::rhi::TextureHandle> handles{
-      {"a-b", TextureHandle(2)},  {"a-d", TextureHandle(3)},
-      {"d-b", TextureHandle(4)},  {"b-c", TextureHandle(5)},
-      {"b-g", TextureHandle(6)},  {"h-c", TextureHandle(7)},
-      {"c-e", TextureHandle(8)},  {"d-e", TextureHandle(9)},
-      {"d-g", TextureHandle(10)}, {"e-f", TextureHandle(11)},
-      {"f-g", TextureHandle(12)}, {"final-color", TextureHandle(13)}};
+      {"a-b", resourceRegistry.setTexture({})},
+      {"a-d", resourceRegistry.setTexture({})},
+      {"d-b", resourceRegistry.setTexture({})},
+      {"b-c", resourceRegistry.setTexture({})},
+      {"b-g", resourceRegistry.setTexture({})},
+      {"h-c", resourceRegistry.setTexture({})},
+      {"c-e", resourceRegistry.setTexture({})},
+      {"d-e", resourceRegistry.setTexture({})},
+      {"d-g", resourceRegistry.setTexture({})},
+      {"e-f", resourceRegistry.setTexture({})},
+      {"f-g", resourceRegistry.setTexture({})},
+      {"final-color", resourceRegistry.setTexture({})}};
 
   {
     auto &pass = graph.addPass("A");
@@ -98,14 +118,14 @@ TEST_F(RenderGraphTest, TopologicallySortRenderGraph) {
     pass.write(handles.at("h-c"), glm::vec4());
   }
 
-  const auto &sortedPasses = graph.compile();
+  graph.compile(resourceRegistry);
 
   // Join sorted pass names to a string
   // for easier assertion
-  std::vector<liquid::String> names(sortedPasses.size());
-  std::transform(
-      sortedPasses.begin(), sortedPasses.end(), names.begin(),
-      [this](size_t index) { return graph.getPasses().at(index).getName(); });
+  std::vector<liquid::String> names(graph.getPasses().size());
+  std::transform(graph.getCompiledPasses().begin(),
+                 graph.getCompiledPasses().end(), names.begin(),
+                 [this](auto &pass) { return pass.getName(); });
 
   // Convert it to string for easier checking
   liquid::String output = "";
@@ -119,46 +139,557 @@ TEST_F(RenderGraphTest, TopologicallySortRenderGraph) {
   EXPECT_EQ(output, "A D B H C E F G");
 }
 
-TEST_F(RenderGraphTest, SetsPassLoadOperations) {
-  liquid::rhi::TextureHandle handle{2};
+TEST_F(RenderGraphTest, SetsPassAttachmentOperations) {
+  auto handle = resourceRegistry.setTexture({});
 
   graph.addPass("A").write(handle, glm::vec4());
   graph.addPass("B").write(handle, glm::vec4());
   graph.addPass("C").write(handle, glm::vec4());
 
-  const auto &sortedPasses = graph.compile();
+  graph.compile(resourceRegistry);
 
-  EXPECT_EQ(
-      graph.getPasses().at(sortedPasses.at(0)).getAttachments().at(0).loadOp,
-      liquid::rhi::AttachmentLoadOp::Clear);
-  EXPECT_EQ(
-      graph.getPasses().at(sortedPasses.at(0)).getAttachments().at(0).storeOp,
-      liquid::rhi::AttachmentStoreOp::Store);
+  EXPECT_EQ(graph.getCompiledPasses().at(0).getAttachments().at(0).loadOp,
+            liquid::rhi::AttachmentLoadOp::Clear);
+  EXPECT_EQ(graph.getCompiledPasses().at(0).getAttachments().at(0).storeOp,
+            liquid::rhi::AttachmentStoreOp::Store);
 
-  EXPECT_EQ(
-      graph.getPasses().at(sortedPasses.at(1)).getAttachments().at(0).loadOp,
-      liquid::rhi::AttachmentLoadOp::Load);
-  EXPECT_EQ(
-      graph.getPasses().at(sortedPasses.at(1)).getAttachments().at(0).storeOp,
-      liquid::rhi::AttachmentStoreOp::Store);
+  EXPECT_EQ(graph.getCompiledPasses().at(1).getAttachments().at(0).loadOp,
+            liquid::rhi::AttachmentLoadOp::Load);
+  EXPECT_EQ(graph.getCompiledPasses().at(1).getAttachments().at(0).storeOp,
+            liquid::rhi::AttachmentStoreOp::Store);
 
-  EXPECT_EQ(
-      graph.getPasses().at(sortedPasses.at(2)).getAttachments().at(0).loadOp,
-      liquid::rhi::AttachmentLoadOp::Load);
-  EXPECT_EQ(
-      graph.getPasses().at(sortedPasses.at(2)).getAttachments().at(0).storeOp,
-      liquid::rhi::AttachmentStoreOp::Store);
+  EXPECT_EQ(graph.getCompiledPasses().at(2).getAttachments().at(0).loadOp,
+            liquid::rhi::AttachmentLoadOp::Load);
+  EXPECT_EQ(graph.getCompiledPasses().at(2).getAttachments().at(0).storeOp,
+            liquid::rhi::AttachmentStoreOp::Store);
+}
+
+TEST_F(RenderGraphTest, SetsOutputImageLayouts) {
+  using TextureDescription = liquid::rhi::TextureDescription;
+  using TextureUsage = liquid::rhi::TextureUsage;
+  TextureDescription colorDescription{};
+  colorDescription.usage = TextureUsage::Color;
+  auto colorTexture = resourceRegistry.setTexture(colorDescription);
+
+  TextureDescription depthDescription{};
+  depthDescription.usage = TextureUsage::Depth;
+  auto depthTexture = resourceRegistry.setTexture(depthDescription);
+
+  {
+    auto &pass = graph.addPass("A");
+    pass.write(colorTexture, glm::vec4{});
+    pass.write(depthTexture, glm::vec4{});
+  }
+
+  {
+    auto &pass = graph.addPass("B");
+    pass.write(depthTexture, {});
+    pass.write(colorTexture, {});
+  }
+
+  graph.compile(resourceRegistry);
+
+  EXPECT_EQ(graph.getCompiledPasses().at(0).getOutputs().at(0).srcLayout,
+            VK_IMAGE_LAYOUT_UNDEFINED);
+  EXPECT_EQ(graph.getCompiledPasses().at(0).getOutputs().at(0).dstLayout,
+            VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL);
+  EXPECT_EQ(graph.getCompiledPasses().at(0).getOutputs().at(1).srcLayout,
+            VK_IMAGE_LAYOUT_UNDEFINED);
+  EXPECT_EQ(graph.getCompiledPasses().at(0).getOutputs().at(1).dstLayout,
+            VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL);
+
+  EXPECT_EQ(graph.getCompiledPasses().at(1).getOutputs().at(0).srcLayout,
+            VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL);
+  EXPECT_EQ(graph.getCompiledPasses().at(1).getOutputs().at(0).dstLayout,
+            VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL);
+  EXPECT_EQ(graph.getCompiledPasses().at(1).getOutputs().at(1).srcLayout,
+            VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL);
+  EXPECT_EQ(graph.getCompiledPasses().at(1).getOutputs().at(1).dstLayout,
+            VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL);
+}
+
+TEST_F(RenderGraphTest, SetsInputImageLayouts) {
+  using TextureDescription = liquid::rhi::TextureDescription;
+  using TextureUsage = liquid::rhi::TextureUsage;
+  TextureDescription colorDescription{};
+  colorDescription.usage = TextureUsage::Color;
+  auto colorTexture = resourceRegistry.setTexture(colorDescription);
+
+  TextureDescription depthDescription{};
+  depthDescription.usage = TextureUsage::Depth;
+  auto depthTexture = resourceRegistry.setTexture(depthDescription);
+
+  {
+    auto &pass = graph.addPass("A");
+    pass.write(colorTexture, glm::vec4{});
+    pass.write(depthTexture, glm::vec4{});
+  }
+
+  {
+    auto &pass = graph.addPass("B");
+    pass.read(depthTexture);
+    pass.read(colorTexture);
+  }
+
+  graph.compile(resourceRegistry);
+
+  EXPECT_EQ(graph.getCompiledPasses().at(1).getInputs().at(0).srcLayout,
+            VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL);
+  EXPECT_EQ(graph.getCompiledPasses().at(1).getInputs().at(0).dstLayout,
+            VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
+  EXPECT_EQ(graph.getCompiledPasses().at(1).getInputs().at(1).srcLayout,
+            VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL);
+  EXPECT_EQ(graph.getCompiledPasses().at(1).getInputs().at(1).dstLayout,
+            VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
+}
+
+TEST_F(RenderGraphTest, SetsPassBarrierForColorOutput) {
+  using TextureDescription = liquid::rhi::TextureDescription;
+  using TextureUsage = liquid::rhi::TextureUsage;
+  TextureDescription colorDescription{};
+  colorDescription.usage = TextureUsage::Color;
+  auto colorTexture = resourceRegistry.setTexture(colorDescription);
+
+  {
+    auto &pass = graph.addPass("A");
+    pass.write(colorTexture, glm::vec4{});
+  }
+
+  graph.compile(resourceRegistry);
+
+  {
+    const auto &preBarrier = graph.getCompiledPasses().at(0).getPreBarrier();
+    const auto &postBarrier = graph.getCompiledPasses().at(0).getPostBarrier();
+    EXPECT_FALSE(preBarrier.enabled);
+    EXPECT_TRUE(postBarrier.enabled);
+    EXPECT_EQ(postBarrier.srcStage,
+              VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT);
+    EXPECT_EQ(postBarrier.dstStage,
+              VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT);
+    EXPECT_EQ(postBarrier.memoryBarriers.at(0).srcAccess,
+              VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT);
+    EXPECT_EQ(postBarrier.memoryBarriers.at(0).dstAccess,
+              VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT |
+                  VK_ACCESS_COLOR_ATTACHMENT_READ_BIT);
+  }
+}
+
+TEST_F(RenderGraphTest, SetsPassBarrierForDepthOutput) {
+  using TextureDescription = liquid::rhi::TextureDescription;
+  using TextureUsage = liquid::rhi::TextureUsage;
+
+  TextureDescription depthDescription{};
+  depthDescription.usage = TextureUsage::Depth;
+  auto depthTexture = resourceRegistry.setTexture(depthDescription);
+
+  {
+    auto &pass = graph.addPass("A");
+    pass.write(depthTexture, glm::vec4{});
+  }
+
+  graph.compile(resourceRegistry);
+
+  {
+    const auto &preBarrier = graph.getCompiledPasses().at(0).getPreBarrier();
+    const auto &postBarrier = graph.getCompiledPasses().at(0).getPostBarrier();
+    EXPECT_FALSE(preBarrier.enabled);
+    EXPECT_TRUE(postBarrier.enabled);
+
+    EXPECT_EQ(postBarrier.srcStage,
+              VK_PIPELINE_STAGE_EARLY_FRAGMENT_TESTS_BIT |
+                  VK_PIPELINE_STAGE_LATE_FRAGMENT_TESTS_BIT);
+    EXPECT_EQ(postBarrier.dstStage,
+              VK_PIPELINE_STAGE_EARLY_FRAGMENT_TESTS_BIT |
+                  VK_PIPELINE_STAGE_LATE_FRAGMENT_TESTS_BIT);
+    EXPECT_EQ(postBarrier.memoryBarriers.at(0).srcAccess,
+              VK_ACCESS_DEPTH_STENCIL_ATTACHMENT_WRITE_BIT);
+    EXPECT_EQ(postBarrier.memoryBarriers.at(0).dstAccess,
+              VK_ACCESS_DEPTH_STENCIL_ATTACHMENT_WRITE_BIT |
+                  VK_ACCESS_DEPTH_STENCIL_ATTACHMENT_READ_BIT);
+  }
+}
+
+TEST_F(RenderGraphTest, SetsBothBarriersFromOutputs) {
+  using TextureDescription = liquid::rhi::TextureDescription;
+  using TextureUsage = liquid::rhi::TextureUsage;
+  TextureDescription colorDescription{};
+  colorDescription.usage = TextureUsage::Color;
+  auto colorTexture = resourceRegistry.setTexture(colorDescription);
+  TextureDescription depthDescription{};
+  depthDescription.usage = TextureUsage::Depth;
+  auto depthTexture = resourceRegistry.setTexture(depthDescription);
+
+  {
+    auto &pass = graph.addPass("A");
+    pass.write(colorTexture, glm::vec4{});
+    pass.write(depthTexture, glm::vec4{});
+  }
+
+  graph.compile(resourceRegistry);
+
+  {
+    const auto &preBarrier = graph.getCompiledPasses().at(0).getPreBarrier();
+    const auto &postBarrier = graph.getCompiledPasses().at(0).getPostBarrier();
+    EXPECT_FALSE(preBarrier.enabled);
+    EXPECT_TRUE(postBarrier.enabled);
+
+    EXPECT_EQ(postBarrier.srcStage,
+              VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT |
+                  VK_PIPELINE_STAGE_EARLY_FRAGMENT_TESTS_BIT |
+                  VK_PIPELINE_STAGE_LATE_FRAGMENT_TESTS_BIT);
+    EXPECT_EQ(postBarrier.dstStage,
+              VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT |
+                  VK_PIPELINE_STAGE_EARLY_FRAGMENT_TESTS_BIT |
+                  VK_PIPELINE_STAGE_LATE_FRAGMENT_TESTS_BIT);
+    EXPECT_EQ(postBarrier.memoryBarriers.at(0).srcAccess,
+              VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT);
+    EXPECT_EQ(postBarrier.memoryBarriers.at(0).dstAccess,
+              VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT |
+                  VK_ACCESS_COLOR_ATTACHMENT_READ_BIT);
+    EXPECT_EQ(postBarrier.memoryBarriers.at(1).srcAccess,
+              VK_ACCESS_DEPTH_STENCIL_ATTACHMENT_WRITE_BIT);
+    EXPECT_EQ(postBarrier.memoryBarriers.at(1).dstAccess,
+              VK_ACCESS_DEPTH_STENCIL_ATTACHMENT_WRITE_BIT |
+                  VK_ACCESS_DEPTH_STENCIL_ATTACHMENT_READ_BIT);
+  }
+}
+
+TEST_F(RenderGraphTest, SetsPassBarrierFromColorInput) {
+  using TextureDescription = liquid::rhi::TextureDescription;
+  using TextureUsage = liquid::rhi::TextureUsage;
+  TextureDescription colorDescription{};
+  colorDescription.usage = TextureUsage::Color;
+  auto colorTexture = resourceRegistry.setTexture(colorDescription);
+
+  {
+    auto &pass = graph.addPass("A");
+    pass.write(colorTexture, glm::vec4{});
+  }
+
+  {
+    auto &pass = graph.addPass("B");
+    pass.read(colorTexture);
+  }
+
+  graph.compile(resourceRegistry);
+
+  {
+    const auto &preBarrier = graph.getCompiledPasses().at(1).getPreBarrier();
+    const auto &postBarrier = graph.getCompiledPasses().at(1).getPostBarrier();
+    EXPECT_TRUE(preBarrier.enabled);
+
+    EXPECT_EQ(preBarrier.srcStage,
+              VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT);
+    EXPECT_EQ(preBarrier.dstStage, VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT);
+    EXPECT_TRUE(preBarrier.memoryBarriers.empty());
+    EXPECT_EQ(preBarrier.imageBarriers.size(), 1);
+    EXPECT_EQ(preBarrier.imageBarriers.at(0).texture, colorTexture);
+    EXPECT_EQ(preBarrier.imageBarriers.at(0).srcLayout,
+              VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL);
+    EXPECT_EQ(preBarrier.imageBarriers.at(0).dstLayout,
+              VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
+    EXPECT_EQ(preBarrier.imageBarriers.at(0).srcAccess,
+              VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT);
+    EXPECT_EQ(preBarrier.imageBarriers.at(0).dstAccess,
+              VK_ACCESS_SHADER_READ_BIT);
+
+    EXPECT_TRUE(postBarrier.enabled);
+    EXPECT_EQ(postBarrier.srcStage, VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT);
+    EXPECT_EQ(postBarrier.dstStage,
+              VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT);
+    EXPECT_TRUE(postBarrier.memoryBarriers.empty());
+    EXPECT_EQ(postBarrier.imageBarriers.size(), 1);
+    EXPECT_EQ(postBarrier.imageBarriers.at(0).texture, colorTexture);
+    EXPECT_EQ(postBarrier.imageBarriers.at(0).srcLayout,
+              VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
+    EXPECT_EQ(postBarrier.imageBarriers.at(0).dstLayout,
+              VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL);
+    EXPECT_EQ(postBarrier.imageBarriers.at(0).srcAccess,
+              VK_ACCESS_SHADER_READ_BIT);
+    EXPECT_EQ(postBarrier.imageBarriers.at(0).dstAccess,
+              VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT);
+  }
+}
+
+TEST_F(RenderGraphTest, SetsPassBarrierFromDepthInput) {
+  using TextureDescription = liquid::rhi::TextureDescription;
+  using TextureUsage = liquid::rhi::TextureUsage;
+  TextureDescription depthDescription{};
+  depthDescription.usage = TextureUsage::Depth;
+  auto depthTexture = resourceRegistry.setTexture(depthDescription);
+
+  {
+    auto &pass = graph.addPass("A");
+    pass.write(depthTexture, glm::vec4{});
+  }
+
+  {
+    auto &pass = graph.addPass("B");
+    pass.read(depthTexture);
+  }
+
+  graph.compile(resourceRegistry);
+
+  {
+    const auto &preBarrier = graph.getCompiledPasses().at(1).getPreBarrier();
+    const auto &postBarrier = graph.getCompiledPasses().at(1).getPostBarrier();
+    EXPECT_TRUE(preBarrier.enabled);
+
+    EXPECT_EQ(preBarrier.srcStage,
+              VK_PIPELINE_STAGE_EARLY_FRAGMENT_TESTS_BIT |
+                  VK_PIPELINE_STAGE_LATE_FRAGMENT_TESTS_BIT);
+    EXPECT_EQ(preBarrier.dstStage, VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT);
+    EXPECT_TRUE(preBarrier.memoryBarriers.empty());
+    EXPECT_EQ(preBarrier.imageBarriers.size(), 1);
+    EXPECT_EQ(preBarrier.imageBarriers.at(0).texture, depthTexture);
+    EXPECT_EQ(preBarrier.imageBarriers.at(0).srcLayout,
+              VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL);
+    EXPECT_EQ(preBarrier.imageBarriers.at(0).dstLayout,
+              VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
+    EXPECT_EQ(preBarrier.imageBarriers.at(0).srcAccess,
+              VK_ACCESS_DEPTH_STENCIL_ATTACHMENT_WRITE_BIT);
+    EXPECT_EQ(preBarrier.imageBarriers.at(0).dstAccess,
+              VK_ACCESS_SHADER_READ_BIT);
+
+    EXPECT_TRUE(postBarrier.enabled);
+    EXPECT_EQ(postBarrier.srcStage, VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT);
+    EXPECT_EQ(postBarrier.dstStage,
+              VK_PIPELINE_STAGE_EARLY_FRAGMENT_TESTS_BIT |
+                  VK_PIPELINE_STAGE_LATE_FRAGMENT_TESTS_BIT);
+    EXPECT_TRUE(postBarrier.memoryBarriers.empty());
+    EXPECT_EQ(postBarrier.imageBarriers.size(), 1);
+    EXPECT_EQ(postBarrier.imageBarriers.at(0).texture, depthTexture);
+    EXPECT_EQ(postBarrier.imageBarriers.at(0).srcLayout,
+              VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
+    EXPECT_EQ(postBarrier.imageBarriers.at(0).dstLayout,
+              VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL);
+    EXPECT_EQ(postBarrier.imageBarriers.at(0).srcAccess,
+              VK_ACCESS_SHADER_READ_BIT);
+    EXPECT_EQ(postBarrier.imageBarriers.at(0).dstAccess,
+              VK_ACCESS_DEPTH_STENCIL_ATTACHMENT_WRITE_BIT);
+  }
+}
+
+TEST_F(RenderGraphTest, SetsPassBarrierFromBothColorAndDepthInputs) {
+  using TextureDescription = liquid::rhi::TextureDescription;
+  using TextureUsage = liquid::rhi::TextureUsage;
+  TextureDescription colorDescription{};
+  colorDescription.usage = TextureUsage::Color;
+  auto colorTexture = resourceRegistry.setTexture(colorDescription);
+  TextureDescription depthDescription{};
+  depthDescription.usage = TextureUsage::Depth;
+  auto depthTexture = resourceRegistry.setTexture(depthDescription);
+
+  {
+    auto &pass = graph.addPass("A");
+    pass.write(colorTexture, glm::vec4{});
+    pass.write(depthTexture, glm::vec4{});
+  }
+
+  {
+    auto &pass = graph.addPass("B");
+    pass.read(colorTexture);
+    pass.read(depthTexture);
+  }
+
+  graph.compile(resourceRegistry);
+
+  {
+    const auto &preBarrier = graph.getCompiledPasses().at(1).getPreBarrier();
+    const auto &postBarrier = graph.getCompiledPasses().at(1).getPostBarrier();
+    EXPECT_TRUE(preBarrier.enabled);
+
+    EXPECT_EQ(preBarrier.srcStage,
+              VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT |
+                  VK_PIPELINE_STAGE_EARLY_FRAGMENT_TESTS_BIT |
+                  VK_PIPELINE_STAGE_LATE_FRAGMENT_TESTS_BIT);
+    EXPECT_EQ(preBarrier.dstStage, VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT);
+    EXPECT_TRUE(preBarrier.memoryBarriers.empty());
+    EXPECT_EQ(preBarrier.imageBarriers.size(), 2);
+    EXPECT_EQ(preBarrier.imageBarriers.at(0).texture, colorTexture);
+    EXPECT_EQ(preBarrier.imageBarriers.at(0).srcLayout,
+              VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL);
+    EXPECT_EQ(preBarrier.imageBarriers.at(0).dstLayout,
+              VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
+    EXPECT_EQ(preBarrier.imageBarriers.at(0).srcAccess,
+              VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT);
+    EXPECT_EQ(preBarrier.imageBarriers.at(0).dstAccess,
+              VK_ACCESS_SHADER_READ_BIT);
+
+    EXPECT_EQ(preBarrier.imageBarriers.at(1).texture, depthTexture);
+    EXPECT_EQ(preBarrier.imageBarriers.at(1).srcLayout,
+              VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL);
+    EXPECT_EQ(preBarrier.imageBarriers.at(1).dstLayout,
+              VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
+    EXPECT_EQ(preBarrier.imageBarriers.at(1).srcAccess,
+              VK_ACCESS_DEPTH_STENCIL_ATTACHMENT_WRITE_BIT);
+    EXPECT_EQ(preBarrier.imageBarriers.at(1).dstAccess,
+              VK_ACCESS_SHADER_READ_BIT);
+
+    EXPECT_TRUE(postBarrier.enabled);
+    EXPECT_EQ(postBarrier.srcStage, VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT);
+    EXPECT_EQ(postBarrier.dstStage,
+              VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT |
+                  VK_PIPELINE_STAGE_EARLY_FRAGMENT_TESTS_BIT |
+                  VK_PIPELINE_STAGE_LATE_FRAGMENT_TESTS_BIT);
+    EXPECT_TRUE(postBarrier.memoryBarriers.empty());
+    EXPECT_EQ(postBarrier.imageBarriers.size(), 2);
+    EXPECT_EQ(postBarrier.imageBarriers.at(0).texture, colorTexture);
+    EXPECT_EQ(postBarrier.imageBarriers.at(0).srcLayout,
+              VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
+    EXPECT_EQ(postBarrier.imageBarriers.at(0).dstLayout,
+              VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL);
+    EXPECT_EQ(postBarrier.imageBarriers.at(0).srcAccess,
+              VK_ACCESS_SHADER_READ_BIT);
+    EXPECT_EQ(postBarrier.imageBarriers.at(0).dstAccess,
+              VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT);
+
+    EXPECT_EQ(postBarrier.imageBarriers.at(1).texture, depthTexture);
+    EXPECT_EQ(postBarrier.imageBarriers.at(1).srcLayout,
+              VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
+    EXPECT_EQ(postBarrier.imageBarriers.at(1).dstLayout,
+              VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL);
+    EXPECT_EQ(postBarrier.imageBarriers.at(1).srcAccess,
+              VK_ACCESS_SHADER_READ_BIT);
+    EXPECT_EQ(postBarrier.imageBarriers.at(1).dstAccess,
+              VK_ACCESS_DEPTH_STENCIL_ATTACHMENT_WRITE_BIT);
+  }
+}
+
+TEST_F(RenderGraphTest, MergesInputAndOutputBarriers) {
+  using TextureDescription = liquid::rhi::TextureDescription;
+  using TextureUsage = liquid::rhi::TextureUsage;
+  TextureDescription colorDescription{};
+  colorDescription.usage = TextureUsage::Color;
+  auto colorTexture1 = resourceRegistry.setTexture(colorDescription);
+  auto colorTexture2 = resourceRegistry.setTexture(colorDescription);
+
+  TextureDescription depthDescription{};
+  depthDescription.usage = TextureUsage::Depth;
+  auto depthTexture1 = resourceRegistry.setTexture(depthDescription);
+  auto depthTexture2 = resourceRegistry.setTexture(depthDescription);
+
+  {
+    auto &pass = graph.addPass("A");
+    pass.write(colorTexture1, glm::vec4{});
+    pass.write(depthTexture1, glm::vec4{});
+  }
+
+  {
+    auto &pass = graph.addPass("B");
+    pass.read(colorTexture1);
+    pass.read(depthTexture1);
+
+    pass.write(depthTexture2, {});
+    pass.write(colorTexture2, {});
+  }
+
+  graph.compile(resourceRegistry);
+
+  {
+    const auto &preBarrier = graph.getCompiledPasses().at(1).getPreBarrier();
+    const auto &postBarrier = graph.getCompiledPasses().at(1).getPostBarrier();
+    EXPECT_TRUE(preBarrier.enabled);
+
+    EXPECT_EQ(preBarrier.srcStage,
+              VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT |
+                  VK_PIPELINE_STAGE_EARLY_FRAGMENT_TESTS_BIT |
+                  VK_PIPELINE_STAGE_LATE_FRAGMENT_TESTS_BIT);
+    EXPECT_EQ(preBarrier.dstStage, VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT);
+    EXPECT_TRUE(preBarrier.memoryBarriers.empty());
+    EXPECT_EQ(preBarrier.imageBarriers.size(), 2);
+    EXPECT_EQ(preBarrier.imageBarriers.at(0).texture, colorTexture1);
+    EXPECT_EQ(preBarrier.imageBarriers.at(0).srcLayout,
+              VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL);
+    EXPECT_EQ(preBarrier.imageBarriers.at(0).dstLayout,
+              VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
+    EXPECT_EQ(preBarrier.imageBarriers.at(0).srcAccess,
+              VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT);
+    EXPECT_EQ(preBarrier.imageBarriers.at(0).dstAccess,
+              VK_ACCESS_SHADER_READ_BIT);
+
+    EXPECT_EQ(preBarrier.imageBarriers.at(1).texture, depthTexture1);
+    EXPECT_EQ(preBarrier.imageBarriers.at(1).srcLayout,
+              VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL);
+    EXPECT_EQ(preBarrier.imageBarriers.at(1).dstLayout,
+              VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
+    EXPECT_EQ(preBarrier.imageBarriers.at(1).srcAccess,
+              VK_ACCESS_DEPTH_STENCIL_ATTACHMENT_WRITE_BIT);
+    EXPECT_EQ(preBarrier.imageBarriers.at(1).dstAccess,
+              VK_ACCESS_SHADER_READ_BIT);
+
+    EXPECT_TRUE(postBarrier.enabled);
+    EXPECT_EQ(postBarrier.srcStage,
+              VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT |
+                  VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT |
+                  VK_PIPELINE_STAGE_EARLY_FRAGMENT_TESTS_BIT |
+                  VK_PIPELINE_STAGE_LATE_FRAGMENT_TESTS_BIT);
+    EXPECT_EQ(postBarrier.dstStage,
+              VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT |
+                  VK_PIPELINE_STAGE_EARLY_FRAGMENT_TESTS_BIT |
+                  VK_PIPELINE_STAGE_LATE_FRAGMENT_TESTS_BIT);
+    EXPECT_EQ(postBarrier.imageBarriers.size(), 2);
+    EXPECT_EQ(postBarrier.imageBarriers.at(0).texture, colorTexture1);
+    EXPECT_EQ(postBarrier.imageBarriers.at(0).srcLayout,
+              VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
+    EXPECT_EQ(postBarrier.imageBarriers.at(0).dstLayout,
+              VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL);
+    EXPECT_EQ(postBarrier.imageBarriers.at(0).srcAccess,
+              VK_ACCESS_SHADER_READ_BIT);
+    EXPECT_EQ(postBarrier.imageBarriers.at(0).dstAccess,
+              VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT);
+
+    EXPECT_EQ(postBarrier.imageBarriers.at(1).texture, depthTexture1);
+    EXPECT_EQ(postBarrier.imageBarriers.at(1).srcLayout,
+              VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
+    EXPECT_EQ(postBarrier.imageBarriers.at(1).dstLayout,
+              VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL);
+    EXPECT_EQ(postBarrier.imageBarriers.at(1).srcAccess,
+              VK_ACCESS_SHADER_READ_BIT);
+    EXPECT_EQ(postBarrier.imageBarriers.at(1).dstAccess,
+              VK_ACCESS_DEPTH_STENCIL_ATTACHMENT_WRITE_BIT);
+
+    EXPECT_EQ(postBarrier.memoryBarriers.size(), 2);
+    EXPECT_EQ(postBarrier.memoryBarriers.at(0).srcAccess,
+              VK_ACCESS_DEPTH_STENCIL_ATTACHMENT_WRITE_BIT);
+    EXPECT_EQ(postBarrier.memoryBarriers.at(0).dstAccess,
+              VK_ACCESS_DEPTH_STENCIL_ATTACHMENT_WRITE_BIT |
+                  VK_ACCESS_DEPTH_STENCIL_ATTACHMENT_READ_BIT);
+    EXPECT_EQ(postBarrier.memoryBarriers.at(1).srcAccess,
+              VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT);
+    EXPECT_EQ(postBarrier.memoryBarriers.at(1).dstAccess,
+              VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT |
+                  VK_ACCESS_COLOR_ATTACHMENT_READ_BIT);
+  }
+}
+
+TEST_F(RenderGraphDeathTest, FailsIfPassReadsFromNonWrittenTexture) {
+  using TextureDescription = liquid::rhi::TextureDescription;
+  using TextureUsage = liquid::rhi::TextureUsage;
+  TextureDescription colorDescription{};
+  colorDescription.usage = TextureUsage::Color;
+  auto colorTexture = resourceRegistry.setTexture(colorDescription);
+
+  {
+    auto &pass = graph.addPass("A");
+    pass.read(colorTexture);
+  }
+
+  EXPECT_DEATH(graph.compile(resourceRegistry), ".*");
 }
 
 TEST_F(RenderGraphTest, CompilationRemovesLonelyNodes) {
-  liquid::rhi::TextureHandle handle{2};
+  liquid::rhi::TextureHandle handle = resourceRegistry.setTexture({});
 
   graph.addPass("A").write(handle, glm::vec4());
   graph.addPass("B");
   graph.addPass("C");
   graph.addPass("E").read(handle);
 
-  EXPECT_EQ(graph.compile().size(), 2);
+  graph.compile(resourceRegistry);
+
+  EXPECT_EQ(graph.getCompiledPasses().size(), 2);
+  EXPECT_EQ(graph.getPasses().size(), 4);
 }
 
 TEST_F(RenderGraphDeathTest, CompilationFailsIfMultipleNodesHaveTheSameName) {
@@ -169,5 +700,5 @@ TEST_F(RenderGraphDeathTest, CompilationFailsIfMultipleNodesHaveTheSameName) {
   graph.addPass("A");
   graph.addPass("E");
 
-  EXPECT_DEATH(graph.compile(), ".*");
+  EXPECT_DEATH(graph.compile(resourceRegistry), ".*");
 }

--- a/engine/tests/rhi/RenderGraphPass.test.cpp
+++ b/engine/tests/rhi/RenderGraphPass.test.cpp
@@ -18,7 +18,7 @@ TEST_F(RenderGraphPassTest, AddsHandleToOutputOnWrite) {
 
   pass.write(handle, glm::vec4());
   EXPECT_EQ(pass.getOutputs().size(), 1);
-  EXPECT_EQ(pass.getOutputs().at(0), handle);
+  EXPECT_EQ(pass.getOutputs().at(0).texture, handle);
 }
 
 TEST_F(RenderGraphPassTest, AddsClearValueToAttachmentDataOnWrite) {
@@ -45,7 +45,7 @@ TEST_F(RenderGraphPassTest, AddsHandleToInputOnRead) {
   EXPECT_EQ(pass.getAttachments().size(), 0);
   EXPECT_EQ(pass.getOutputs().size(), 0);
   EXPECT_EQ(pass.getInputs().size(), 1);
-  EXPECT_EQ(pass.getInputs().at(0), handle);
+  EXPECT_EQ(pass.getInputs().at(0).texture, handle);
 }
 
 TEST_F(RenderGraphPassTest, AddsPipeline) {


### PR DESCRIPTION
- Add image and memory barrier structures
- Add pipeline barrier command list
- Add memory barriers for render pass outputs in render graph
- Add image barriers to render pass inputs in render graph
- Set image layouts for all output attachments
- Update tests
- Determine barriers and layouts during compilation
- Add barriers in presenter
- Sort render graph in place and provide a way to use sorted passes
- Disable compilation if render graph is already compiled