### PR TITLE
Fix text rendering alpha blending

### DIFF
--- a/demos/pong-3d/src/main.cpp
+++ b/demos/pong-3d/src/main.cpp
@@ -61,6 +61,7 @@ public:
                                         assetManager.getRegistry());
 
     const auto &passData = sceneRenderer.attach(graph);
+    sceneRenderer.attachText(graph, passData);
 
     mainLoop.setUpdateFn([=](float dt) mutable {
       scriptingSystem.start(entityDatabase);

--- a/editor/assets/shaders/editor-grid.frag
+++ b/editor/assets/shaders/editor-grid.frag
@@ -57,6 +57,10 @@ void main() {
     }
 
     outColor = color;
+
+    if (outColor.w == 0.0) {
+      discard;
+    }
   }
 
   // Compute depth

--- a/editor/src/liquidator/screens/EditorScreen.cpp
+++ b/editor/src/liquidator/screens/EditorScreen.cpp
@@ -127,8 +127,17 @@ void EditorScreen::start(const Project &project) {
 
   auto scenePassGroup = renderer.getSceneRenderer().attach(graph);
   auto imguiPassGroup = renderer.getImguiRenderer().attach(graph);
-
   imguiPassGroup.pass.read(scenePassGroup.sceneColor);
+
+  {
+    constexpr glm::vec4 BLUEISH_CLEAR_VALUE{0.19f, 0.21f, 0.26f, 1.0f};
+    auto &pass = editorRenderer.attach(graph);
+    pass.write(scenePassGroup.sceneColor, BLUEISH_CLEAR_VALUE);
+    pass.write(scenePassGroup.depthBuffer,
+               liquid::rhi::DepthStencilClear{1.0f, 0});
+  }
+
+  renderer.getSceneRenderer().attachText(graph, scenePassGroup);
 
   graph.setFramebufferExtent(mWindow.getFramebufferSize());
 
@@ -151,14 +160,6 @@ void EditorScreen::start(const Project &project) {
 
   ui.getAssetBrowser().setOnCreateEntry(
       [&assetManager](auto path) { assetManager.loadAsset(path); });
-
-  {
-    constexpr glm::vec4 BLUEISH_CLEAR_VALUE{0.19f, 0.21f, 0.26f, 1.0f};
-    auto &pass = editorRenderer.attach(graph);
-    pass.write(scenePassGroup.sceneColor, BLUEISH_CLEAR_VALUE);
-    pass.write(scenePassGroup.depthBuffer,
-               liquid::rhi::DepthStencilClear{1.0f, 0});
-  }
 
   mainLoop.setUpdateFn([&editorCamera, &animationSystem, &physicsSystem,
                         &entityManager, &aspectRatioUpdater, &skeletonUpdater,

--- a/engine/src/liquid/renderer/SceneRenderer.h
+++ b/engine/src/liquid/renderer/SceneRenderer.h
@@ -48,6 +48,14 @@ public:
   SceneRenderPassData attach(rhi::RenderGraph &graph);
 
   /**
+   * @brief Attach text pass to render graph
+   *
+   * @param graph Render graph
+   * @param passData Scene render pass data
+   */
+  void attachText(rhi::RenderGraph &graph, const SceneRenderPassData &passData);
+
+  /**
    * @brief Update frame data
    *
    * @param entityDatabase Entity database


### PR DESCRIPTION
- Create separate pass for text rendering
- Allow attaching the pass separate from the scene renderer
- Discard fragments if alpha is ZERO in editor grid shader
- Attach text pass after editor pass in editor
- Attach text pass in pong demo