### PR TITLE
Create asset loader

### DIFF
--- a/editor/src/asset/AssetLoader.cpp
+++ b/editor/src/asset/AssetLoader.cpp
@@ -1,0 +1,86 @@
+#include "liquid/core/Base.h"
+#include "AssetLoader.h"
+#include "GLTFImporter.h"
+
+namespace liquidator {
+
+const std::vector<liquid::String> AssetLoader::ScriptExtensions{"lua"};
+const std::vector<liquid::String> AssetLoader::AudioExtensions{"wav", "mp3"};
+const std::vector<liquid::String> AssetLoader::SceneExtensions{"gltf"};
+
+/**
+ * @brief Get unique path for a given path
+ *
+ * Appends incrementing number at the end of
+ * file to until the file no longer exists in
+ * directory
+ *
+ * @param path File path
+ * @return Unique file path
+ */
+static liquid::Path getUniquePath(liquid::Path path) {
+  auto ext = path.extension();
+
+  auto tmpPath = path;
+
+  uint32_t index = 1;
+  while (std::filesystem::exists(tmpPath)) {
+    liquid::String uniqueSuffix = "-" + std::to_string(index++);
+    tmpPath = path;
+    tmpPath.replace_extension();
+    tmpPath += uniqueSuffix;
+    tmpPath.replace_extension(ext);
+  }
+
+  return tmpPath;
+}
+
+AssetLoader::AssetLoader(liquid::AssetManager &assetManager,
+                         liquid::rhi::ResourceRegistry &resourceRegistry)
+    : mAssetManager(assetManager), mDeviceRegistry(resourceRegistry) {}
+
+liquid::Result<bool> AssetLoader::loadFromPath(const liquid::Path &path,
+                                               const liquid::Path &directory) {
+  auto ext = path.extension().string();
+  ext.erase(0, 1);
+
+  auto isExtension = [&ext](const auto &extensions) {
+    return std::find(extensions.begin(), extensions.end(), ext) !=
+           extensions.end();
+  };
+
+  if (isExtension(SceneExtensions)) {
+    auto res = GLTFImporter(mAssetManager).loadFromFile(path, directory);
+    mAssetManager.getRegistry().syncWithDeviceRegistry(mDeviceRegistry);
+    return res;
+  }
+
+  auto targetPath = getUniquePath(directory / path.filename());
+
+  if (isExtension(ScriptExtensions) || isExtension(AudioExtensions)) {
+    if (std::filesystem::copy_file(path, targetPath)) {
+      return mAssetManager.loadAsset(targetPath);
+    }
+  }
+
+  return liquid::Result<bool>::Error("Loaded file is not supported");
+}
+
+liquid::Result<bool>
+AssetLoader::loadFromFileDialog(const liquid::Path &directory) {
+
+  using FileTypeEntry = liquid::platform_tools::NativeFileDialog::FileTypeEntry;
+
+  std::vector<FileTypeEntry> entries{
+      FileTypeEntry{"Scene files", SceneExtensions},
+      FileTypeEntry{"Audio files", AudioExtensions},
+      FileTypeEntry{"Script files", ScriptExtensions}};
+
+  auto filePath = mNativeFileDialog.getFilePathFromDialog(entries);
+  if (filePath.empty())
+    return liquid::Result<bool>::Ok(true, {});
+
+  return loadFromPath(filePath, directory);
+}
+
+} // namespace liquidator

--- a/editor/src/asset/AssetLoader.h
+++ b/editor/src/asset/AssetLoader.h
@@ -1,0 +1,53 @@
+#pragma once
+
+#include "liquid/asset/AssetManager.h"
+#include "liquid/platform-tools/NativeFileDialog.h"
+
+namespace liquidator {
+
+/**
+ * @brief Asset loader
+ *
+ * Loads all supported asset types
+ * from the editor
+ */
+class AssetLoader {
+  static const std::vector<liquid::String> ScriptExtensions;
+  static const std::vector<liquid::String> AudioExtensions;
+  static const std::vector<liquid::String> SceneExtensions;
+
+public:
+  /**
+   * @brief Create asset loader
+   *
+   * @param assetManager Asset manager
+   * @param resourceRegistry Resource registry
+   */
+  AssetLoader(liquid::AssetManager &assetManager,
+              liquid::rhi::ResourceRegistry &resourceRegistry);
+
+  /**
+   * @brief Load asset from path
+   *
+   * @param path Path to asset
+   * @param directory Target directory path
+   * @return Asset load result
+   */
+  liquid::Result<bool> loadFromPath(const liquid::Path &path,
+                                    const liquid::Path &directory);
+
+  /**
+   * @brief Load asset from native file dialog
+   *
+   * @param directory Target directory path
+   * @return Asset load result
+   */
+  liquid::Result<bool> loadFromFileDialog(const liquid::Path &directory);
+
+private:
+  liquid::AssetManager &mAssetManager;
+  liquid::rhi::ResourceRegistry &mDeviceRegistry;
+  liquid::platform_tools::NativeFileDialog mNativeFileDialog;
+};
+
+} // namespace liquidator

