### PR TITLE
Add audio in editor

### DIFF
--- a/editor/src/editor-scene/EntityManager.h
+++ b/editor/src/editor-scene/EntityManager.h
@@ -118,6 +118,14 @@ public:
                  const liquid::PerspectiveLensComponent &lens, bool autoRatio);
 
   /**
+   * @brief Set audio for entity
+   *
+   * @param entity Entity
+   * @param source Audio source asset
+   */
+  void setAudio(liquid::Entity entity, liquid::AudioAssetHandle source);
+
+  /**
    * @brief Set script for entity
    *
    * @param entity Entity

--- a/editor/src/ui/AssetBrowser.cpp
+++ b/editor/src/ui/AssetBrowser.cpp
@@ -254,6 +254,7 @@ void AssetBrowser::render(liquid::AssetManager &assetManager,
                           entry.assetType == liquid::AssetType::SkinnedMesh ||
                           entry.assetType == liquid::AssetType::Skeleton ||
                           entry.assetType == liquid::AssetType::Texture ||
+                          entry.assetType == liquid::AssetType::Audio ||
                           entry.assetType == liquid::AssetType::LuaScript;
 
         if (dndAllowed) {

--- a/editor/src/ui/EntityPanel.cpp
+++ b/editor/src/ui/EntityPanel.cpp
@@ -26,6 +26,7 @@ void EntityPanel::render(EditorManager &editorManager,
       renderSkeleton();
       renderCollidable();
       renderRigidBody();
+      renderAudio(assetRegistry);
       renderScripting(assetRegistry);
       renderAddComponent();
       handleDragAndDrop(renderer, assetRegistry);
@@ -563,6 +564,25 @@ void EntityPanel::renderRigidBody() {
   }
 }
 
+void EntityPanel::renderAudio(liquid::AssetRegistry &assetRegistry) {
+  if (!mEntityManager.getActiveEntityDatabase()
+           .hasComponent<liquid::AudioSourceComponent>(mSelectedEntity)) {
+    return;
+  }
+
+  if (!ImGui::CollapsingHeader("Audio")) {
+    return;
+  }
+
+  const auto &audio =
+      mEntityManager.getActiveEntityDatabase()
+          .getComponent<liquid::AudioSourceComponent>(mSelectedEntity);
+
+  const auto &asset = assetRegistry.getAudios().getAsset(audio.source);
+
+  ImGui::Text("Name: %s", asset.name.c_str());
+}
+
 void EntityPanel::renderScripting(liquid::AssetRegistry &assetRegistry) {
   if (!mEntityManager.getActiveEntityDatabase()
            .hasComponent<liquid::ScriptingComponent>(mSelectedEntity)) {
@@ -685,6 +705,14 @@ void EntityPanel::handleDragAndDrop(liquid::Renderer &renderer,
       auto asset = *static_cast<liquid::SkeletonAssetHandle *>(payload->Data);
 
       mEntityManager.setSkeletonForEntity(mSelectedEntity, asset);
+      mEntityManager.save(mSelectedEntity);
+    }
+
+    if (auto *payload = ImGui::AcceptDragDropPayload(
+            liquid::getAssetTypeString(liquid::AssetType::Audio).c_str())) {
+      auto asset = *static_cast<liquid::AudioAssetHandle *>(payload->Data);
+
+      mEntityManager.setAudio(mSelectedEntity, asset);
       mEntityManager.save(mSelectedEntity);
     }
 

--- a/editor/src/ui/EntityPanel.h
+++ b/editor/src/ui/EntityPanel.h
@@ -92,6 +92,13 @@ private:
   void renderRigidBody();
 
   /**
+   * @brief Render audio component
+   *
+   * @param assetRegistry Asset registry
+   */
+  void renderAudio(liquid::AssetRegistry &assetRegistry);
+
+  /**
    * @brief Render scripting component
    *
    * @param assetRegistry Asset registry

--- a/engine/src/liquid/audio/AudioSystem.h
+++ b/engine/src/liquid/audio/AudioSystem.h
@@ -54,6 +54,18 @@ public:
   }
 
   /**
+   * @brief Cleanup all the audio instances
+   *
+   * @param entityDatabase Entity database
+   */
+  void cleanup(EntityDatabase &entityDatabase) {
+    entityDatabase.iterateEntities<AudioStatusComponent>(
+        [this](auto entity, const auto &status) {
+          mBackend.destroySound(status.instance);
+        });
+  }
+
+  /**
    * @brief Get audio backend
    *
    * @return Audio backend


### PR DESCRIPTION
- Run audio system when in simulation mode
- Drag and drop audio to entity panel
- Render audio in entity panel
- Save audio in scene file
- Load audio from scene file
- Run script start on update to allow newly created scripts to also get initialized