--- a/editor/src/asset/GLTFImporter.cpp
+++ b/editor/src/asset/GLTFImporter.cpp
@@ -1136,9 +1136,8 @@ void loadPrefabs(
   manager.loadPrefabFromFile(path.getData());
 }
 
-GLTFImporter::GLTFImporter(liquid::AssetManager &assetManager,
-                           liquid::rhi::ResourceRegistry &deviceRegistry)
-    : mAssetManager(assetManager), mDeviceRegistry(deviceRegistry) {}
+GLTFImporter::GLTFImporter(liquid::AssetManager &assetManager)
+    : mAssetManager(assetManager) {}
 
 liquid::Result<bool>
 GLTFImporter::loadFromFile(const liquid::Path &filePath,
@@ -1200,8 +1199,6 @@ GLTFImporter::loadFromFile(const liquid::Path &filePath,
 
   loadPrefabs(model, prefabPath, mAssetManager, meshMap, skinnedMeshMap,
               skeletonData, animationData);
-
-  mAssetManager.getRegistry().syncWithDeviceRegistry(mDeviceRegistry);
 
   return liquid::Result<bool>::Ok(true, warnings);
 }

--- a/editor/src/asset/GLTFImporter.h
+++ b/editor/src/asset/GLTFImporter.h
@@ -17,10 +17,8 @@ public:
    * @brief Create GLTF importer
    *
    * @param assetManager Asset manager
-   * @param deviceRegistry Device registry
    */
-  GLTFImporter(liquid::AssetManager &assetManager,
-               liquid::rhi::ResourceRegistry &deviceRegistry);
+  GLTFImporter(liquid::AssetManager &assetManager);
 
   /**
    * @brief Load GLTF from file
@@ -34,7 +32,6 @@ public:
 
 private:
   liquid::AssetManager &mAssetManager;
-  liquid::rhi::ResourceRegistry &mDeviceRegistry;
 };
 
 } // namespace liquidator

--- a/editor/src/project/ProjectManager.cpp
+++ b/editor/src/project/ProjectManager.cpp
@@ -9,7 +9,8 @@ namespace liquidator {
 bool ProjectManager::createProjectInPath() {
   liquid::platform_tools::NativeFileDialog dialog;
 
-  auto projectPath = dialog.getFilePathFromCreateDialog({});
+  auto projectPath =
+      dialog.getFilePathFromCreateDialog({{"Liquid project", {"lqproj"}}});
 
   if (projectPath.empty()) {
     return false;
@@ -48,7 +49,8 @@ bool ProjectManager::createProjectInPath() {
 bool ProjectManager::openProjectInPath() {
   liquid::platform_tools::NativeFileDialog dialog;
 
-  auto projectFilePath = dialog.getFilePathFromDialog({"lqproj"});
+  auto projectFilePath =
+      dialog.getFilePathFromDialog({{"Liquid project", {"lqproj"}}});
   if (projectFilePath.empty()) {
     return false;
   }

--- a/editor/src/screens/EditorScreen.cpp
+++ b/editor/src/screens/EditorScreen.cpp
@@ -97,7 +97,7 @@ void EditorScreen::start(const Project &project) {
   editorManager.loadEditorState(statePath);
 
   liquid::MainLoop mainLoop(mWindow, fpsCounter);
-  liquidator::GLTFImporter gltfImporter(assetManager, renderer.getRegistry());
+  liquidator::AssetLoader assetLoader(assetManager, renderer.getRegistry());
 
   liquid::AnimationSystem animationSystem(assetManager.getRegistry());
   liquid::PhysicsSystem physicsSystem(mEventSystem);
@@ -112,7 +112,7 @@ void EditorScreen::start(const Project &project) {
                                      mDevice->getDeviceStats(),
                                      renderer.getRegistry(), fpsCounter);
 
-  liquidator::UIRoot ui(entityManager, gltfImporter);
+  liquidator::UIRoot ui(entityManager, assetLoader);
   ui.getIconRegistry().loadIcons(renderer.getRegistry(),
                                  std::filesystem::current_path() / "assets" /
                                      "icons");

--- a/editor/src/ui/AssetBrowser.cpp
+++ b/editor/src/ui/AssetBrowser.cpp
@@ -86,8 +86,8 @@ static EditorIcon getIconFromAssetType(liquid::AssetType type) {
   }
 }
 
-AssetBrowser::AssetBrowser(GLTFImporter &gltfImporter)
-    : mGltfImporter(gltfImporter), mStatusDialog("AssetLoadStatus") {}
+AssetBrowser::AssetBrowser(AssetLoader &assetLoader)
+    : mAssetLoader(assetLoader), mStatusDialog("AssetLoadStatus") {}
 
 void AssetBrowser::render(liquid::AssetManager &assetManager,
                           IconRegistry &iconRegistry,
@@ -158,8 +158,8 @@ void AssetBrowser::render(liquid::AssetManager &assetManager,
 
   if (ImGui::Begin("Asset Browser")) {
     if (ImGui::BeginPopupContextWindow()) {
-      if (ImGui::MenuItem("Import GLTF")) {
-        handleGLTFImport();
+      if (ImGui::MenuItem("Import asset")) {
+        handleAssetImport();
       }
 
       if (ImGui::MenuItem("Create directory")) {
@@ -289,12 +289,8 @@ void AssetBrowser::render(liquid::AssetManager &assetManager,
 
 void AssetBrowser::reload() { mDirectoryChanged = true; }
 
-void AssetBrowser::handleGLTFImport() {
-  auto filePath = mFileDialog.getFilePathFromDialog({"gltf"});
-  if (filePath.empty())
-    return;
-
-  auto res = mGltfImporter.loadFromFile(filePath, mCurrentDirectory);
+void AssetBrowser::handleAssetImport() {
+  auto res = mAssetLoader.loadFromFileDialog(mCurrentDirectory);
 
   if (res.hasError()) {
     mStatusDialog.setTitle("GLTF import Error");

--- a/editor/src/ui/AssetBrowser.h
+++ b/editor/src/ui/AssetBrowser.h
@@ -4,7 +4,7 @@
 #include "liquid/platform-tools/NativeFileDialog.h"
 #include "liquid/platform-tools/NativeFileOpener.h"
 
-#include "../asset/GLTFImporter.h"
+#include "../asset/AssetLoader.h"
 #include "../editor-scene/EditorManager.h"
 
 #include "IconRegistry.h"
@@ -32,9 +32,9 @@ public:
   /**
    * @brief Create asset browser
    *
-   * @param gltfImporter GLTF importer
+   * @param assetLoader Asset loader
    */
-  AssetBrowser(GLTFImporter &gltfImporter);
+  AssetBrowser(AssetLoader &assetLoader);
 
   /**
    * @brief Render status bar
@@ -54,9 +54,9 @@ public:
 
 private:
   /**
-   * @brief Handle GLTF import
+   * @brief Handle importing assets
    */
-  void handleGLTFImport();
+  void handleAssetImport();
 
   /**
    * @brief Handle entry creation
@@ -79,7 +79,7 @@ private:
   std::filesystem::path mCurrentDirectory;
   bool mDirectoryChanged = true;
   size_t mSelected = std::numeric_limits<size_t>::max();
-  GLTFImporter &mGltfImporter;
+  AssetLoader &mAssetLoader;
   liquid::platform_tools::NativeFileDialog mFileDialog;
   liquid::platform_tools::NativeFileOpener mFileOpener;
 

--- a/editor/src/ui/UIRoot.cpp
+++ b/editor/src/ui/UIRoot.cpp
@@ -3,8 +3,8 @@
 
 namespace liquidator {
 
-UIRoot::UIRoot(EntityManager &entityManager, GLTFImporter &gltfImporter)
-    : mAssetBrowser(gltfImporter), mSceneHierarchyPanel(entityManager),
+UIRoot::UIRoot(EntityManager &entityManager, AssetLoader &assetLoader)
+    : mAssetBrowser(assetLoader), mSceneHierarchyPanel(entityManager),
       mEntityPanel(entityManager) {
   mSceneHierarchyPanel.setEntityClickHandler([this](liquid::Entity entity) {
     mEntityPanel.setSelectedEntity(entity);

--- a/editor/src/ui/UIRoot.h
+++ b/editor/src/ui/UIRoot.h
@@ -30,9 +30,9 @@ public:
    * @brief Create UI Root
    *
    * @param entityManager Entity manager
-   * @param gltfImporter GLTF importer
+   * @param assetLoader Asset loader
    */
-  UIRoot(EntityManager &entityManager, GLTFImporter &gltfImporter);
+  UIRoot(EntityManager &entityManager, AssetLoader &assetLoader);
 
   /**
    * @brief Render UI Root

--- a/engine/platform-tools/include/liquid/platform-tools/NativeFileDialog.h
+++ b/engine/platform-tools/include/liquid/platform-tools/NativeFileDialog.h
@@ -12,22 +12,38 @@ namespace liquid::platform_tools {
 class NativeFileDialog {
 public:
   /**
+   * @brief File type entry
+   */
+  struct FileTypeEntry {
+    /**
+     * @brief Entry label
+     */
+    liquid::StringView label;
+
+    /**
+     * @brief Entry extensions
+     */
+    std::vector<liquid::String> extensions;
+  };
+
+public:
+  /**
    * @brief Get file path from OS file dialog
    *
-   * @param extensions File extensions to show
+   * @param fileTypes Supported file types
    * @return Chosen or empty file path
    */
   liquid::Path
-  getFilePathFromDialog(const std::vector<liquid::String> &extensions);
+  getFilePathFromDialog(const std::vector<FileTypeEntry> &fileTypes);
 
   /**
    * @brief Get file path from OS create file dialog
    *
-   * @param extensions File extensions to show
+   * @param fileTypes Supported file types
    * @return Chosen or empty file path
    */
   liquid::Path
-  getFilePathFromCreateDialog(const std::vector<liquid::String> &extensions);
+  getFilePathFromCreateDialog(const std::vector<FileTypeEntry> &fileTypes);
 };
 
 } // namespace liquid::platform_tools

--- a/engine/platform-tools/src/file-dialog/MacOsFileDialog.mm
+++ b/engine/platform-tools/src/file-dialog/MacOsFileDialog.mm
@@ -3,11 +3,16 @@
 
 namespace liquid::platform_tools {
 
-liquid::Path NativeFileDialog::getFilePathFromDialog(const std::vector<liquid::String> &extensions) {
-    std::vector<NSString *> nssExtensions(extensions.size());
-    std::transform(extensions.begin(), extensions.end(), nssExtensions.begin(), [](const liquid::String &ext) {
-        return [NSString stringWithUTF8String:ext.c_str()];
-    });
+liquid::Path NativeFileDialog::getFilePathFromDialog(const std::vector<FileTypeEntry> &fileTypes) {
+    // TODO: Fix this in macOS
+    std::vector<NSString *> nssExtensions;
+
+    for (auto &fileType : fileTypes) {
+        for (auto &ext : fileType.extensions) {
+            nssExtensions.push_back([NSString stringWithUTF8String:ext.c_str()]);
+        }
+    }
+
     NSOpenPanel *fileDialog = [NSOpenPanel openPanel];
     fileDialog.canChooseDirectories = false;
     fileDialog.allowsMultipleSelection = false;
@@ -27,7 +32,7 @@ liquid::Path NativeFileDialog::getFilePathFromDialog(const std::vector<liquid::S
 }
 
 liquid::Path 
-NativeFileDialog::getFilePathFromCreateDialog(const std::vector<liquid::String> &extensions) {
+NativeFileDialog::getFilePathFromCreateDialog(const std::vector<FileTypeEntry> &fileTypes) {
     LIQUID_ASSERT(false, "Not implemented");
     return "";
 }

--- a/engine/platform-tools/src/file-dialog/X11FileDialog.linux.cpp
+++ b/engine/platform-tools/src/file-dialog/X11FileDialog.linux.cpp
@@ -4,13 +4,13 @@
 namespace liquid::platform_tools {
 
 liquid::Path NativeFileDialog::getFilePathFromDialog(
-    const std::vector<liquid::String> &extensions) {
+    const std::vector<FileTypeEntry> &fileTypes) {
   LIQUID_ASSERT(false, "Not implemented");
   return "";
 }
 
 liquid::Path NativeFileDialog::getFilePathFromCreateDialog(
-    const std::vector<liquid::String> &extensions) {
+    const std::vector<FileTypeEntry> &fileTypes) {
   LIQUID_ASSERT(false, "Not implemented");
   return "";
 }


### PR DESCRIPTION
- Load all new assets from asset browser using asset loader in editor
- Rename import gltf to import asset in asset browser
- Import mp3, wav, lua and files to assets directory
- Use gltf importer to import gltf files as
- Define all supported file types in asset loader
- Pass multiple file types to native file dialog