### PR TITLE
Add docblocks and rename casings of parameters

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,111 +1,121 @@
 ---
-Checks:          'clang-diagnostic-*,clang-analyzer-cplusplus-*,-*,cppcoreguidelines-*,-cppcoreguidelines-pro-type-static-cast-downcast,-cppcoreguidelines-pro-type-const-cast,-cppcoreguidelines-owning-memory,-cppcoreguidelines-pro-type-union-access,-cppcoreguidelines-pro-bounds-pointer-arithmetic,-cppcoreguidelines-pro-type-reinterpret-cast,-cppcoreguidelines-pro-type-vararg,llvm-*,-llvm-include-order,-llvm-header-guard, -cppcoreguidelines-prefer-member-initializer, readability-identifier-naming'
-WarningsAsErrors: '*'
-HeaderFilterRegex: ''
+Checks: "clang-diagnostic-*,clang-analyzer-cplusplus-*,-*,cppcoreguidelines-*,-cppcoreguidelines-pro-type-static-cast-downcast,-cppcoreguidelines-pro-type-const-cast,-cppcoreguidelines-owning-memory,-cppcoreguidelines-pro-type-union-access,-cppcoreguidelines-pro-bounds-pointer-arithmetic,-cppcoreguidelines-pro-type-reinterpret-cast,-cppcoreguidelines-pro-type-vararg,llvm-*,-llvm-include-order,-llvm-header-guard, -cppcoreguidelines-prefer-member-initializer, readability-identifier-naming"
+WarningsAsErrors: "*"
+HeaderFilterRegex: ""
 AnalyzeTemporaryDtors: false
-FormatStyle:     none
+FormatStyle: none
 CheckOptions:
-  - key:             readability-identifier-naming.PrivateMemberCase
-    value:           CamelCase
-  - key:             readability-identifier-naming.PrivateMemberPrefix
-    value:           m
-  - key:             modernize-replace-auto-ptr.IncludeStyle
-    value:           llvm
-  - key:             cppcoreguidelines-no-malloc.Reallocations
-    value:           '::realloc'
-  - key:             cppcoreguidelines-owning-memory.LegacyResourceConsumers
-    value:           '::free;::realloc;::freopen;::fclose'
-  - key:             cppcoreguidelines-avoid-magic-numbers.IgnoreAllFloatingPointValues
-    value:           'false'
-  - key:             cppcoreguidelines-special-member-functions.AllowMissingMoveFunctions
-    value:           'false'
-  - key:             cert-oop54-cpp.WarnOnlyIfThisHasSuspiciousField
-    value:           '0'
-  - key:             cert-dcl16-c.NewSuffixes
-    value:           'L;LL;LU;LLU'
-  - key:             cppcoreguidelines-macro-usage.CheckCapsOnly
-    value:           'false'
-  - key:             modernize-loop-convert.MaxCopySize
-    value:           '16'
-  - key:             cppcoreguidelines-pro-bounds-constant-array-index.GslHeader
-    value:           ''
-  - key:             cppcoreguidelines-explicit-virtual-functions.IgnoreDestructors
-    value:           'true'
-  - key:             llvm-namespace-comment.ShortNamespaceLines
-    value:           '1'
-  - key:             llvm-namespace-comment.SpacesBeforeComments
-    value:           '1'
-  - key:             cert-str34-c.DiagnoseSignedUnsignedCharComparisons
-    value:           '0'
-  - key:             cppcoreguidelines-explicit-virtual-functions.AllowOverrideAndFinal
-    value:           'false'
-  - key:             google-readability-braces-around-statements.ShortStatementLines
-    value:           '1'
-  - key:             cppcoreguidelines-pro-type-member-init.IgnoreArrays
-    value:           'false'
-  - key:             cppcoreguidelines-avoid-magic-numbers.IgnoredFloatingPointValues
-    value:           '1.0;100.0;'
-  - key:             cppcoreguidelines-macro-usage.IgnoreCommandLineMacros
-    value:           'true'
-  - key:             cppcoreguidelines-pro-bounds-constant-array-index.IncludeStyle
-    value:           llvm
-  - key:             cppcoreguidelines-owning-memory.LegacyResourceProducers
-    value:           '::malloc;::aligned_alloc;::realloc;::calloc;::fopen;::freopen;::tmpfile'
-  - key:             cppcoreguidelines-narrowing-conversions.WarnOnFloatingPointNarrowingConversion
-    value:           'true'
-  - key:             cppcoreguidelines-init-variables.IncludeStyle
-    value:           llvm
-  - key:             cppcoreguidelines-avoid-magic-numbers.IgnoredIntegerValues
-    value:           '1;2;3;4;'
-  - key:             cppcoreguidelines-non-private-member-variables-in-classes.IgnorePublicMemberVariables
-    value:           'false'
-  - key:             modernize-loop-convert.MinConfidence
-    value:           reasonable
-  - key:             cppcoreguidelines-avoid-magic-numbers.IgnorePowersOf2IntegerValues
-    value:           'false'
-  - key:             cppcoreguidelines-special-member-functions.AllowMissingMoveFunctionsWhenCopyIsDeleted
-    value:           'false'
-  - key:             google-readability-namespace-comments.ShortNamespaceLines
-    value:           '10'
-  - key:             google-readability-namespace-comments.SpacesBeforeComments
-    value:           '2'
-  - key:             cppcoreguidelines-non-private-member-variables-in-classes.IgnoreClassesWithAllMemberVariablesBeingPublic
-    value:           'true'
-  - key:             cppcoreguidelines-avoid-magic-numbers.IgnoreBitFieldsWidths
-    value:           'true'
-  - key:             cppcoreguidelines-no-malloc.Allocations
-    value:           '::malloc;::calloc'
-  - key:             cppcoreguidelines-explicit-virtual-functions.FinalSpelling
-    value:           final
-  - key:             llvm-qualified-auto.AddConstToQualified
-    value:           'false'
-  - key:             modernize-loop-convert.NamingStyle
-    value:           CamelCase
-  - key:             cppcoreguidelines-pro-type-member-init.UseAssignment
-    value:           'false'
-  - key:             cppcoreguidelines-init-variables.MathHeader
-    value:           '<math.h>'
-  - key:             google-readability-function-size.StatementThreshold
-    value:           '800'
-  - key:             llvm-else-after-return.WarnOnConditionVariables
-    value:           'false'
-  - key:             modernize-pass-by-value.IncludeStyle
-    value:           llvm
-  - key:             cppcoreguidelines-explicit-virtual-functions.OverrideSpelling
-    value:           override
-  - key:             cppcoreguidelines-special-member-functions.AllowSoleDefaultDtor
-    value:           'false'
-  - key:             modernize-use-nullptr.NullMacros
-    value:           'NULL'
-  - key:             cppcoreguidelines-no-malloc.Deallocations
-    value:           '::free'
-  - key:             cppcoreguidelines-macro-usage.AllowedRegexp
-    value:           '^DEBUG_*'
-  - key:             llvm-header-guard.HeaderFileExtensions
-    value:           ';h;hh;hpp;hxx'
-  - key:             cppcoreguidelines-narrowing-conversions.PedanticMode
-    value:           'false'
-  - key:             llvm-else-after-return.WarnOnUnfixable
-    value:           'false'
-...
+  - key: readability-identifier-naming.PrivateMemberCase
+    value: CamelCase
+  - key: readability-identifier-naming.PrivateMemberPrefix
+    value: m
+  - key: readability-identifier-naming.ConstexprVariableCase
+    value: CamelCase
+  - key: readability-identifier-naming.ConstantMemberCase
+    value: CamelCase
+  - key: readability-identifier-naming.StaticConstantCase
+    value: CamelCase
+  - key: readbility-identifier-naming.TemplateParameterCase
+    value: CamelCase
+  - key: readability-identifier-naming.TemplateParameterPrefix
+    value: T
+  - key: modernize-replace-auto-ptr.IncludeStyle
+    value: llvm
+  - key: cppcoreguidelines-no-malloc.Reallocations
+    value: "::realloc"
+  - key: cppcoreguidelines-owning-memory.LegacyResourceConsumers
+    value: "::free;::realloc;::freopen;::fclose"
+  - key: cppcoreguidelines-avoid-magic-numbers.IgnoreAllFloatingPointValues
+    value: "false"
+  - key: cppcoreguidelines-special-member-functions.AllowMissingMoveFunctions
+    value: "false"
+  - key: cert-oop54-cpp.WarnOnlyIfThisHasSuspiciousField
+    value: "0"
+  - key: cert-dcl16-c.NewSuffixes
+    value: "L;LL;LU;LLU"
+  - key: cppcoreguidelines-macro-usage.CheckCapsOnly
+    value: "false"
+  - key: modernize-loop-convert.MaxCopySize
+    value: "16"
+  - key: cppcoreguidelines-pro-bounds-constant-array-index.GslHeader
+    value: ""
+  - key: cppcoreguidelines-explicit-virtual-functions.IgnoreDestructors
+    value: "true"
+  - key: llvm-namespace-comment.ShortNamespaceLines
+    value: "1"
+  - key: llvm-namespace-comment.SpacesBeforeComments
+    value: "1"
+  - key: cert-str34-c.DiagnoseSignedUnsignedCharComparisons
+    value: "0"
+  - key: cppcoreguidelines-explicit-virtual-functions.AllowOverrideAndFinal
+    value: "false"
+  - key: google-readability-braces-around-statements.ShortStatementLines
+    value: "1"
+  - key: cppcoreguidelines-pro-type-member-init.IgnoreArrays
+    value: "false"
+  - key: cppcoreguidelines-avoid-magic-numbers.IgnoredFloatingPointValues
+    value: "1.0;100.0;"
+  - key: cppcoreguidelines-macro-usage.IgnoreCommandLineMacros
+    value: "true"
+  - key: cppcoreguidelines-pro-bounds-constant-array-index.IncludeStyle
+    value: llvm
+  - key: cppcoreguidelines-owning-memory.LegacyResourceProducers
+    value: "::malloc;::aligned_alloc;::realloc;::calloc;::fopen;::freopen;::tmpfile"
+  - key: cppcoreguidelines-narrowing-conversions.WarnOnFloatingPointNarrowingConversion
+    value: "true"
+  - key: cppcoreguidelines-init-variables.IncludeStyle
+    value: llvm
+  - key: cppcoreguidelines-avoid-magic-numbers.IgnoredIntegerValues
+    value: "1;2;3;4;"
+  - key: cppcoreguidelines-non-private-member-variables-in-classes.IgnorePublicMemberVariables
+    value: "false"
+  - key: modernize-loop-convert.MinConfidence
+    value: reasonable
+  - key: cppcoreguidelines-avoid-magic-numbers.IgnorePowersOf2IntegerValues
+    value: "false"
+  - key: cppcoreguidelines-special-member-functions.AllowMissingMoveFunctionsWhenCopyIsDeleted
+    value: "false"
+  - key: google-readability-namespace-comments.ShortNamespaceLines
+    value: "10"
+  - key: google-readability-namespace-comments.SpacesBeforeComments
+    value: "2"
+  - key: cppcoreguidelines-non-private-member-variables-in-classes.IgnoreClassesWithAllMemberVariablesBeingPublic
+    value: "true"
+  - key: cppcoreguidelines-avoid-magic-numbers.IgnoreBitFieldsWidths
+    value: "true"
+  - key: cppcoreguidelines-no-malloc.Allocations
+    value: "::malloc;::calloc"
+  - key: cppcoreguidelines-explicit-virtual-functions.FinalSpelling
+    value: final
+  - key: llvm-qualified-auto.AddConstToQualified
+    value: "false"
+  - key: modernize-loop-convert.NamingStyle
+    value: CamelCase
+  - key: cppcoreguidelines-pro-type-member-init.UseAssignment
+    value: "false"
+  - key: cppcoreguidelines-init-variables.MathHeader
+    value: "<math.h>"
+  - key: google-readability-function-size.StatementThreshold
+    value: "800"
+  - key: llvm-else-after-return.WarnOnConditionVariables
+    value: "false"
+  - key: modernize-pass-by-value.IncludeStyle
+    value: llvm
+  - key: cppcoreguidelines-explicit-virtual-functions.OverrideSpelling
+    value: override
+  - key: cppcoreguidelines-special-member-functions.AllowSoleDefaultDtor
+    value: "false"
+  - key: modernize-use-nullptr.NullMacros
+    value: "NULL"
+  - key: cppcoreguidelines-no-malloc.Deallocations
+    value: "::free"
+  - key: cppcoreguidelines-macro-usage.AllowedRegexp
+    value: "^DEBUG_*"
+  - key: llvm-header-guard.HeaderFileExtensions
+    value: ";h;hh;hpp;hxx"
+  - key: cppcoreguidelines-narrowing-conversions.PedanticMode
+    value: "false"
+  - key: llvm-else-after-return.WarnOnUnfixable
+    value: "false"
+---
 

--- a/Doxyfile
+++ b/Doxyfile
@@ -328,7 +328,7 @@ OPTIMIZE_OUTPUT_SLICE  = NO
 #
 # Note see also the list of default file extension mappings.
 
-EXTENSION_MAPPING      =
+EXTENSION_MAPPING      = .frag=C++, .vert=C++, .comp=C++
 
 # If the MARKDOWN_SUPPORT tag is enabled then doxygen pre-processes all comments
 # according to the Markdown format, which allows for more readable
@@ -939,7 +939,10 @@ FILE_PATTERNS          = *.c \
                          *.vhdl \
                          *.ucf \
                          *.qsf \
-                         *.ice
+                         *.ice \
+                         *.vert \
+                         *.frag \
+                         *.comp
 
 # The RECURSIVE tag can be used to specify whether or not subdirectories should
 # be searched for input files as well.

--- a/STYLE_GUIDE.md
+++ b/STYLE_GUIDE.md
@@ -4,7 +4,19 @@ This document covers basics for styling all the projects in this repository.
 
 ## Formatting
 
-All C++ source and shader files in this project are formatted using Clang Format using [LLVM coding standards](https://llvm.org/docs/CodingStandards.html#source-code-formatting). Please refer to [.clang-format](./.clang-format) to view clang-format properties.
+All C++ source and shader files in this project are formatted using Clang Format
+using [LLVM coding standards](https://llvm.org/docs/CodingStandards.html#source-code-formatting). Please
+refer to [.clang-format](./.clang-format) to view clang-format properties.
+
+## Docblocks
+
+All the source code, including shaders must have docblocks. The docblocks are automatically verified when
+creating Pull requests. Doxygen style commands are allowed inside docblocks but they must **always**
+start with `@` character instead of `\` (e.g `@param`).
+
+As a general rule of thumb, descriptions of functions and compound interface **must**
+start with `@brief` command while non-static public member variables of classes
+do not need to be annotated with `@brief` command.
 
 ## Shaders
 
@@ -166,7 +178,7 @@ requiring additional descriptions, single-line comments must be used.
 
 All functions must have multi-line comments that start with
 two stars (`/**`) and must use Doxygen commands that
-start with `@` sign.  Example:
+start with `@` sign. Example:
 
 ```glsl
 /**
@@ -186,4 +198,4 @@ vec3 lambertianDiffuse(vec3 diffuseColor) { return diffuseColor / PI; }
 **Code:**
 
 If a code snippet needs to be explained with comments, single line
-comments must be used. 
+comments must be used.

--- a/editor/assets/shaders/object-icons.vert
+++ b/editor/assets/shaders/object-icons.vert
@@ -9,7 +9,13 @@ layout(set = 0, binding = 0) uniform CameraData {
 }
 uCameraData;
 
+/**
+ * @brief Single object transforms
+ */
 struct ObjectItem {
+  /**
+   * Model matrix for object
+   */
   mat4 modelMatrix;
 };
 

--- a/editor/assets/shaders/skeleton-lines.vert
+++ b/editor/assets/shaders/skeleton-lines.vert
@@ -8,11 +8,23 @@ layout(set = 0, binding = 0) uniform CameraData {
 }
 uCameraData;
 
+/**
+ * @brief Single object transforms
+ */
 struct ObjectItem {
+  /**
+   * Model matrix for object
+   */
   mat4 modelMatrix;
 };
 
-struct SkeletonItem {
+/**
+ * @brief Single debug skeleton transforms
+ */
+struct DebugSkeletonItem {
+  /**
+   * Bone matrices for skeleton
+   */
   mat4 bones[64];
 };
 
@@ -22,7 +34,7 @@ layout(std140, set = 0, binding = 1) readonly buffer ObjectData {
 uObjectData;
 
 layout(std140, set = 0, binding = 2) readonly buffer SkeletonData {
-  SkeletonItem items[];
+  DebugSkeletonItem items[];
 }
 uSkeletonData;
 

--- a/editor/src/liquidator/asset/GLTFImporter.cpp
+++ b/editor/src/liquidator/asset/GLTFImporter.cpp
@@ -177,13 +177,10 @@ static BufferMeta getBufferMetaForAccessor(const tinygltf::Model &model,
 TransformData loadTransformData(const tinygltf::Node &node) {
   TransformData data{};
 
-  constexpr size_t TRANSFORM_MATRIX_SIZE = 6;
-  constexpr size_t TRANSLATION_MATRIX_SIZE = 3;
-  constexpr size_t SCALE_MATRIX_SIZE = 3;
-  constexpr size_t ROTATION_MATRIX_SIZE = 4;
+  static constexpr size_t TransformMatrixSize = 6;
 
   glm::mat4 finalTransform = glm::mat4{1.0f};
-  if (node.matrix.size() == TRANSFORM_MATRIX_SIZE) {
+  if (node.matrix.size() == TransformMatrixSize) {
     finalTransform = glm::make_mat4(node.matrix.data());
     decomposeMatrix(finalTransform, data.localPosition, data.localRotation,
                     data.localScale);
@@ -192,7 +189,7 @@ TransformData loadTransformData(const tinygltf::Node &node) {
     liquid::engineLogger.log(Logger::Warning)
         << "Node matrix data must have 16 values. Skipping...";
   } else {
-    if (node.translation.size() == TRANSLATION_MATRIX_SIZE) {
+    if (node.translation.size() == glm::vec3::length()) {
       data.localPosition = glm::make_vec3(node.translation.data());
       finalTransform *= glm::translate(glm::mat4{1.0f}, data.localPosition);
     } else if (node.translation.size() > 0) {
@@ -200,7 +197,7 @@ TransformData loadTransformData(const tinygltf::Node &node) {
           << "Node translation data must have 3 values. Skipping...";
     }
 
-    if (node.rotation.size() == ROTATION_MATRIX_SIZE) {
+    if (node.rotation.size() == glm::quat::length()) {
       data.localRotation = glm::make_quat(node.rotation.data());
       finalTransform *= glm::toMat4(data.localRotation);
     } else if (node.rotation.size() > 0) {
@@ -208,7 +205,7 @@ TransformData loadTransformData(const tinygltf::Node &node) {
           << "Node rotation data must have 4 values. Skipping...";
     }
 
-    if (node.scale.size() == SCALE_MATRIX_SIZE) {
+    if (node.scale.size() == glm::vec3::length()) {
       data.localScale = glm::make_vec3(node.scale.data());
       finalTransform *= glm::scale(glm::mat4{1.0f}, data.localScale);
     } else if (node.scale.size() > 0) {

--- a/editor/src/liquidator/core/EditorRenderer.cpp
+++ b/editor/src/liquidator/core/EditorRenderer.cpp
@@ -109,8 +109,8 @@ EditorRenderer::attach(liquid::rhi::RenderGraph &graph) {
       commandList.bindDescriptor(editorGridPipeline, 0, sceneDescriptor);
       commandList.bindDescriptor(editorGridPipeline, 1, gridDescriptor);
 
-      constexpr uint32_t PLANE_VERTICES = 6;
-      commandList.draw(PLANE_VERTICES, 0);
+      static constexpr uint32_t GridPlaneNumVertices = 6;
+      commandList.draw(GridPlaneNumVertices, 0);
     }
 
     // Skeleton bones
@@ -200,12 +200,11 @@ void EditorRenderer::updateFrameData(liquid::EntityDatabase &entityDatabase,
   entityDatabase.iterateEntities<liquid::WorldTransformComponent,
                                  liquid::PerspectiveLensComponent>(
       [this](auto entity, const auto &world, const auto &camera) {
-        static constexpr float NINETY_DEGREES_IN_RADIANS =
-            glm::pi<float>() / 2.0f;
+        static constexpr float NinetyDegreesInRadians = glm::pi<float>() / 2.0f;
 
         mRenderStorage.addGizmo(mIconRegistry.getIcon(EditorIcon::Camera),
                                 glm::rotate(world.worldTransform,
-                                            NINETY_DEGREES_IN_RADIANS,
+                                            NinetyDegreesInRadians,
                                             glm::vec3(0, 1, 0)));
       });
 

--- a/editor/src/liquidator/core/EditorRendererStorage.cpp
+++ b/editor/src/liquidator/core/EditorRendererStorage.cpp
@@ -8,7 +8,7 @@ EditorRendererStorage::EditorRendererStorage(size_t reservedSpace)
   mSkeletonTransforms.reserve(mReservedSpace);
   mNumBones.reserve(mReservedSpace);
   mGizmoTransforms.reserve(reservedSpace);
-  mSkeletonVector.reset(new glm::mat4[mReservedSpace * MAX_NUM_BONES]);
+  mSkeletonVector.reset(new glm::mat4[mReservedSpace * MaxNumBones]);
 }
 
 void EditorRendererStorage::addSkeleton(
@@ -17,9 +17,8 @@ void EditorRendererStorage::addSkeleton(
   mSkeletonTransforms.push_back(worldTransform);
   mNumBones.push_back(static_cast<uint32_t>(boneTransforms.size()));
 
-  auto *currentSkeleton =
-      mSkeletonVector.get() + (mLastSkeleton * MAX_NUM_BONES);
-  size_t dataSize = std::min(boneTransforms.size(), MAX_NUM_BONES);
+  auto *currentSkeleton = mSkeletonVector.get() + (mLastSkeleton * MaxNumBones);
+  size_t dataSize = std::min(boneTransforms.size(), MaxNumBones);
   memcpy(currentSkeleton, boneTransforms.data(), dataSize * sizeof(glm::mat4));
 
   mLastSkeleton++;
@@ -65,7 +64,7 @@ void EditorRendererStorage::updateBuffers(
     mSkeletonBoneTransformsBuffer = registry.setBuffer(
         {
             liquid::rhi::BufferType::Storage,
-            mReservedSpace * MAX_NUM_BONES * sizeof(glm::mat4),
+            mReservedSpace * MaxNumBones * sizeof(glm::mat4),
             mSkeletonVector.get(),
         },
         mSkeletonBoneTransformsBuffer);

--- a/editor/src/liquidator/core/EditorRendererStorage.h
+++ b/editor/src/liquidator/core/EditorRendererStorage.h
@@ -14,12 +14,12 @@ class EditorRendererStorage {
   /**
    * @brief Maximum number of debug bones
    */
-  static constexpr size_t MAX_NUM_BONES = 64;
+  static constexpr size_t MaxNumBones = 64;
 
   /**
    * @brief Default reserved space for buffers
    */
-  static constexpr size_t DEFAULT_RESERVED_SPACE = 2000;
+  static constexpr size_t DefaultReservedSpace = 2000;
 
 public:
   /**
@@ -27,7 +27,7 @@ public:
    *
    * @param reservedSpace Reserved space for buffer data
    */
-  EditorRendererStorage(size_t reservedSpace = DEFAULT_RESERVED_SPACE);
+  EditorRendererStorage(size_t reservedSpace = DefaultReservedSpace);
 
   /**
    * @brief Add skeleton

--- a/editor/src/liquidator/editor-scene/EditorCamera.cpp
+++ b/editor/src/liquidator/editor-scene/EditorCamera.cpp
@@ -51,7 +51,7 @@ EditorCamera::EditorCamera(liquid::EntityDatabase &entityDatabase,
           return;
         }
 
-        constexpr float MIN_OOB_THRESHOLD = 2.0f;
+        static constexpr float MinOOBThreshold = 2.0f;
         const auto &size = mWindow.getWindowSize();
 
         float minX = 0;
@@ -64,18 +64,18 @@ EditorCamera::EditorCamera(liquid::EntityDatabase &entityDatabase,
         glm::vec2 newPos{data.xpos, data.ypos};
 
         if (data.xpos <= minX) {
-          newPos.x = maxX - MIN_OOB_THRESHOLD;
+          newPos.x = maxX - MinOOBThreshold;
           outOfBounds = true;
         } else if (data.xpos >= maxX) {
-          newPos.x = minX + MIN_OOB_THRESHOLD;
+          newPos.x = minX + MinOOBThreshold;
           outOfBounds = true;
         }
 
         if (data.ypos <= minY) {
-          newPos.y = maxY - MIN_OOB_THRESHOLD;
+          newPos.y = maxY - MinOOBThreshold;
           outOfBounds = true;
         } else if (data.ypos >= maxY) {
-          newPos.y = minY + MIN_OOB_THRESHOLD;
+          newPos.y = minY + MinOOBThreshold;
           outOfBounds = true;
         }
 
@@ -97,7 +97,7 @@ EditorCamera::EditorCamera(liquid::EntityDatabase &entityDatabase,
           return;
         }
         glm::vec3 change =
-            glm::vec3(mEye - mCenter) * event.yoffset * ZOOM_SPEED;
+            glm::vec3(mEye - mCenter) * event.yoffset * ZoomSpeed;
         mCenter += change;
         mEye += change;
       });
@@ -144,12 +144,12 @@ void EditorCamera::update() {
 }
 
 void EditorCamera::reset() {
-  mEye = DEFAULT_EYE;
-  mCenter = DEFAULT_CENTER;
-  mUp = DEFAULT_UP;
-  mFov = DEFAULT_FOV;
-  mNear = DEFAULT_NEAR;
-  mFar = DEFAULT_FAR;
+  mEye = DefaultEye;
+  mCenter = DefaultCenter;
+  mUp = DefaultUp;
+  mFov = DefaultFOV;
+  mNear = DefaultNear;
+  mFar = DefaultFar;
 
   if (!mEntityDatabase.hasEntity(mCameraEntity)) {
     mCameraEntity = mEntityDatabase.createEntity();
@@ -158,13 +158,13 @@ void EditorCamera::reset() {
 }
 
 void EditorCamera::pan() {
-  constexpr float PAN_SPEED = 0.03f;
+  static constexpr float PanSpeed = 0.03f;
 
   glm::vec2 mousePos = mWindow.getCurrentMousePosition();
   glm::vec3 right = glm::normalize(glm::cross(glm::vec3(mEye - mCenter), mUp));
 
   glm::vec2 mousePosDiff =
-      glm::vec4((mousePos - mPrevMousePos) * PAN_SPEED, 0.0f, 0.0f);
+      glm::vec4((mousePos - mPrevMousePos) * PanSpeed, 0.0f, 0.0f);
 
   glm::vec3 change = mUp * mousePosDiff.y + right * mousePosDiff.x;
   mEye += change;
@@ -173,13 +173,13 @@ void EditorCamera::pan() {
 }
 
 void EditorCamera::rotate() {
-  constexpr float TWO_PI = 2.0f * glm::pi<float>();
+  static constexpr float TwoPi = 2.0f * glm::pi<float>();
 
   glm::vec2 mousePos = mWindow.getCurrentMousePosition();
   const auto &size = mWindow.getFramebufferSize();
 
   glm ::vec2 screenToSphere{// horizontal = 2pi
-                            (TWO_PI / static_cast<float>(size.x)),
+                            (TwoPi / static_cast<float>(size.x)),
                             // vertical = pi
                             (glm::pi<float>() / static_cast<float>(size.y))};
 
@@ -201,7 +201,7 @@ void EditorCamera::rotate() {
 
 void EditorCamera::zoom() {
   glm::vec2 mousePos = mWindow.getCurrentMousePosition();
-  float zoomFactor = (mousePos.y - mPrevMousePos.y) * ZOOM_SPEED;
+  float zoomFactor = (mousePos.y - mPrevMousePos.y) * ZoomSpeed;
 
   glm::vec3 change = glm::vec3(mEye - mCenter) * zoomFactor;
   mCenter += change;

--- a/editor/src/liquidator/editor-scene/EditorCamera.h
+++ b/editor/src/liquidator/editor-scene/EditorCamera.h
@@ -24,37 +24,37 @@ public:
   /**
    * Zoom speed when scrolling
    */
-  static constexpr float ZOOM_SPEED = 0.03f;
+  static constexpr float ZoomSpeed = 0.03f;
 
   /**
    * Default Field of view value
    */
-  static constexpr float DEFAULT_FOV = 70.0f;
+  static constexpr float DefaultFOV = 70.0f;
 
   /**
    * Default near perspective plane
    */
-  static constexpr float DEFAULT_NEAR = 0.001f;
+  static constexpr float DefaultNear = 0.001f;
 
   /**
    * Default far perspective plane
    */
-  static constexpr float DEFAULT_FAR = 1000.0f;
+  static constexpr float DefaultFar = 1000.0f;
 
   /**
    * Default camera position
    */
-  static constexpr glm::vec3 DEFAULT_EYE{0.0f, 5.0f, -10.0f};
+  static constexpr glm::vec3 DefaultEye{0.0f, 5.0f, -10.0f};
 
   /**
    * Default camera center
    */
-  static constexpr glm::vec3 DEFAULT_CENTER{0.0f, 0.0f, 0.0f};
+  static constexpr glm::vec3 DefaultCenter{0.0f, 0.0f, 0.0f};
 
   /**
    * Default camera up vector
    */
-  static constexpr glm::vec3 DEFAULT_UP{0.0f, 1.0f, 0.0f};
+  static constexpr glm::vec3 DefaultUp{0.0f, 1.0f, 0.0f};
 
 public:
   /**
@@ -216,9 +216,9 @@ private:
   void zoom();
 
 private:
-  float mFov = DEFAULT_FOV;
-  float mNear = DEFAULT_NEAR;
-  float mFar = DEFAULT_FAR;
+  float mFov = DefaultFOV;
+  float mNear = DefaultNear;
+  float mFar = DefaultFar;
 
   float mX = 0.0f;
   float mY = 0.0f;
@@ -228,9 +228,9 @@ private:
   InputState mInputState = InputState::None;
   glm::vec2 mPrevMousePos{};
 
-  glm::vec3 mEye = DEFAULT_EYE;
-  glm::vec3 mCenter = DEFAULT_CENTER;
-  glm::vec3 mUp = DEFAULT_UP;
+  glm::vec3 mEye = DefaultEye;
+  glm::vec3 mCenter = DefaultCenter;
+  glm::vec3 mUp = DefaultUp;
 
   liquid::EventObserverId mMouseButtonPressHandler = 0;
   liquid::EventObserverId mMouseButtonReleaseHandler = 0;

--- a/editor/src/liquidator/editor-scene/EditorGrid.h
+++ b/editor/src/liquidator/editor-scene/EditorGrid.h
@@ -25,7 +25,6 @@ struct EditorGridData {
  * Controls editor grid
  */
 class EditorGrid {
-
 public:
   /**
    * @brief Set grid lines display flag

--- a/editor/src/liquidator/editor-scene/EditorManager.cpp
+++ b/editor/src/liquidator/editor-scene/EditorManager.cpp
@@ -50,11 +50,11 @@ void EditorManager::loadEditorState(const std::filesystem::path &path) {
     const auto &camera = node["camera"];
 
     // defaults
-    float fov = EditorCamera::DEFAULT_FOV, near = EditorCamera::DEFAULT_NEAR,
-          far = EditorCamera::DEFAULT_FAR;
-    glm::vec3 eye = EditorCamera::DEFAULT_EYE,
-              center = EditorCamera::DEFAULT_CENTER,
-              up = EditorCamera::DEFAULT_UP;
+    float fov = EditorCamera::DefaultFOV, near = EditorCamera::DefaultNear,
+          far = EditorCamera::DefaultFar;
+    glm::vec3 eye = EditorCamera::DefaultEye,
+              center = EditorCamera::DefaultCenter,
+              up = EditorCamera::DefaultUp;
 
     if (camera["fov"].IsScalar()) {
       fov = camera["fov"].as<float>();
@@ -121,11 +121,11 @@ void EditorManager::switchToEditorCamera() {
 }
 
 void EditorManager::createNewScene() {
-  static constexpr glm::vec3 LIGHT_START_POS(0.0f, 5.0f, 0.0f);
+  static constexpr glm::vec3 LightStartPos(0.0f, 5.0f, 0.0f);
 
   {
     liquid::LocalTransformComponent transform{};
-    transform.localPosition = LIGHT_START_POS;
+    transform.localPosition = LightStartPos;
     transform.localRotation =
         glm::quat(glm::vec3(0.0f, 0.0f, glm::pi<float>()));
 
@@ -159,11 +159,11 @@ void EditorManager::moveCameraToEntity(liquid::Entity entity) {
   const auto &translation =
       glm::vec3(glm::column(transformComponent.worldTransform, 3));
 
-  constexpr glm::vec3 distanceFromCenter{0.0f, 0.0f, 10.0f};
+  static constexpr glm::vec3 DistanceFromCenter{0.0f, 0.0f, 10.0f};
 
   mEditorCamera.reset();
   mEditorCamera.setCenter(translation);
-  mEditorCamera.setEye(translation - distanceFromCenter);
+  mEditorCamera.setEye(translation - DistanceFromCenter);
 }
 
 bool EditorManager::hasEnvironment() {

--- a/editor/src/liquidator/editor-scene/EntityManager.cpp
+++ b/editor/src/liquidator/editor-scene/EntityManager.cpp
@@ -295,9 +295,9 @@ EntityManager::getTransformFromCamera(EditorCamera &camera) const {
       entityDatabase.getComponent<liquid::CameraComponent>(camera.getCamera())
           .viewMatrix;
 
-  constexpr glm::vec3 distanceFromEye = {0.0f, 0.0f, -10.0f};
+  static constexpr glm::vec3 DistanceFromEye{0.0f, 0.0f, -10.0f};
   const auto &invViewMatrix = glm::inverse(viewMatrix);
-  const auto &orientation = invViewMatrix * glm::translate(distanceFromEye);
+  const auto &orientation = invViewMatrix * glm::translate(DistanceFromEye);
 
   liquid::LocalTransformComponent transform;
   transform.localPosition = orientation[3];

--- a/editor/src/liquidator/project/ProjectManager.h
+++ b/editor/src/liquidator/project/ProjectManager.h
@@ -40,21 +40,21 @@ struct Project {
 class ProjectManager {
 public:
   /**
-   * Create project in path
+   * @brief Create project in path
    *
    * @return Project created successfully
    */
   bool createProjectInPath();
 
   /**
-   * Open project in path
+   * @brief Open project in path
    *
    * @return Project opened successfully
    */
   bool openProjectInPath();
 
   /**
-   * Get project
+   * @brief Get project
    *
    * @return Project
    */

--- a/editor/src/liquidator/screens/EditorScreen.cpp
+++ b/editor/src/liquidator/screens/EditorScreen.cpp
@@ -107,9 +107,9 @@ void EditorScreen::start(const Project &project) {
   imguiPassGroup.pass.read(scenePassGroup.sceneColor);
 
   {
-    static constexpr glm::vec4 BLUEISH_CLEAR_VALUE{0.52f, 0.54f, 0.89f, 1.0f};
+    static constexpr glm::vec4 BlueishClearValue{0.52f, 0.54f, 0.89f, 1.0f};
     auto &pass = editorRenderer.attach(graph);
-    pass.write(scenePassGroup.sceneColor, BLUEISH_CLEAR_VALUE);
+    pass.write(scenePassGroup.sceneColor, BlueishClearValue);
     pass.write(scenePassGroup.depthBuffer,
                liquid::rhi::DepthStencilClear{1.0f, 0});
   }

--- a/editor/src/liquidator/screens/ProjectSelectorScreen.cpp
+++ b/editor/src/liquidator/screens/ProjectSelectorScreen.cpp
@@ -36,8 +36,7 @@ std::optional<Project> ProjectSelectorScreen::start() {
   liquidator::IconRegistry iconRegistry;
   std::optional<liquidator::Project> project;
 
-  static constexpr float HALF = 0.5f;
-  static constexpr float ICON_SIZE = 80.0f;
+  static constexpr float IconSize = 80.0f;
 
   presenter.updateFramebuffers(mDevice->getSwapchain());
 
@@ -75,9 +74,11 @@ std::optional<Project> ProjectSelectorScreen::start() {
     imgui.beginRendering();
 
     const auto &fbSize = glm::vec2(mWindow.getFramebufferSize());
-    auto center = fbSize * HALF;
+    const auto center = fbSize * 0.5f;
 
-    ImGui::SetNextWindowPos(ImVec2(center.x, center.y), 0, ImVec2(HALF, HALF));
+    static constexpr ImVec2 CenterWindowPivot(0.5f, 0.5f);
+
+    ImGui::SetNextWindowPos(ImVec2(center.x, center.y), 0, CenterWindowPivot);
 
     if (ImGui::Begin("Liquidator", nullptr,
                      ImGuiWindowFlags_NoResize | ImGuiWindowFlags_NoScrollbar |
@@ -89,7 +90,7 @@ std::optional<Project> ProjectSelectorScreen::start() {
         ImGui::TableNextColumn();
         if (liquid::imgui::imageButton(
                 iconRegistry.getIcon(liquidator::EditorIcon::CreateDirectory),
-                ImVec2(ICON_SIZE, ICON_SIZE))) {
+                ImVec2(IconSize, IconSize))) {
           if (projectManager.createProjectInPath()) {
             project = projectManager.getProject();
           }
@@ -99,7 +100,7 @@ std::optional<Project> ProjectSelectorScreen::start() {
         ImGui::TableNextColumn();
         if (liquid::imgui::imageButton(
                 iconRegistry.getIcon(liquidator::EditorIcon::Directory),
-                ImVec2(ICON_SIZE, ICON_SIZE))) {
+                ImVec2(IconSize, IconSize))) {
           if (projectManager.openProjectInPath()) {
             project = projectManager.getProject();
           }

--- a/editor/src/liquidator/ui/AssetBrowser.cpp
+++ b/editor/src/liquidator/ui/AssetBrowser.cpp
@@ -96,11 +96,12 @@ void AssetBrowser::render(liquid::AssetManager &assetManager,
                           IconRegistry &iconRegistry,
                           EditorManager &editorManager,
                           EntityManager &entityManager) {
-  constexpr uint32_t ITEM_WIDTH = 90;
-  constexpr uint32_t ITEM_HEIGHT = 100;
-  constexpr ImVec2 ICON_SIZE(80.0f, 80.0f);
-  constexpr float IMAGE_PADDING = ((ITEM_WIDTH * 1.0f) - ICON_SIZE.x) / 2.0f;
-  constexpr uint32_t TEXT_WIDTH = ITEM_WIDTH - 8;
+  static constexpr uint32_t ItemWidth = 90;
+  static constexpr uint32_t ItemHeight = 100;
+  static constexpr ImVec2 IconSize(80.0f, 80.0f);
+  static constexpr float ImagePadding =
+      ((ItemWidth * 1.0f) - IconSize.x) / 2.0f;
+  static constexpr uint32_t TextWidth = ItemWidth - 8;
 
   if (mDirectoryChanged) {
     if (mCurrentDirectory.empty()) {
@@ -142,10 +143,10 @@ void AssetBrowser::render(liquid::AssetManager &assetManager,
 
       entry.textWidth = calculateTextWidth(entry);
 
-      if (ImGui::CalcTextSize(entry.clippedName.c_str()).x > TEXT_WIDTH) {
+      if (ImGui::CalcTextSize(entry.clippedName.c_str()).x > TextWidth) {
         bool changed = false;
 
-        while (calculateTextWidth(entry) > TEXT_WIDTH) {
+        while (calculateTextWidth(entry) > TextWidth) {
           entry.clippedName.pop_back();
         }
 
@@ -183,7 +184,7 @@ void AssetBrowser::render(liquid::AssetManager &assetManager,
     }
 
     const auto &size = ImGui::GetContentRegionAvail();
-    auto itemsPerRow = static_cast<int32_t>(size.x / ITEM_WIDTH);
+    auto itemsPerRow = static_cast<int32_t>(size.x / ItemWidth);
 
     if (itemsPerRow == 0)
       itemsPerRow = 1;
@@ -207,12 +208,12 @@ void AssetBrowser::render(liquid::AssetManager &assetManager,
       if (mHasStagingEntry) {
         startIndex = 1;
 
-        ImGui::TableNextRow(ImGuiTableRowFlags_None, ITEM_HEIGHT * 1.0f);
+        ImGui::TableNextRow(ImGuiTableRowFlags_None, ItemHeight * 1.0f);
         ImGui::TableNextColumn();
 
         liquid::imgui::image(iconRegistry.getIcon(mStagingEntry.icon),
-                             ICON_SIZE);
-        ImGui::PushItemWidth(ITEM_WIDTH);
+                             IconSize);
+        ImGui::PushItemWidth(ItemWidth);
 
         if (!mInitialFocusSet) {
           ImGui::SetKeyboardFocusHere();
@@ -230,7 +231,7 @@ void AssetBrowser::render(liquid::AssetManager &assetManager,
         const auto &entry = mEntries.at(i);
         auto colIndex = (i % itemsPerRow);
         if (colIndex == 0) {
-          ImGui::TableNextRow(ImGuiTableRowFlags_None, ITEM_HEIGHT * 1.0f);
+          ImGui::TableNextRow(ImGuiTableRowFlags_None, ItemHeight * 1.0f);
         }
 
         const auto &filename = entry.path.filename();
@@ -242,7 +243,7 @@ void AssetBrowser::render(liquid::AssetManager &assetManager,
             std::to_string(static_cast<uint32_t>(entry.assetType));
         if (ImGui::Selectable(id.c_str(), mSelected == i,
                               ImGuiSelectableFlags_AllowDoubleClick,
-                              ImVec2(ITEM_WIDTH, ITEM_HEIGHT))) {
+                              ImVec2(ItemWidth, ItemHeight))) {
           // Select when item is clicked
           mSelected = i;
 
@@ -284,7 +285,7 @@ void AssetBrowser::render(liquid::AssetManager &assetManager,
           ImGui::EndTooltip();
         }
 
-        ImGui::SetCursorPosY(ImGui::GetCursorPosY() - ITEM_HEIGHT);
+        ImGui::SetCursorPosY(ImGui::GetCursorPosY() - ItemHeight);
 
         renderEntry(entry);
       }
@@ -345,24 +346,24 @@ void AssetBrowser::handleCreateEntry() {
 }
 
 void AssetBrowser::renderEntry(const Entry &entry) {
-  constexpr uint32_t ITEM_WIDTH = 90;
-  constexpr uint32_t ITEM_HEIGHT = 100;
-  constexpr ImVec2 ICON_SIZE(80.0f, 80.0f);
-  constexpr float IMAGE_PADDING = ((ITEM_WIDTH * 1.0f) - ICON_SIZE.x) / 2.0f;
-  constexpr uint32_t TEXT_WIDTH = ITEM_WIDTH - 8;
+  static constexpr uint32_t ItemWidth = 90;
+  static constexpr uint32_t ItemHeight = 100;
+  static constexpr ImVec2 IconSize(80.0f, 80.0f);
+  static constexpr float ImagePadding =
+      ((ItemWidth * 1.0f) - IconSize.x) / 2.0f;
+  static constexpr uint32_t TextWidth = ItemWidth - 8;
 
   {
     float initialCursorPos = ImGui::GetCursorPosX();
-    ImGui::SetCursorPosX(initialCursorPos + IMAGE_PADDING);
-    liquid::imgui::image(entry.preview, ICON_SIZE);
+    ImGui::SetCursorPosX(initialCursorPos + ImagePadding);
+    liquid::imgui::image(entry.preview, IconSize);
     ImGui::SetCursorPosX(initialCursorPos);
   }
 
   {
-    static constexpr float HALF = 0.5f;
     float initialCursorPos = ImGui::GetCursorPosX();
-    float centerPos =
-        initialCursorPos + (ITEM_WIDTH * 1.0f - entry.textWidth) * HALF;
+    const float centerPos =
+        initialCursorPos + (ItemWidth * 1.0f - entry.textWidth) * 0.5f;
     ImGui::SetCursorPosX(centerPos);
     ImGui::Text("%s", entry.clippedName.c_str());
     ImGui::SetCursorPosX(initialCursorPos);

--- a/editor/src/liquidator/ui/EntityPanel.cpp
+++ b/editor/src/liquidator/ui/EntityPanel.cpp
@@ -58,9 +58,6 @@ static bool ImguiMultilineInputText(const liquid::String &label,
                                    InputTextCallback, &userData);
 }
 
-constexpr size_t VEC3_ARRAY_SIZE = 3;
-constexpr size_t VEC4_ARRAY_SIZE = 4;
-
 EntityPanel::EntityPanel(EntityManager &entityManager)
     : mEntityManager(entityManager) {}
 
@@ -205,8 +202,8 @@ void EntityPanel::renderCamera(EditorManager &editorManager) {
     }
 
     ImGui::Text("Aspect Ratio");
-    static constexpr float MIN_CUSTOM_ASPECT_RATIO = 0.01f;
-    static constexpr float MAX_CUSTOM_ASPECT_RATIO = 1000.0f;
+    static constexpr float MinCustomAspectRatio = 0.01f;
+    static constexpr float MaxCustomAspectRatio = 1000.0f;
 
     bool hasViewportAspectRatio =
         mEntityManager.getActiveEntityDatabase()
@@ -235,8 +232,8 @@ void EntityPanel::renderCamera(EditorManager &editorManager) {
     if (!hasViewportAspectRatio) {
       ImGui::Text("Custom aspect ratio");
       if (ImGui::DragFloat("###CustomAspectRatio", &component.aspectRatio,
-                           MIN_CUSTOM_ASPECT_RATIO, MIN_CUSTOM_ASPECT_RATIO,
-                           MAX_CUSTOM_ASPECT_RATIO, "%.2f")) {
+                           MinCustomAspectRatio, MinCustomAspectRatio,
+                           MaxCustomAspectRatio, "%.2f")) {
       }
 
       if (ImGui::IsItemDeactivatedAfterEdit()) {
@@ -277,7 +274,9 @@ void EntityPanel::renderTransform() {
 
     ImGui::Text("Rotation");
     const auto &euler = glm::eulerAngles(component.localRotation);
-    std::array<float, VEC3_ARRAY_SIZE> imguiRotation{euler.x, euler.y, euler.z};
+
+    std::array<float, glm::vec3::length()> imguiRotation{euler.x, euler.y,
+                                                         euler.z};
     if (ImGui::InputFloat3("###InputTransformRotation", imguiRotation.data())) {
       component.localRotation = glm::quat(glm::vec3(
           imguiRotation.at(0), imguiRotation.at(1), imguiRotation.at(2)));
@@ -627,12 +626,12 @@ void EntityPanel::renderText(liquid::AssetRegistry &assetRegistry) {
 
     const auto &fonts = assetRegistry.getFonts().getAssets();
 
-    static constexpr float CONTENT_INPUT_HEIGHT = 100.0f;
+    static constexpr float ContentInputHeight = 100.0f;
 
     ImGui::Text("Content");
     if (ImguiMultilineInputText(
             "###InputContent", text.text,
-            ImVec2(ImGui::GetWindowWidth(), CONTENT_INPUT_HEIGHT), 0)) {
+            ImVec2(ImGui::GetWindowWidth(), ContentInputHeight), 0)) {
       mEntityManager.save(mSelectedEntity);
     }
 
@@ -744,12 +743,12 @@ void EntityPanel::renderAddComponent() {
     if (!mEntityManager.getActiveEntityDatabase()
              .hasComponent<liquid::CollidableComponent>(mSelectedEntity) &&
         ImGui::Selectable("Collidable")) {
-      constexpr glm::vec3 DEFAULT_VALUE(0.5f);
+      static constexpr glm::vec3 DefaultValue(0.5f);
 
       mEntityManager.getActiveEntityDatabase()
           .setComponent<liquid::CollidableComponent>(
               mSelectedEntity, {liquid::PhysicsGeometryType::Box,
-                                liquid::PhysicsGeometryBox{DEFAULT_VALUE}});
+                                liquid::PhysicsGeometryBox{DefaultValue}});
       mEntityManager.save(mSelectedEntity);
     }
 

--- a/editor/src/liquidator/ui/Layout.cpp
+++ b/editor/src/liquidator/ui/Layout.cpp
@@ -45,20 +45,20 @@ void Layout::setup() {
                                   ImGuiDockNodeFlags_PassthruCentralNode);
     ImGui::DockBuilderSetNodeSize(dockspaceId, viewport->Size);
 
-    constexpr float RATIO_5_1 = 0.2f;
-    constexpr float RATIO_1_4 = 0.25;
+    static constexpr float Ratio51 = 0.2f;
+    static constexpr float Ratio14 = 0.25;
 
     ImGuiID topAreaId = -1;
-    auto browserId = ImGui::DockBuilderSplitNode(
-        dockspaceId, ImGuiDir_Down, RATIO_1_4, nullptr, &topAreaId);
+    auto browserId = ImGui::DockBuilderSplitNode(dockspaceId, ImGuiDir_Down,
+                                                 Ratio14, nullptr, &topAreaId);
 
     ImGuiID topRightAreaId = -1;
     auto hierarchyId = ImGui::DockBuilderSplitNode(
-        topAreaId, ImGuiDir_Left, RATIO_5_1, nullptr, &topRightAreaId);
+        topAreaId, ImGuiDir_Left, Ratio51, nullptr, &topRightAreaId);
 
     ImGuiID viewId = -1;
     auto inspectorId = ImGui::DockBuilderSplitNode(
-        topRightAreaId, ImGuiDir_Right, RATIO_1_4, nullptr, &viewId);
+        topRightAreaId, ImGuiDir_Right, Ratio14, nullptr, &viewId);
 
     ImGui::DockBuilderDockWindow("Hierarchy", hierarchyId);
     ImGui::DockBuilderDockWindow("Entity", inspectorId);

--- a/editor/src/main.cpp
+++ b/editor/src/main.cpp
@@ -6,14 +6,13 @@
 #include "liquidator/screens/ProjectSelectorScreen.h"
 
 int main() {
-  static constexpr uint32_t INITIAL_WIDTH = 1024;
-  static constexpr uint32_t INITIAL_HEIGHT = 768;
+  static constexpr uint32_t InitialWidth = 1024;
+  static constexpr uint32_t InitialHeight = 768;
 
   liquid::Engine::setAssetsPath(liquid::Path("./engine/assets").string());
 
   liquid::EventSystem eventSystem;
-  liquid::Window window("Liquidator", INITIAL_WIDTH, INITIAL_HEIGHT,
-                        eventSystem);
+  liquid::Window window("Liquidator", InitialWidth, InitialHeight, eventSystem);
 
   liquid::rhi::VulkanRenderBackend backend(window);
   auto *device = backend.createDefaultDevice();

--- a/engine/assets/shaders/geometry.vert
+++ b/engine/assets/shaders/geometry.vert
@@ -22,7 +22,13 @@ layout(set = 0, binding = 0) uniform CameraData {
 }
 uCameraData;
 
+/**
+ * @brief Single object transforms
+ */
 struct ObjectItem {
+  /**
+   * Object model matrix
+   */
   mat4 modelMatrix;
 };
 

--- a/engine/assets/shaders/pbr.frag
+++ b/engine/assets/shaders/pbr.frag
@@ -21,9 +21,23 @@ uCameraData;
 layout(std140, set = 2, binding = 1) uniform SceneData { ivec4 data; }
 uSceneData;
 
+/**
+ * @brief Single light data
+ */
 struct LightItem {
+  /**
+   * Light data
+   */
   vec4 data;
+
+  /**
+   * Light color
+   */
   vec4 color;
+
+  /**
+   * Light space matrix
+   */
   mat4 lightMatrix;
 };
 
@@ -56,22 +70,117 @@ layout(std140, set = 3, binding = 0) uniform MaterialDataRaw {
 }
 uMaterialDataRaw;
 
+/**
+ * @brief PBR Material data
+ */
 struct MaterialData {
+  /**
+   * Index to base color texture
+   */
   int baseColorTexture;
+
+  /**
+   * Texture coordinates index
+   * for base color texture
+   *
+   * Only two texture coordinate
+   * groups are supported
+   */
   int baseColorTextureCoord;
+
+  /**
+   * Base color factor
+   *
+   * If texture is not provided,
+   * the factor is used as the
+   * base color.
+   *
+   * If texture is provided
+   * this the factor is used
+   * to scale the texture
+   * color.
+   */
   vec4 baseColorFactor;
+
+  /**
+   * Index to metallic roughness texture
+   */
   int metallicRoughnessTexture;
+
+  /**
+   * Texture coordinates index
+   * for metallic roughness texture
+   *
+   * Only two texture coordinate
+   * groups are supported
+   */
   int metallicRoughnessTextureCoord;
+
+  /**
+   * Metallic factor
+   */
   float metallicFactor;
+
+  /**
+   * Roughness factor
+   */
   float roughnessFactor;
+
+  /**
+   * Index to normal texture
+   */
   int normalTexture;
+
+  /**
+   * Texture coordinates index
+   * for normal texture
+   *
+   * Only two texture coordinate
+   * groups are supported
+   */
   int normalTextureCoord;
+
+  /**
+   * Normal scale
+   */
   float normalScale;
+
+  /**
+   * Index to occlusion texture
+   */
   int occlusionTexture;
+
+  /**
+   * Texture coordinates index
+   * for occlusion texture
+   *
+   * Only two texture coordinate
+   * groups are supported
+   */
   int occlusionTextureCoord;
+
+  /**
+   * Occlusion strength
+   */
   float occlusionStrength;
+
+  /**
+   * Index to emissive texture
+   */
   int emissiveTexture;
+
+  /**
+   * Texture coordinates index
+   * for emissive texture
+   *
+   * Only two texture coordinate
+   * groups are supported
+   */
   int emissiveTextureCoord;
+
+  /**
+   * Emissive factor
+   */
   vec3 emissiveFactor;
 };
 
@@ -94,7 +203,7 @@ const mat4 DEPTH_BIAS = mat4(0.5, 0.0, 0.0, 0.0, 0.0, 0.5, 0.0, 0.0, 0.0, 0.0,
                              1.0, 0.0, 0.5, 0.5, 0.0, 1.0);
 
 /**
- * sRGB to Linear color
+ * @brief sRGB to Linear color
  *
  * @param srgbColor Color in SRGB color space
  * @return Color in linear color space
@@ -108,7 +217,7 @@ vec4 srgbToLinear(vec4 srgbColor) {
 }
 
 /**
- * Linear color to sRGB
+ * @brief Linear color to sRGB
  *
  * @param linearColor Color in linear color space
  * @return Color in sRGB color space
@@ -123,7 +232,7 @@ vec4 linearToSrgb(vec4 linearColor) {
 }
 
 /**
- * Lambertian diffuse
+ * @brief Lambertian diffuse
  *
  * @param diffuseColor Diffuse color
  * @return Diffuse
@@ -131,7 +240,7 @@ vec4 linearToSrgb(vec4 linearColor) {
 vec3 lambertianDiffuse(vec3 diffuseColor) { return diffuseColor / PI; }
 
 /**
- * Schlick Fresnel approximation
+ * @brief Schlick Fresnel approximation
  *
  * @param reflectance0 Reflectance at normal incidence
  * @param VdotH Dot product of V and H
@@ -142,7 +251,7 @@ vec3 schlickFresnel(vec3 reflectance0, float VdotH) {
 }
 
 /**
- * GGX/Trowbridge-Reitz normal distribution
+ * @brief GGX/Trowbridge-Reitz normal distribution
  *
  * @param roughness Roughness
  * @param NdotH Dot product of N and H
@@ -154,7 +263,7 @@ float ggxNormalDistribution(float roughness, float NdotH) {
 }
 
 /**
- * Schlick Specular Geometric Attenuation
+ * @brief Schlick Specular Geometric Attenuation
  *
  * @param roughness Roughness
  * @param NdotV Dot product of N and V
@@ -171,7 +280,7 @@ float schlickSpecularGeometricAttenuation(float roughness, float NdotV,
 }
 
 /**
- * Get normals from world position
+ * @brief Get normals from world position
  *
  * Checking for tangent existence is based on
  * w attribute of tangent vector, which determines
@@ -208,10 +317,28 @@ vec3 getNormal() {
   }
 }
 
+/**
+ * @brief Light calculation results
+ */
 struct LightCalculations {
+  /**
+   * Dot product of N and L
+   */
   float NdotL;
+
+  /**
+   * Dot product of N and H
+   */
   float NdotH;
+
+  /**
+   * Dot product of V dot H
+   */
   float VdotH;
+
+  /**
+   * Light intensity
+   */
   float intensity;
 };
 

--- a/engine/assets/shaders/shadowmap.vert
+++ b/engine/assets/shaders/shadowmap.vert
@@ -4,9 +4,23 @@
 
 layout(location = 0) in vec3 inPosition;
 
+/**
+ * @brief Single light data
+ */
 struct LightItem {
+  /**
+   * Light data
+   */
   vec4 data;
+
+  /**
+   * Light color
+   */
   vec4 color;
+
+  /**
+   * Light space matrix
+   */
   mat4 lightMatrix;
 };
 
@@ -15,7 +29,13 @@ layout(std140, set = 0, binding = 0) readonly buffer LightData {
 }
 uLightData;
 
+/**
+ * @brief Single object transforms
+ */
 struct ObjectItem {
+  /**
+   * Object model matrix
+   */
   mat4 modelMatrix;
 };
 

--- a/engine/assets/shaders/skinnedGeometry.vert
+++ b/engine/assets/shaders/skinnedGeometry.vert
@@ -29,6 +29,9 @@ struct ObjectItem {
 };
 
 struct SkeletonItem {
+  /**
+   * Joints for skeleton
+   */
   mat4 joints[32];
 };
 

--- a/engine/assets/shaders/skinnedShadowmap.vert
+++ b/engine/assets/shaders/skinnedShadowmap.vert
@@ -7,8 +7,19 @@ layout(location = 6) in uvec4 inJoints;
 layout(location = 7) in vec4 inWeights;
 
 struct LightItem {
+  /**
+   * Light data
+   */
   vec4 data;
+
+  /**
+   * Light color
+   */
   vec4 color;
+
+  /**
+   * Light space matrix
+   */
   mat4 lightMatrix;
 };
 
@@ -17,11 +28,23 @@ layout(std140, set = 0, binding = 0) readonly buffer LightData {
 }
 uLightData;
 
+/**
+ * @brief Single object transforms
+ */
 struct ObjectItem {
+  /**
+   * Model matrix for object
+   */
   mat4 modelMatrix;
 };
 
+/**
+ * @brief Single skeleton transforms
+ */
 struct SkeletonItem {
+  /**
+   * Joint matrices of skeleton
+   */
   mat4 joints[16];
 };
 

--- a/engine/assets/shaders/text.vert
+++ b/engine/assets/shaders/text.vert
@@ -19,8 +19,18 @@ layout(std140, set = 1, binding = 0) readonly buffer ObjectData {
 }
 uObjectData;
 
+/**
+ * @brief Single glyph data
+ */
 struct GlyphItem {
+  /**
+   * Glyph atlas bounds
+   */
   vec4 bounds;
+
+  /**
+   * Glyph quad bounds
+   */
   vec4 planeBounds;
 };
 

--- a/engine/platform-tools/include/liquid/platform-tools/NativeFileDialog.h
+++ b/engine/platform-tools/include/liquid/platform-tools/NativeFileDialog.h
@@ -16,12 +16,12 @@ public:
    */
   struct FileTypeEntry {
     /**
-     * @brief Entry label
+     * Entry label
      */
     liquid::StringView label;
 
     /**
-     * @brief Entry extensions
+     * Entry extensions
      */
     std::vector<liquid::String> extensions;
   };

--- a/engine/rhi/core/include/liquid/rhi/PipelineBarrier.h
+++ b/engine/rhi/core/include/liquid/rhi/PipelineBarrier.h
@@ -10,12 +10,12 @@ namespace liquid::rhi {
  */
 struct MemoryBarrier {
   /**
-   * @brief Source access flags
+   * Source access flags
    */
   VkAccessFlags srcAccess = VK_ACCESS_NONE_KHR;
 
   /**
-   * @brief Destination access flags
+   * Destination access flags
    */
   VkAccessFlags dstAccess = VK_ACCESS_NONE_KHR;
 };
@@ -25,27 +25,27 @@ struct MemoryBarrier {
  */
 struct ImageBarrier {
   /**
-   * @brief Source access flags
+   * Source access flags
    */
   VkAccessFlags srcAccess = VK_ACCESS_NONE_KHR;
 
   /**
-   * @brief Destination access flags
+   * Destination access flags
    */
   VkAccessFlags dstAccess = VK_ACCESS_NONE_KHR;
 
   /**
-   * @brief Source image layout
+   * Source image layout
    */
   VkImageLayout srcLayout = VK_IMAGE_LAYOUT_MAX_ENUM;
 
   /**
-   * @brief Destination image layout
+   * Destination image layout
    */
   VkImageLayout dstLayout = VK_IMAGE_LAYOUT_MAX_ENUM;
 
   /**
-   * @brief Texture
+   * Texture
    */
   TextureHandle texture = TextureHandle::Invalid;
 };

--- a/engine/rhi/core/include/liquid/rhi/PipelineDescription.h
+++ b/engine/rhi/core/include/liquid/rhi/PipelineDescription.h
@@ -157,12 +157,12 @@ struct PipelineVertexInputLayout {
  */
 template <>
 inline PipelineVertexInputLayout PipelineVertexInputLayout::create<Vertex>() {
-  const uint32_t POSITION_LOCATION = 0;
-  const uint32_t NORMAL_LOCATION = 1;
-  const uint32_t TANGENT_LOCATION = 2;
-  const uint32_t COLOR_LOCATION = 3;
-  const uint32_t TEXCOORD0_LOCATION = 4;
-  const uint32_t TEXCOORD1_LOCATION = 5;
+  static constexpr uint32_t PositionSlot = 0;
+  static constexpr uint32_t NormalSlot = 1;
+  static constexpr uint32_t TangentSlot = 2;
+  static constexpr uint32_t ColorSlot = 3;
+  static constexpr uint32_t TexCoord0Slot = 4;
+  static constexpr uint32_t TexCoord1Slot = 5;
 
   // TODO: Create abstract format type
   const uint32_t R32G32B32A32_SFLOAT = 109;
@@ -171,18 +171,20 @@ inline PipelineVertexInputLayout PipelineVertexInputLayout::create<Vertex>() {
 
   return PipelineVertexInputLayout{
       {PipelineVertexInputBinding{0, sizeof(Vertex), VertexInputRate::Vertex}},
-      {PipelineVertexInputAttribute{POSITION_LOCATION, 0, R32G32B32_SFLOAT,
-                                    offsetof(Vertex, x)},
-       PipelineVertexInputAttribute{NORMAL_LOCATION, 0, R32G32B32_SFLOAT,
-                                    offsetof(Vertex, nx)},
-       PipelineVertexInputAttribute{TANGENT_LOCATION, 0, R32G32B32A32_SFLOAT,
-                                    offsetof(Vertex, tx)},
-       PipelineVertexInputAttribute{COLOR_LOCATION, 0, R32G32B32_SFLOAT,
-                                    offsetof(Vertex, r)},
-       PipelineVertexInputAttribute{TEXCOORD0_LOCATION, 0, R32G32_SFLOAT,
-                                    offsetof(Vertex, u0)},
-       PipelineVertexInputAttribute{TEXCOORD1_LOCATION, 0, R32G32_SFLOAT,
-                                    offsetof(Vertex, u1)}}};
+      {
+          PipelineVertexInputAttribute{PositionSlot, 0, R32G32B32_SFLOAT,
+                                       offsetof(SkinnedVertex, x)},
+          PipelineVertexInputAttribute{NormalSlot, 0, R32G32B32_SFLOAT,
+                                       offsetof(SkinnedVertex, nx)},
+          PipelineVertexInputAttribute{TangentSlot, 0, R32G32B32A32_SFLOAT,
+                                       offsetof(SkinnedVertex, tx)},
+          PipelineVertexInputAttribute{ColorSlot, 0, R32G32B32_SFLOAT,
+                                       offsetof(SkinnedVertex, r)},
+          PipelineVertexInputAttribute{TexCoord0Slot, 0, R32G32_SFLOAT,
+                                       offsetof(SkinnedVertex, u0)},
+          PipelineVertexInputAttribute{TexCoord1Slot, 0, R32G32_SFLOAT,
+                                       offsetof(SkinnedVertex, u1)},
+      }};
 }
 
 /**
@@ -193,39 +195,39 @@ inline PipelineVertexInputLayout PipelineVertexInputLayout::create<Vertex>() {
 template <>
 inline PipelineVertexInputLayout
 PipelineVertexInputLayout::create<SkinnedVertex>() {
-  constexpr uint32_t POSITION_LOCATION = 0;
-  constexpr uint32_t NORMAL_LOCATION = 1;
-  constexpr uint32_t TANGENT_LOCATION = 2;
-  constexpr uint32_t COLOR_LOCATION = 3;
-  constexpr uint32_t TEXCOORD0_LOCATION = 4;
-  constexpr uint32_t TEXCOORD1_LOCATION = 5;
-  constexpr uint32_t JOINTS_LOCATION = 6;
-  constexpr uint32_t WEIGHTS_LOCATION = 7;
+  static constexpr uint32_t PositionSlot = 0;
+  static constexpr uint32_t NormalSlot = 1;
+  static constexpr uint32_t TangentSlot = 2;
+  static constexpr uint32_t ColorSlot = 3;
+  static constexpr uint32_t TexCoord0Slot = 4;
+  static constexpr uint32_t TexCoord1Slot = 5;
+  static constexpr uint32_t JointsSlot = 6;
+  static constexpr uint32_t WeightsSlot = 7;
 
   // TODO: Create abstract format type
-  constexpr uint32_t R32G32B32A32_SFLOAT = 109;
-  constexpr uint32_t R32G32B32_SFLOAT = 106;
-  constexpr uint32_t R32G32_SFLOAT = 103;
-  constexpr uint32_t R32G32B32A32_UINT = 107;
+  static constexpr uint32_t R32G32B32A32_SFLOAT = 109;
+  static constexpr uint32_t R32G32B32_SFLOAT = 106;
+  static constexpr uint32_t R32G32_SFLOAT = 103;
+  static constexpr uint32_t R32G32B32A32_UINT = 107;
 
   return PipelineVertexInputLayout{
       {PipelineVertexInputBinding{0, sizeof(SkinnedVertex),
                                   VertexInputRate::Vertex}},
-      {PipelineVertexInputAttribute{POSITION_LOCATION, 0, R32G32B32_SFLOAT,
+      {PipelineVertexInputAttribute{PositionSlot, 0, R32G32B32_SFLOAT,
                                     offsetof(SkinnedVertex, x)},
-       PipelineVertexInputAttribute{NORMAL_LOCATION, 0, R32G32B32_SFLOAT,
+       PipelineVertexInputAttribute{NormalSlot, 0, R32G32B32_SFLOAT,
                                     offsetof(SkinnedVertex, nx)},
-       PipelineVertexInputAttribute{TANGENT_LOCATION, 0, R32G32B32A32_SFLOAT,
+       PipelineVertexInputAttribute{TangentSlot, 0, R32G32B32A32_SFLOAT,
                                     offsetof(SkinnedVertex, tx)},
-       PipelineVertexInputAttribute{COLOR_LOCATION, 0, R32G32B32_SFLOAT,
+       PipelineVertexInputAttribute{ColorSlot, 0, R32G32B32_SFLOAT,
                                     offsetof(SkinnedVertex, r)},
-       PipelineVertexInputAttribute{TEXCOORD0_LOCATION, 0, R32G32_SFLOAT,
+       PipelineVertexInputAttribute{TexCoord0Slot, 0, R32G32_SFLOAT,
                                     offsetof(SkinnedVertex, u0)},
-       PipelineVertexInputAttribute{TEXCOORD1_LOCATION, 0, R32G32_SFLOAT,
+       PipelineVertexInputAttribute{TexCoord1Slot, 0, R32G32_SFLOAT,
                                     offsetof(SkinnedVertex, u1)},
-       PipelineVertexInputAttribute{JOINTS_LOCATION, 0, R32G32B32A32_UINT,
+       PipelineVertexInputAttribute{JointsSlot, 0, R32G32B32A32_UINT,
                                     offsetof(SkinnedVertex, j0)},
-       PipelineVertexInputAttribute{WEIGHTS_LOCATION, 0, R32G32B32A32_SFLOAT,
+       PipelineVertexInputAttribute{WeightsSlot, 0, R32G32B32A32_SFLOAT,
                                     offsetof(SkinnedVertex, w0)}}};
 }
 

--- a/engine/rhi/core/include/liquid/rhi/RenderFrame.h
+++ b/engine/rhi/core/include/liquid/rhi/RenderFrame.h
@@ -7,17 +7,17 @@ namespace liquid::rhi {
  */
 struct RenderFrame {
   /**
-   * @brief Frame index
+   * Frame index
    */
   uint32_t frameIndex = std::numeric_limits<uint32_t>::max();
 
   /**
-   * @brief Swapchain image index
+   * Swapchain image index
    */
   uint32_t swapchainImageIndex = std::numeric_limits<uint32_t>::max();
 
   /**
-   * @brief Command list
+   * Command list
    */
   RenderCommandList &commandList;
 };

--- a/engine/rhi/core/include/liquid/rhi/RenderHandle.h
+++ b/engine/rhi/core/include/liquid/rhi/RenderHandle.h
@@ -21,7 +21,7 @@ enum class PipelineHandle : uint32_t { Invalid = 0 };
  * @tparam ...Rest Other types
  */
 template <class T, class... Rest>
-inline constexpr bool is_any_same = (std::is_same_v<T, Rest> || ...);
+inline constexpr bool IsAnySame = (std::is_same_v<T, Rest> || ...);
 
 /**
  * @brief Check if handle is valid
@@ -32,10 +32,9 @@ inline constexpr bool is_any_same = (std::is_same_v<T, Rest> || ...);
  * @retval false Handle is not valid
  */
 template <class THandle> constexpr inline bool isHandleValid(THandle handle) {
-  static_assert(
-      is_any_same<THandle, ShaderHandle, BufferHandle, TextureHandle,
-                  RenderPassHandle, FramebufferHandle, PipelineHandle>,
-      "Type must be a render handle");
+  static_assert(IsAnySame<THandle, ShaderHandle, BufferHandle, TextureHandle,
+                          RenderPassHandle, FramebufferHandle, PipelineHandle>,
+                "Type must be a render handle");
   return handle != THandle::Invalid;
 }
 
@@ -48,10 +47,9 @@ template <class THandle> constexpr inline bool isHandleValid(THandle handle) {
  */
 template <class THandle>
 constexpr inline uint32_t castHandleToUint(THandle handle) {
-  static_assert(
-      is_any_same<THandle, ShaderHandle, BufferHandle, TextureHandle,
-                  RenderPassHandle, FramebufferHandle, PipelineHandle>,
-      "Type must be a render handle");
+  static_assert(IsAnySame<THandle, ShaderHandle, BufferHandle, TextureHandle,
+                          RenderPassHandle, FramebufferHandle, PipelineHandle>,
+                "Type must be a render handle");
 
   return static_cast<uint32_t>(handle);
 }

--- a/engine/rhi/core/include/liquid/rhi/Swapchain.h
+++ b/engine/rhi/core/include/liquid/rhi/Swapchain.h
@@ -7,12 +7,12 @@ namespace liquid::rhi {
  */
 struct Swapchain {
   /**
-   * @brief Swapchain textures
+   * Swapchain textures
    */
   std::vector<TextureHandle> textures{};
 
   /**
-   * @brief Swapchain extent
+   * Swapchain extent
    */
   glm::uvec2 extent{};
 };

--- a/engine/rhi/core/include/liquid/rhi/TextureDescription.h
+++ b/engine/rhi/core/include/liquid/rhi/TextureDescription.h
@@ -14,11 +14,11 @@ enum class TextureUsage : uint8_t {
   TransferDestination = 1 << 3
 };
 
-constexpr TextureUsage operator|(TextureUsage a, TextureUsage b) {
+constexpr inline TextureUsage operator|(TextureUsage a, TextureUsage b) {
   return TextureUsage(static_cast<uint8_t>(a) | static_cast<uint8_t>(b));
 }
 
-constexpr TextureUsage operator&(TextureUsage a, TextureUsage b) {
+constexpr inline TextureUsage operator&(TextureUsage a, TextureUsage b) {
   return TextureUsage(static_cast<uint8_t>(a) & static_cast<uint8_t>(b));
 }
 

--- a/engine/rhi/core/src/RenderGraph.cpp
+++ b/engine/rhi/core/src/RenderGraph.cpp
@@ -106,12 +106,12 @@ void RenderGraph::compile(ResourceRegistry &resourceRegistry) {
 
   std::reverse(mCompiledPasses.begin(), mCompiledPasses.end());
 
-  static constexpr VkPipelineStageFlags STAGE_FRAGMENT_TEST =
+  static constexpr VkPipelineStageFlags StageFragmentTest =
       VK_PIPELINE_STAGE_EARLY_FRAGMENT_TESTS_BIT |
       VK_PIPELINE_STAGE_LATE_FRAGMENT_TESTS_BIT;
-  static constexpr VkPipelineStageFlags STAGE_COLOR =
+  static constexpr VkPipelineStageFlags StageColor =
       VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT;
-  static constexpr VkPipelineStageFlags STAGE_FRAGMENT_SHADER =
+  static constexpr VkPipelineStageFlags StageFragmentShader =
       VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT;
 
   // Determine attachments, image layouts, and barriers
@@ -131,10 +131,10 @@ void RenderGraph::compile(ResourceRegistry &resourceRegistry) {
       VkAccessFlags otherAccess = 0;
 
       if (input.srcLayout == VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL) {
-        otherStage = STAGE_FRAGMENT_TEST;
+        otherStage = StageFragmentTest;
         otherAccess = VK_ACCESS_DEPTH_STENCIL_ATTACHMENT_WRITE_BIT;
       } else if (input.srcLayout == VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL) {
-        otherStage = STAGE_COLOR;
+        otherStage = StageColor;
         otherAccess = VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT;
       }
 
@@ -154,11 +154,11 @@ void RenderGraph::compile(ResourceRegistry &resourceRegistry) {
 
       pass.mPreBarrier.enabled = true;
       pass.mPreBarrier.srcStage |= otherStage;
-      pass.mPreBarrier.dstStage |= STAGE_FRAGMENT_SHADER;
+      pass.mPreBarrier.dstStage |= StageFragmentShader;
       pass.mPreBarrier.imageBarriers.push_back(preImageBarrier);
 
       pass.mPostBarrier.enabled = true;
-      pass.mPostBarrier.srcStage |= STAGE_FRAGMENT_SHADER;
+      pass.mPostBarrier.srcStage |= StageFragmentShader;
       pass.mPostBarrier.dstStage |= otherStage;
       pass.mPostBarrier.imageBarriers.push_back(postImageBarrier);
     }
@@ -184,12 +184,12 @@ void RenderGraph::compile(ResourceRegistry &resourceRegistry) {
           resourceRegistry.getTextureMap().getDescription(output.texture);
       if ((texture.usage & TextureUsage::Color) == TextureUsage::Color) {
         output.dstLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
-        stage = STAGE_COLOR;
+        stage = StageColor;
         srcAccess = VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT;
         dstAccess = srcAccess | VK_ACCESS_COLOR_ATTACHMENT_READ_BIT;
       } else if ((texture.usage & TextureUsage::Depth) == TextureUsage::Depth) {
         output.dstLayout = VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL;
-        stage = STAGE_FRAGMENT_TEST;
+        stage = StageFragmentTest;
         srcAccess = VK_ACCESS_DEPTH_STENCIL_ATTACHMENT_WRITE_BIT;
         dstAccess = srcAccess | VK_ACCESS_DEPTH_STENCIL_ATTACHMENT_READ_BIT;
       }

--- a/engine/rhi/core/src/RenderGraphEvaluator.cpp
+++ b/engine/rhi/core/src/RenderGraphEvaluator.cpp
@@ -134,10 +134,10 @@ RenderGraphEvaluator::createAttachment(const AttachmentData &attachment,
   info.attachment.initialLayout = renderTarget.srcLayout;
   info.attachment.layout = renderTarget.dstLayout;
 
-  constexpr uint32_t HUNDRED_PERCENT = 100;
+  static constexpr uint32_t HundredPercent = 100;
   if (desc.sizeMethod == TextureSizeMethod::FramebufferRatio) {
-    info.width = desc.width * extent.x / HUNDRED_PERCENT;
-    info.height = desc.height * extent.y / HUNDRED_PERCENT;
+    info.width = desc.width * extent.x / HundredPercent;
+    info.height = desc.height * extent.y / HundredPercent;
   } else {
     info.width = desc.width;
     info.height = desc.height;

--- a/engine/rhi/vulkan/src/VulkanDescriptorManager.cpp
+++ b/engine/rhi/vulkan/src/VulkanDescriptorManager.cpp
@@ -126,25 +126,25 @@ VulkanDescriptorManager::allocateDescriptorSet(VkDescriptorSetLayout layout) {
 }
 
 void VulkanDescriptorManager::createDescriptorPool() {
-  constexpr uint32_t NUM_UNIFORM_BUFFERS = 15000;
-  constexpr uint32_t NUM_STORAGE_BUFFERS = 10;
-  constexpr uint32_t NUM_SAMPLERS = 1000;
-  constexpr uint32_t NUM_DESCRIPTORS = 30000;
-  constexpr uint32_t MAX_TEXTURE_DESCRIPTORS = 8;
+  static constexpr uint32_t NumUniformBuffers = 15000;
+  static constexpr uint32_t NumStorageBuffers = 10;
+  static constexpr uint32_t NumSamplers = 1000;
+  static constexpr uint32_t NumDescriptors = 30000;
+  static constexpr uint32_t MaxTextureDescriptors = 8;
 
   std::array<VkDescriptorPoolSize, 3> poolSizes{
       VkDescriptorPoolSize{VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER,
-                           NUM_UNIFORM_BUFFERS},
+                           NumUniformBuffers},
       VkDescriptorPoolSize{VK_DESCRIPTOR_TYPE_STORAGE_BUFFER,
-                           NUM_STORAGE_BUFFERS},
+                           NumStorageBuffers},
       VkDescriptorPoolSize{VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER,
-                           MAX_TEXTURE_DESCRIPTORS * NUM_SAMPLERS}};
+                           MaxTextureDescriptors * NumSamplers}};
 
   VkDescriptorPoolCreateInfo descriptorPoolInfo{};
   descriptorPoolInfo.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_POOL_CREATE_INFO;
   descriptorPoolInfo.pNext = nullptr;
   descriptorPoolInfo.flags = 0;
-  descriptorPoolInfo.maxSets = NUM_DESCRIPTORS;
+  descriptorPoolInfo.maxSets = NumDescriptors;
   descriptorPoolInfo.poolSizeCount = static_cast<uint32_t>(poolSizes.size());
   descriptorPoolInfo.pPoolSizes = poolSizes.data();
 

--- a/engine/rhi/vulkan/src/VulkanRenderDevice.cpp
+++ b/engine/rhi/vulkan/src/VulkanRenderDevice.cpp
@@ -43,14 +43,14 @@ VulkanRenderDevice::VulkanRenderDevice(
 }
 
 RenderFrame VulkanRenderDevice::beginFrame() {
-  static constexpr auto SKIP_FRAME = std::numeric_limits<uint32_t>::max();
+  static constexpr auto SkipFrame = std::numeric_limits<uint32_t>::max();
   static RenderCommandList emptyCommandList;
 
   LIQUID_PROFILE_EVENT("VulkanRenderDevice::beginFrame");
 
   if (mBackend.isFramebufferResized()) {
     recreateSwapchain();
-    return {SKIP_FRAME, SKIP_FRAME, emptyCommandList};
+    return {SkipFrame, SkipFrame, emptyCommandList};
   }
 
   mStats.resetCalls();
@@ -61,7 +61,7 @@ RenderFrame VulkanRenderDevice::beginFrame() {
 
   if (imageIndex == std::numeric_limits<uint32_t>::max()) {
     recreateSwapchain();
-    return {SKIP_FRAME, SKIP_FRAME, emptyCommandList};
+    return {SkipFrame, SkipFrame, emptyCommandList};
   }
 
   auto &commandBuffer = mRenderContext.beginRendering(mFrameManager);
@@ -70,8 +70,6 @@ RenderFrame VulkanRenderDevice::beginFrame() {
 }
 
 void VulkanRenderDevice::endFrame(const RenderFrame &renderFrame) {
-  static constexpr auto SKIP_FRAME = std::numeric_limits<uint32_t>::max();
-
   LIQUID_PROFILE_EVENT("VulkanRenderDevice::endFrame");
   mSwapchainRecreated = false;
 

--- a/engine/rhi/vulkan/src/VulkanTexture.cpp
+++ b/engine/rhi/vulkan/src/VulkanTexture.cpp
@@ -46,12 +46,12 @@ VulkanTexture::VulkanTexture(const TextureDescription &description,
     imageViewType = VK_IMAGE_VIEW_TYPE_2D;
   }
 
-  static constexpr uint32_t HUNDRED_PERCENT = 100;
+  static constexpr uint32_t HundredPercent = 100;
 
   VkExtent3D extent{};
   if (isFramebufferRelative()) {
-    extent.width = description.width * swapchainExtent.x / HUNDRED_PERCENT;
-    extent.height = description.height * swapchainExtent.y / HUNDRED_PERCENT;
+    extent.width = description.width * swapchainExtent.x / HundredPercent;
+    extent.height = description.height * swapchainExtent.y / HundredPercent;
   } else {
     extent.width = description.width;
     extent.height = description.height;

--- a/engine/src/liquid/asset/AssetFileHeader.h
+++ b/engine/src/liquid/asset/AssetFileHeader.h
@@ -4,7 +4,7 @@
 
 namespace liquid {
 
-constexpr size_t ASSET_FILE_MAGIC_LENGTH = 11;
+static constexpr size_t AssetFileMagicLength = 11;
 
 /**
  * @brief Asset file header

--- a/engine/src/liquid/asset/AssetManager.cpp
+++ b/engine/src/liquid/asset/AssetManager.cpp
@@ -21,8 +21,8 @@ Result<bool> AssetManager::checkAssetFile(InputBinaryStream &file,
   }
 
   AssetFileHeader header;
-  String magic(ASSET_FILE_MAGIC_LENGTH, '$');
-  file.read(magic.data(), ASSET_FILE_MAGIC_LENGTH);
+  String magic(AssetFileMagicLength, '$');
+  file.read(magic.data(), AssetFileMagicLength);
   file.read(header.version);
   file.read(header.type);
 
@@ -120,8 +120,8 @@ Result<bool> AssetManager::loadAsset(const Path &path, bool updateExisting) {
 
   InputBinaryStream stream(path);
   AssetFileHeader header;
-  String magic(ASSET_FILE_MAGIC_LENGTH, '$');
-  stream.read(magic.data(), ASSET_FILE_MAGIC_LENGTH);
+  String magic(AssetFileMagicLength, '$');
+  stream.read(magic.data(), AssetFileMagicLength);
 
   if (magic != header.magic) {
     return Result<bool>::Error("Not a liquid asset");

--- a/engine/src/liquid/asset/AssetManagerAnimation.cpp
+++ b/engine/src/liquid/asset/AssetManagerAnimation.cpp
@@ -23,7 +23,7 @@ AssetManager::createAnimationFromAsset(const AssetData<AnimationAsset> &asset) {
   AssetFileHeader header{};
   header.type = AssetType::Animation;
   header.version = createVersion(0, 1);
-  file.write(header.magic, ASSET_FILE_MAGIC_LENGTH);
+  file.write(header.magic, AssetFileMagicLength);
   file.write(header.version);
   file.write(header.type);
 

--- a/engine/src/liquid/asset/AssetManagerMaterial.cpp
+++ b/engine/src/liquid/asset/AssetManagerMaterial.cpp
@@ -26,7 +26,7 @@ AssetManager::createMaterialFromAsset(const AssetData<MaterialAsset> &asset) {
   header.type = AssetType::Material;
   header.version = createVersion(0, 1);
 
-  file.write(header.magic, ASSET_FILE_MAGIC_LENGTH);
+  file.write(header.magic, AssetFileMagicLength);
   file.write(header.version);
   file.write(header.type);
 

--- a/engine/src/liquid/asset/AssetManagerMesh.cpp
+++ b/engine/src/liquid/asset/AssetManagerMesh.cpp
@@ -23,7 +23,7 @@ AssetManager::createMeshFromAsset(const AssetData<MeshAsset> &asset) {
   AssetFileHeader header{};
   header.type = AssetType::Mesh;
   header.version = createVersion(0, 1);
-  file.write(header.magic, ASSET_FILE_MAGIC_LENGTH);
+  file.write(header.magic, AssetFileMagicLength);
   file.write(header.version);
   file.write(header.type);
 
@@ -170,7 +170,7 @@ Result<Path> AssetManager::createSkinnedMeshFromAsset(
   AssetFileHeader header{};
   header.type = AssetType::SkinnedMesh;
   header.version = createVersion(0, 1);
-  file.write(header.magic, ASSET_FILE_MAGIC_LENGTH);
+  file.write(header.magic, AssetFileMagicLength);
   file.write(header.version);
   file.write(header.type);
 

--- a/engine/src/liquid/asset/AssetManagerPrefab.cpp
+++ b/engine/src/liquid/asset/AssetManagerPrefab.cpp
@@ -23,7 +23,7 @@ AssetManager::createPrefabFromAsset(const AssetData<PrefabAsset> &asset) {
   AssetFileHeader header{};
   header.type = AssetType::Prefab;
   header.version = createVersion(0, 1);
-  file.write(header.magic, ASSET_FILE_MAGIC_LENGTH);
+  file.write(header.magic, AssetFileMagicLength);
   file.write(header.version);
   file.write(header.type);
 

--- a/engine/src/liquid/asset/AssetManagerSkeleton.cpp
+++ b/engine/src/liquid/asset/AssetManagerSkeleton.cpp
@@ -23,7 +23,7 @@ AssetManager::createSkeletonFromAsset(const AssetData<SkeletonAsset> &asset) {
   AssetFileHeader header{};
   header.type = AssetType::Skeleton;
   header.version = createVersion(0, 1);
-  file.write(header.magic, ASSET_FILE_MAGIC_LENGTH);
+  file.write(header.magic, AssetFileMagicLength);
   file.write(header.version);
   file.write(header.type);
 

--- a/engine/src/liquid/asset/AssetManagerTexture.cpp
+++ b/engine/src/liquid/asset/AssetManagerTexture.cpp
@@ -66,7 +66,7 @@ AssetManager::createTextureFromAsset(const AssetData<TextureAsset> &asset) {
 
 Result<TextureAssetHandle>
 AssetManager::loadTextureFromFile(const Path &filePath) {
-  constexpr uint32_t CUBEMAP_SIDES = 6;
+  static constexpr uint32_t CubemapSides = 6;
 
   ktxTexture *ktxTextureData = nullptr;
   KTX_error_code result = ktxTexture_CreateFromNamedFile(
@@ -96,7 +96,7 @@ AssetManager::loadTextureFromFile(const Path &filePath) {
   texture.data.width = ktxTextureData->baseWidth;
   texture.data.height = ktxTextureData->baseHeight;
   texture.data.layers = ktxTextureData->numLayers *
-                        (ktxTextureData->isCubemap ? CUBEMAP_SIDES : 1);
+                        (ktxTextureData->isCubemap ? CubemapSides : 1);
   texture.data.type = ktxTextureData->isCubemap ? TextureAssetType::Cubemap
                                                 : TextureAssetType::Standard;
   texture.data.format = ktxTexture_GetVkFormat(ktxTextureData);
@@ -108,7 +108,7 @@ AssetManager::loadTextureFromFile(const Path &filePath) {
 
     char *dstData = static_cast<char *>(texture.data.data);
 
-    for (size_t i = 0; i < CUBEMAP_SIDES; ++i) {
+    for (size_t i = 0; i < CubemapSides; ++i) {
       size_t offset = 0;
       ktxTexture_GetImageOffset(ktxTextureData, 0, 0,
                                 static_cast<ktx_uint32_t>(i), &offset);

--- a/engine/src/liquid/asset/AudioAsset.h
+++ b/engine/src/liquid/asset/AudioAsset.h
@@ -9,12 +9,12 @@ enum class AudioAssetFormat { Unknown = 0, Wav, Mp3 };
  */
 struct AudioAsset {
   /**
-   * @brief Audio data
+   * Audio data
    */
   std::vector<char> bytes{};
 
   /**
-   * @brief Audio asset format
+   * Audio asset format
    */
   AudioAssetFormat format = AudioAssetFormat::Unknown;
 };

--- a/engine/src/liquid/asset/FileTracker.h
+++ b/engine/src/liquid/asset/FileTracker.h
@@ -9,12 +9,12 @@ enum class FileStatus { Created, Updated, Deleted };
  */
 struct ChangedFile {
   /**
-   * @brief Path to changed file
+   * Path to changed file
    */
   Path path;
 
   /**
-   * @brief Change status
+   * Change status
    */
   FileStatus status;
 };

--- a/engine/src/liquid/asset/TextureAsset.h
+++ b/engine/src/liquid/asset/TextureAsset.h
@@ -6,7 +6,7 @@ namespace liquid {
 
 enum class TextureAssetType { Standard, Cubemap };
 
-static constexpr uint32_t DEFAULT_TEXTURE_FORMAT = 43;
+static constexpr uint32_t DefaultTextureFormat = 43;
 
 /**
  * @brief Texture asset data
@@ -35,7 +35,7 @@ struct TextureAsset {
   /**
    * Texture format
    */
-  uint32_t format = DEFAULT_TEXTURE_FORMAT;
+  uint32_t format = DefaultTextureFormat;
 
   /**
    * Raw texture data

--- a/engine/src/liquid/audio/AudioScriptingInterface.h
+++ b/engine/src/liquid/audio/AudioScriptingInterface.h
@@ -37,7 +37,7 @@ public:
   /**
    * @brief Interface fields
    */
-  static constexpr std::array<InterfaceField, 2> fields{
+  static constexpr std::array<InterfaceField, 2> Fields{
       InterfaceField{"play", play}, InterfaceField{"is_playing", isPlaying}};
 
   /**

--- a/engine/src/liquid/audio/AudioStatusComponent.h
+++ b/engine/src/liquid/audio/AudioStatusComponent.h
@@ -7,7 +7,7 @@ namespace liquid {
  */
 struct AudioStatusComponent {
   /**
-   * @brief Sound instance
+   * Sound instance
    */
   void *instance = nullptr;
 };

--- a/engine/src/liquid/audio/AudioSystem.h
+++ b/engine/src/liquid/audio/AudioSystem.h
@@ -10,7 +10,7 @@ namespace liquid {
 /**
  * @brief Audio system
  *
- * @tparam Backend Audio backend
+ * @tparam AudioBackend Audio backend
  */
 template <class AudioBackend = DefaultAudioBackend> class AudioSystem {
 public:

--- a/engine/src/liquid/core/NameScriptingInterface.h
+++ b/engine/src/liquid/core/NameScriptingInterface.h
@@ -36,7 +36,7 @@ public:
   /**
    * @brief Interface fields
    */
-  static constexpr std::array<InterfaceField, 2> fields{
+  static constexpr std::array<InterfaceField, 2> Fields{
       InterfaceField{"get", get}, InterfaceField{"set", set}};
 
   /**

--- a/engine/src/liquid/core/Version.h
+++ b/engine/src/liquid/core/Version.h
@@ -11,8 +11,8 @@ namespace liquid {
  * @param build Build number
  * @return Version uint
  */
-constexpr uint64_t createVersion(uint8_t major, uint8_t minor = 0,
-                                 uint8_t patch = 0, uint32_t build = 0) {
+constexpr inline uint64_t createVersion(uint8_t major, uint8_t minor = 0,
+                                        uint8_t patch = 0, uint32_t build = 0) {
   return (static_cast<uint64_t>(major) << 56) |
          (static_cast<uint64_t>(minor) << 48) |
          (static_cast<uint64_t>(patch) << 40) | (static_cast<uint64_t>(build));

--- a/engine/src/liquid/entity/EntityQueryScriptingInterface.h
+++ b/engine/src/liquid/entity/EntityQueryScriptingInterface.h
@@ -30,7 +30,7 @@ public:
   /**
    * @brief Interface fields
    */
-  static constexpr std::array<InterfaceField, 1> fields{
+  static constexpr std::array<InterfaceField, 1> Fields{
       InterfaceField{"get_first_entity_by_name", getFirstEntityByName}};
 
   /**

--- a/engine/src/liquid/entity/EntityUtils.h
+++ b/engine/src/liquid/entity/EntityUtils.h
@@ -3,9 +3,9 @@
 namespace liquid::entity_utils {
 
 template <class T, class... Types>
-constexpr bool are_types_unique =
-    (!std::is_same_v<T, Types> && ...) && are_types_unique<Types...>;
+constexpr bool AreTypesUnique =
+    (!std::is_same_v<T, Types> && ...) && AreTypesUnique<Types...>;
 
-template <class T> constexpr bool are_types_unique<T> = std::true_type{};
+template <class T> constexpr bool AreTypesUnique<T> = std::true_type{};
 
 } // namespace liquid::entity_utils

--- a/engine/src/liquid/events/EventObserver.h
+++ b/engine/src/liquid/events/EventObserver.h
@@ -4,6 +4,6 @@ namespace liquid {
 
 using EventObserverId = size_t;
 
-constexpr size_t EVENT_OBSERVER_MAX = std::numeric_limits<size_t>::max();
+static constexpr size_t EventObserverMax = std::numeric_limits<size_t>::max();
 
 } // namespace liquid

--- a/engine/src/liquid/imgui/ImguiRenderer.cpp
+++ b/engine/src/liquid/imgui/ImguiRenderer.cpp
@@ -32,8 +32,8 @@ ImguiRenderer::ImguiRenderer(Window &window, ShaderLibrary &shaderLibrary,
   io.BackendFlags |= ImGuiBackendFlags_RendererHasVtxOffset;
   io.IniFilename = nullptr;
 
-  static constexpr size_t FRAMES_IN_FLIGHT = 2;
-  mFrameData.resize(FRAMES_IN_FLIGHT);
+  static constexpr size_t FramesInFlight = 2;
+  mFrameData.resize(FramesInFlight);
 
   ImGui::GetIO().ConfigFlags |= ImGuiConfigFlags_DockingEnable;
 
@@ -71,13 +71,13 @@ ImguiRenderPassData ImguiRenderer::attach(rhi::RenderGraph &graph) {
   LIQUID_ASSERT(mReady, "Fonts are not built. Call ImguiRenderer::loadFonts "
                         "before starting rendering");
 
-  constexpr uint32_t FRAMEBUFFER_SIZE_PERCENTAGE = 100;
+  static constexpr uint32_t FramebufferSizePercentage = 100;
 
   rhi::TextureDescription imguiDesc{};
   imguiDesc.sizeMethod = rhi::TextureSizeMethod::FramebufferRatio;
   imguiDesc.usage = rhi::TextureUsage::Color | rhi::TextureUsage::Sampled;
-  imguiDesc.width = FRAMEBUFFER_SIZE_PERCENTAGE;
-  imguiDesc.height = FRAMEBUFFER_SIZE_PERCENTAGE;
+  imguiDesc.width = FramebufferSizePercentage;
+  imguiDesc.height = FramebufferSizePercentage;
   imguiDesc.layers = 1;
   imguiDesc.format = VK_FORMAT_R8G8B8A8_UNORM;
   auto imgui = mRegistry.setTexture(imguiDesc);

--- a/engine/src/liquid/imgui/ImguiRenderer.h
+++ b/engine/src/liquid/imgui/ImguiRenderer.h
@@ -16,7 +16,7 @@ namespace liquid {
  */
 struct ImguiRenderPassData {
   /**
-   * @brief Imgui pass
+   * Imgui pass
    */
   rhi::RenderGraphPass &pass;
 

--- a/engine/src/liquid/imgui/ImguiUtils.h
+++ b/engine/src/liquid/imgui/ImguiUtils.h
@@ -35,7 +35,7 @@ void renderColumn(const String &value);
 
 void renderColumn(uint32_t value);
 
-template <class... Args> void renderRow(const Args &...args) {
+template <class... TArgs> void renderRow(const TArgs &...args) {
   ImGui::TableNextRow();
   (renderColumn(args), ...);
 }

--- a/engine/src/liquid/loaders/KtxTextureLoader.cpp
+++ b/engine/src/liquid/loaders/KtxTextureLoader.cpp
@@ -28,7 +28,7 @@ rhi::TextureHandle KtxTextureLoader::loadFromFile(const String &filename) {
       KtxError("Texture arrays are not supported", KTX_UNSUPPORTED_FEATURE)
           .what());
 
-  constexpr uint32_t CUBEMAP_SIDES = 6;
+  static constexpr uint32_t CubemapSides = 6;
 
   rhi::TextureDescription description;
   description.type = ktxTextureData->isCubemap ? rhi::TextureType::Cubemap
@@ -38,7 +38,7 @@ rhi::TextureHandle KtxTextureLoader::loadFromFile(const String &filename) {
   description.depth = ktxTextureData->baseDepth;
   description.format = ktxTexture_GetVkFormat(ktxTextureData);
   description.layers = ktxTextureData->numLayers *
-                       (ktxTextureData->isCubemap ? CUBEMAP_SIDES : 1);
+                       (ktxTextureData->isCubemap ? CubemapSides : 1);
   description.size = ktxTexture_GetDataSizeUncompressed(ktxTextureData);
   description.usage = rhi::TextureUsage::Sampled | rhi::TextureUsage::Color |
                       rhi::TextureUsage::TransferDestination;
@@ -51,7 +51,7 @@ rhi::TextureHandle KtxTextureLoader::loadFromFile(const String &filename) {
 
     char *dstData = static_cast<char *>(description.data);
 
-    for (size_t i = 0; i < CUBEMAP_SIDES; ++i) {
+    for (size_t i = 0; i < CubemapSides; ++i) {
       size_t offset = 0;
       ktxTexture_GetImageOffset(ktxTextureData, 0, 0,
                                 static_cast<ktx_uint32_t>(i), &offset);

--- a/engine/src/liquid/loop/MainLoop.cpp
+++ b/engine/src/liquid/loop/MainLoop.cpp
@@ -20,9 +20,9 @@ void MainLoop::setRenderFn(const std::function<void()> &renderFn) {
 void MainLoop::run() {
   bool running = true;
 
-  constexpr uint32_t ONE_SECOND_IN_MS = 1000;
-  constexpr double MAX_UPDATE_TIME = 0.25;
-  constexpr double dt = 0.01;
+  static constexpr uint32_t OneSecondInMs = 1000;
+  static constexpr double MaxUpdateTime = 0.25;
+  static constexpr double TimeDelta = 0.01;
 
   uint32_t frames = 0;
   double accumulator = 0.0;
@@ -41,21 +41,21 @@ void MainLoop::run() {
 
     double frameTime = std::clamp(
         std::chrono::duration<double>(currentTime - prevGameTime).count(), 0.0,
-        MAX_UPDATE_TIME);
+        MaxUpdateTime);
 
     prevGameTime = currentTime;
     accumulator += frameTime;
 
-    while (accumulator >= dt) {
-      running = mUpdateFn(static_cast<float>(dt));
-      accumulator -= dt;
+    while (accumulator >= TimeDelta) {
+      running = mUpdateFn(static_cast<float>(TimeDelta));
+      accumulator -= TimeDelta;
     }
 
     mRenderFn();
 
     if (std::chrono::duration_cast<std::chrono::milliseconds>(currentTime -
                                                               prevFrameTime)
-            .count() >= ONE_SECOND_IN_MS) {
+            .count() >= OneSecondInMs) {
       prevFrameTime = currentTime;
       mFpsCounter.collectFPS(frames);
       frames = 0;

--- a/engine/src/liquid/physics/ForceComponent.h
+++ b/engine/src/liquid/physics/ForceComponent.h
@@ -7,7 +7,7 @@ namespace liquid {
  */
 struct ForceComponent {
   /**
-   * @brief Total amount of applied force
+   * Total amount of applied force
    */
   glm::vec3 force;
 };

--- a/engine/src/liquid/physics/PhysicsSystem.cpp
+++ b/engine/src/liquid/physics/PhysicsSystem.cpp
@@ -144,16 +144,16 @@ public:
    */
   PhysicsSystemImpl(EventSystem &eventSystem)
       : mEventSystem(eventSystem), mSimulationEventCallback(mEventSystem) {
-    constexpr uint32_t PVD_PORT = 5425;
-    constexpr uint32_t PVD_TIMEOUT_IN_MS = 2000;
-    constexpr glm::vec3 GRAVITY(0.0f, -9.8f, 0.0f);
+    static constexpr uint32_t PvdPort = 5425;
+    static constexpr uint32_t PvdTimeoutInMs = 2000;
+    static constexpr glm::vec3 Gravity(0.0f, -9.8f, 0.0f);
 
     mFoundation = PxCreateFoundation(PX_PHYSICS_VERSION, mDefaultAllocator,
                                      mDefaultErrorCallback);
 
     mPvd = PxCreatePvd(*mFoundation);
-    PxPvdTransport *transport = PxDefaultPvdSocketTransportCreate(
-        "127.0.0.1", PVD_PORT, PVD_TIMEOUT_IN_MS);
+    PxPvdTransport *transport =
+        PxDefaultPvdSocketTransportCreate("127.0.0.1", PvdPort, PvdTimeoutInMs);
     mPvd->connect(*transport, PxPvdInstrumentationFlag::eALL);
 
     mPhysics =
@@ -164,7 +164,7 @@ public:
     mDispatcher = PxDefaultCpuDispatcherCreate(1);
     sceneDesc.cpuDispatcher = mDispatcher;
     sceneDesc.filterShader = phyxFilterAllCollisionShader;
-    sceneDesc.gravity = PxVec3(GRAVITY.x, GRAVITY.y, GRAVITY.z);
+    sceneDesc.gravity = PxVec3(Gravity.x, Gravity.y, Gravity.z);
     sceneDesc.flags = PxSceneFlag::eENABLE_ACTIVE_ACTORS;
     sceneDesc.simulationEventCallback = &mSimulationEventCallback;
 

--- a/engine/src/liquid/physics/RigidBodyScriptingInterface.h
+++ b/engine/src/liquid/physics/RigidBodyScriptingInterface.h
@@ -37,7 +37,7 @@ public:
   /**
    * @brief Interface fields
    */
-  static constexpr std::array<InterfaceField, 2> fields{
+  static constexpr std::array<InterfaceField, 2> Fields{
       InterfaceField{"apply_force", applyForce},
       InterfaceField{"apply_torque", applyTorque}};
 

--- a/engine/src/liquid/physics/TorqueComponent.h
+++ b/engine/src/liquid/physics/TorqueComponent.h
@@ -7,7 +7,7 @@ namespace liquid {
  */
 struct TorqueComponent {
   /**
-   * @brief Total amount of applied torque
+   * Total amount of applied torque
    */
   glm::vec3 torque;
 };

--- a/engine/src/liquid/renderer/RenderStorage.cpp
+++ b/engine/src/liquid/renderer/RenderStorage.cpp
@@ -11,9 +11,9 @@ RenderStorage::RenderStorage(size_t reservedSpace)
   mMeshTransformMatrices.reserve(mReservedSpace);
 
   mSkinnedMeshTransformMatrices.reserve(mReservedSpace);
-  mSkeletonVector.reset(new glm::mat4[mReservedSpace * MAX_NUM_JOINTS]);
+  mSkeletonVector.reset(new glm::mat4[mReservedSpace * MaxNumJoints]);
 
-  mLights.reserve(MAX_NUM_LIGHTS);
+  mLights.reserve(MaxNumLights);
 
   mTextTransforms.reserve(mReservedSpace);
   mTextGlyphs.reserve(mReservedSpace);
@@ -39,7 +39,7 @@ void RenderStorage::updateBuffers(rhi::ResourceRegistry &registry) {
   mSkeletonsBuffer = registry.setBuffer(
       {
           rhi::BufferType::Storage,
-          mReservedSpace * MAX_NUM_JOINTS * sizeof(glm::mat4),
+          mReservedSpace * MaxNumJoints * sizeof(glm::mat4),
           mSkeletonVector.get(),
       },
       mSkeletonsBuffer);
@@ -95,8 +95,8 @@ void RenderStorage::addSkinnedMesh(SkinnedMeshAssetHandle handle,
   mSkinnedMeshGroups.at(handle).indices.push_back(index);
 
   auto *currentSkeleton =
-      mSkeletonVector.get() + (mLastSkeleton * MAX_NUM_JOINTS);
-  size_t dataSize = std::min(skeleton.size(), MAX_NUM_JOINTS);
+      mSkeletonVector.get() + (mLastSkeleton * MaxNumJoints);
+  size_t dataSize = std::min(skeleton.size(), MaxNumJoints);
   memcpy(currentSkeleton, skeleton.data(), dataSize * sizeof(glm::mat4));
 
   mLastSkeleton++;

--- a/engine/src/liquid/renderer/RenderStorage.h
+++ b/engine/src/liquid/renderer/RenderStorage.h
@@ -19,17 +19,17 @@ public:
   /**
    * Default reserved space for buffers
    */
-  static constexpr size_t DEFAULT_RESERVED_SPACE = 10000;
+  static constexpr size_t DefaultReservedSpace = 10000;
 
   /**
    * Maximum number of joints
    */
-  static constexpr size_t MAX_NUM_JOINTS = 32;
+  static constexpr size_t MaxNumJoints = 32;
 
   /**
    * Maximum number of lights
    */
-  static constexpr size_t MAX_NUM_LIGHTS = 256;
+  static constexpr size_t MaxNumLights = 256;
 
   /**
    * @brief Light data
@@ -125,7 +125,7 @@ public:
    *
    * @param reservedSpace Reserved space for buffer data
    */
-  RenderStorage(size_t reservedSpace = DEFAULT_RESERVED_SPACE);
+  RenderStorage(size_t reservedSpace = DefaultReservedSpace);
 
   /**
    * @brief Update storage buffers

--- a/engine/src/liquid/renderer/SceneRenderer.cpp
+++ b/engine/src/liquid/renderer/SceneRenderer.cpp
@@ -54,24 +54,24 @@ void SceneRenderer::setClearColor(const glm::vec4 &clearColor) {
 }
 
 SceneRenderPassData SceneRenderer::attach(rhi::RenderGraph &graph) {
-  constexpr uint32_t NUM_LIGHTS = 16;
-  constexpr uint32_t SHADOWMAP_DIMENSIONS = 2048;
-  constexpr uint32_t SWAPCHAIN_SIZE_PERCENTAGE = 100;
+  static constexpr uint32_t NumLights = 16;
+  static constexpr uint32_t ShadowMapDimensions = 2048;
+  static constexpr uint32_t SwapchainSizePercentage = 100;
 
   rhi::TextureDescription shadowMapDesc{};
   shadowMapDesc.sizeMethod = rhi::TextureSizeMethod::Fixed;
   shadowMapDesc.usage = rhi::TextureUsage::Depth | rhi::TextureUsage::Sampled;
-  shadowMapDesc.width = SHADOWMAP_DIMENSIONS;
-  shadowMapDesc.height = SHADOWMAP_DIMENSIONS;
-  shadowMapDesc.layers = NUM_LIGHTS;
+  shadowMapDesc.width = ShadowMapDimensions;
+  shadowMapDesc.height = ShadowMapDimensions;
+  shadowMapDesc.layers = NumLights;
   shadowMapDesc.format = VK_FORMAT_D16_UNORM;
   auto shadowmap = mRegistry.setTexture(shadowMapDesc);
 
   rhi::TextureDescription sceneColorDesc{};
   sceneColorDesc.sizeMethod = rhi::TextureSizeMethod::FramebufferRatio;
   sceneColorDesc.usage = rhi::TextureUsage::Color | rhi::TextureUsage::Sampled;
-  sceneColorDesc.width = SWAPCHAIN_SIZE_PERCENTAGE;
-  sceneColorDesc.height = SWAPCHAIN_SIZE_PERCENTAGE;
+  sceneColorDesc.width = SwapchainSizePercentage;
+  sceneColorDesc.height = SwapchainSizePercentage;
   sceneColorDesc.layers = 1;
   sceneColorDesc.format = VK_FORMAT_B8G8R8A8_SRGB;
   auto sceneColor = mRegistry.setTexture(sceneColorDesc);
@@ -79,8 +79,8 @@ SceneRenderPassData SceneRenderer::attach(rhi::RenderGraph &graph) {
   rhi::TextureDescription depthBufferDesc{};
   depthBufferDesc.sizeMethod = rhi::TextureSizeMethod::FramebufferRatio;
   depthBufferDesc.usage = rhi::TextureUsage::Depth | rhi::TextureUsage::Sampled;
-  depthBufferDesc.width = SWAPCHAIN_SIZE_PERCENTAGE;
-  depthBufferDesc.height = SWAPCHAIN_SIZE_PERCENTAGE;
+  depthBufferDesc.width = SwapchainSizePercentage;
+  depthBufferDesc.height = SwapchainSizePercentage;
   depthBufferDesc.layers = 1;
   depthBufferDesc.format = VK_FORMAT_D32_SFLOAT;
   auto depthBuffer = mRegistry.setTexture(depthBufferDesc);
@@ -181,7 +181,7 @@ SceneRenderPassData SceneRenderer::attach(rhi::RenderGraph &graph) {
 
       rhi::Descriptor sceneDescriptor, sceneDescriptorFragment;
 
-      static constexpr uint32_t BRDF_BINDING = 5;
+      static constexpr uint32_t BrdfBinding = 5;
 
       sceneDescriptor.bind(0, mRenderStorage.getActiveCameraBuffer(),
                            rhi::DescriptorType::UniformBuffer);
@@ -197,7 +197,7 @@ SceneRenderPassData SceneRenderer::attach(rhi::RenderGraph &graph) {
                 {mRenderStorage.getIrradianceMap(),
                  mRenderStorage.getSpecularMap()},
                 rhi::DescriptorType::CombinedImageSampler)
-          .bind(BRDF_BINDING, {mRenderStorage.getBrdfLUT()},
+          .bind(BrdfBinding, {mRenderStorage.getBrdfLUT()},
                 rhi::DescriptorType::CombinedImageSampler);
 
       {
@@ -456,7 +456,7 @@ void SceneRenderer::renderSkinned(rhi::RenderCommandList &commandList,
 
 void SceneRenderer::renderText(rhi::RenderCommandList &commandList,
                                rhi::PipelineHandle pipeline) {
-  static constexpr uint32_t NUM_VERTICES = 6;
+  static constexpr uint32_t QuadNumVertices = 6;
   for (const auto &[font, texts] : mRenderStorage.getTextGroups()) {
     auto textureHandle =
         mAssetRegistry.getFonts().getAsset(font).data.deviceHandle;
@@ -484,8 +484,8 @@ void SceneRenderer::renderText(rhi::RenderCommandList &commandList,
           pipeline, VK_SHADER_STAGE_VERTEX_BIT, 0, sizeof(glm::uvec4),
           static_cast<void *>(glm::value_ptr(glyphStart)));
 
-      commandList.draw(NUM_VERTICES * static_cast<uint32_t>(text.length), 0, 1,
-                       text.index);
+      commandList.draw(QuadNumVertices * static_cast<uint32_t>(text.length), 0,
+                       1, text.index);
     }
   }
 }

--- a/engine/src/liquid/renderer/SceneRenderer.h
+++ b/engine/src/liquid/renderer/SceneRenderer.h
@@ -13,12 +13,12 @@ namespace liquid {
  */
 struct SceneRenderPassData {
   /**
-   * @brief Scene texture
+   * Scene texture
    */
   rhi::TextureHandle sceneColor;
 
   /**
-   * @brief Scene depth buffer
+   * Scene depth buffer
    */
   rhi::TextureHandle depthBuffer;
 };

--- a/engine/src/liquid/scene/AutoAspectRatioComponent.h
+++ b/engine/src/liquid/scene/AutoAspectRatioComponent.h
@@ -2,6 +2,12 @@
 
 namespace liquid {
 
+/**
+ * @brief Auto aspect ratio component
+ *
+ * Used to automatically calculate the
+ * aspect ratio of a camera
+ */
 struct AutoAspectRatioComponent {};
 
 } // namespace liquid

--- a/engine/src/liquid/scene/TransformScriptingInterface.h
+++ b/engine/src/liquid/scene/TransformScriptingInterface.h
@@ -53,7 +53,7 @@ public:
   /**
    * @brief Interface fields
    */
-  static constexpr std::array<InterfaceField, 4> fields{
+  static constexpr std::array<InterfaceField, 4> Fields{
       InterfaceField{"get_scale", getScale},
       InterfaceField{"set_scale", setScale},
       InterfaceField{"get_position", getPosition},

--- a/engine/src/liquid/scripting/ComponentLuaInterface.h
+++ b/engine/src/liquid/scripting/ComponentLuaInterface.h
@@ -9,12 +9,12 @@ public:
    */
   struct InterfaceField {
     /**
-     * @brief Field key
+     * Field key
      */
     const char *key;
 
     /**
-     * @brief Field function
+     * Field function
      */
     int (*fn)(void *);
   };

--- a/engine/src/liquid/scripting/EntityDecorator.cpp
+++ b/engine/src/liquid/scripting/EntityDecorator.cpp
@@ -19,11 +19,11 @@ namespace liquid {
  * @return Lua table
  */
 template <class TLuaInterface> LuaTable createInterfaceTable(LuaScope &scope) {
-  constexpr auto tableSize =
-      static_cast<uint32_t>(sizeof(TLuaInterface::fields));
-  auto table = scope.createTable(tableSize + 1);
+  static constexpr auto TableSize =
+      static_cast<uint32_t>(sizeof(TLuaInterface::Fields));
+  auto table = scope.createTable(TableSize + 1);
 
-  for (auto &field : TLuaInterface::fields) {
+  for (auto &field : TLuaInterface::Fields) {
     table.set(field.key, field.fn);
   }
 

--- a/engine/src/liquid/scripting/LuaScope.h
+++ b/engine/src/liquid/scripting/LuaScope.h
@@ -11,7 +11,7 @@ namespace liquid {
  */
 struct LuaUserData {
   /**
-   * @brief User data pointer
+   * User data pointer
    */
   void *pointer = nullptr;
 };

--- a/engine/src/liquid/scripting/ScriptingComponent.h
+++ b/engine/src/liquid/scripting/ScriptingComponent.h
@@ -33,22 +33,22 @@ struct ScriptingComponent {
   /**
    * Collision start observer
    */
-  EventObserverId onCollisionStart = EVENT_OBSERVER_MAX;
+  EventObserverId onCollisionStart = EventObserverMax;
 
   /**
    * Collision end observer
    */
-  EventObserverId onCollisionEnd = EVENT_OBSERVER_MAX;
+  EventObserverId onCollisionEnd = EventObserverMax;
 
   /**
    * Key press observer
    */
-  EventObserverId onKeyPress = EVENT_OBSERVER_MAX;
+  EventObserverId onKeyPress = EventObserverMax;
 
   /**
    * Key release observer
    */
-  EventObserverId onKeyRelease = EVENT_OBSERVER_MAX;
+  EventObserverId onKeyRelease = EventObserverMax;
 };
 
 } // namespace liquid

--- a/engine/src/liquid/scripting/ScriptingSystem.cpp
+++ b/engine/src/liquid/scripting/ScriptingSystem.cpp
@@ -125,21 +125,21 @@ void ScriptingSystem::createScriptingData(ScriptingComponent &component,
 void ScriptingSystem::destroyScriptingData(ScriptingComponent &component) {
   mLuaInterpreter.destroyScope(component.scope);
 
-  if (component.onCollisionStart != EVENT_OBSERVER_MAX) {
+  if (component.onCollisionStart != EventObserverMax) {
     mEventSystem.removeObserver(CollisionEvent::CollisionStarted,
                                 component.onCollisionStart);
   }
 
-  if (component.onCollisionEnd != EVENT_OBSERVER_MAX) {
+  if (component.onCollisionEnd != EventObserverMax) {
     mEventSystem.removeObserver(CollisionEvent::CollisionEnded,
                                 component.onCollisionEnd);
   }
 
-  if (component.onKeyPress != EVENT_OBSERVER_MAX) {
+  if (component.onKeyPress != EventObserverMax) {
     mEventSystem.removeObserver(KeyboardEvent::Pressed, component.onKeyPress);
   }
 
-  if (component.onKeyRelease != EVENT_OBSERVER_MAX) {
+  if (component.onKeyRelease != EventObserverMax) {
     mEventSystem.removeObserver(KeyboardEvent::Released,
                                 component.onKeyRelease);
   }

--- a/engine/src/liquid/text/TextComponent.h
+++ b/engine/src/liquid/text/TextComponent.h
@@ -9,17 +9,17 @@ namespace liquid {
  */
 struct TextComponent {
   /**
-   * @brief Text contents
+   * Text contents
    */
   String text;
 
   /**
-   * @brief Line height
+   * Line height
    */
   float lineHeight = 1.0f;
 
   /**
-   * @brief Font used for rendering
+   * Font used for rendering
    */
   FontAssetHandle font = FontAssetHandle::Invalid;
 };

--- a/engine/src/liquid/window/Window.h
+++ b/engine/src/liquid/window/Window.h
@@ -132,8 +132,8 @@ private:
   EventSystem &mEventSystem;
   ::GLFWwindow *mWindowInstance;
 
-  template <class FunctionType>
-  using HandlerMap = std::map<uint32_t, std::function<FunctionType>>;
+  template <class TFunctionType>
+  using HandlerMap = std::map<uint32_t, std::function<TFunctionType>>;
 
   HandlerMap<void(uint32_t, uint32_t)> mResizeHandlers;
   HandlerMap<void(bool)> mFocusHandlers;

--- a/engine/tests/liquid-tests/asset/AssetManagerAnimation.test.cpp
+++ b/engine/tests/liquid-tests/asset/AssetManagerAnimation.test.cpp
@@ -62,7 +62,7 @@ TEST_F(AssetManagerTest, CreatesAnimationFile) {
   EXPECT_TRUE(file.good());
 
   liquid::AssetFileHeader header;
-  liquid::String magic(liquid::ASSET_FILE_MAGIC_LENGTH, '$');
+  liquid::String magic(liquid::AssetFileMagicLength, '$');
   file.read(magic.data(), magic.length());
   file.read(header.version);
   file.read(header.type);

--- a/engine/tests/liquid-tests/asset/AssetManagerMaterial.test.cpp
+++ b/engine/tests/liquid-tests/asset/AssetManagerMaterial.test.cpp
@@ -88,7 +88,7 @@ TEST_F(AssetManagerTest, CreatesMaterialWithTexturesFromAsset) {
 
     liquid::AssetFileHeader header;
 
-    liquid::String magic(liquid::ASSET_FILE_MAGIC_LENGTH, '$');
+    liquid::String magic(liquid::AssetFileMagicLength, '$');
     file.read(magic.data(), magic.size());
 
     file.read(header.version);
@@ -169,7 +169,7 @@ TEST_F(AssetManagerTest,
     EXPECT_TRUE(file.good());
 
     liquid::AssetFileHeader header;
-    liquid::String magic(liquid::ASSET_FILE_MAGIC_LENGTH, '$');
+    liquid::String magic(liquid::AssetFileMagicLength, '$');
     file.read(magic.data(), magic.length());
     file.read(header.version);
     file.read(header.type);

--- a/engine/tests/liquid-tests/asset/AssetManagerMesh.test.cpp
+++ b/engine/tests/liquid-tests/asset/AssetManagerMesh.test.cpp
@@ -135,7 +135,7 @@ TEST_F(AssetManagerTest, CreatesMeshFileFromMeshAsset) {
   EXPECT_TRUE(file.good());
 
   liquid::AssetFileHeader header;
-  liquid::String magic(liquid::ASSET_FILE_MAGIC_LENGTH, '$');
+  liquid::String magic(liquid::AssetFileMagicLength, '$');
   file.read(magic.data(), magic.length());
   file.read(header.version);
   file.read(header.type);
@@ -297,7 +297,7 @@ TEST_F(AssetManagerTest, CreatesSkinnedMeshFileFromSkinnedMeshAsset) {
   EXPECT_TRUE(file.good());
 
   liquid::AssetFileHeader header;
-  liquid::String magic(liquid::ASSET_FILE_MAGIC_LENGTH, '$');
+  liquid::String magic(liquid::AssetFileMagicLength, '$');
   file.read(magic.data(), magic.length());
   file.read(header.version);
   file.read(header.type);

--- a/engine/tests/liquid-tests/asset/AssetManagerPrefab.test.cpp
+++ b/engine/tests/liquid-tests/asset/AssetManagerPrefab.test.cpp
@@ -88,7 +88,7 @@ TEST_F(AssetManagerTest, CreatesPrefabFile) {
   EXPECT_TRUE(file.good());
 
   liquid::AssetFileHeader header;
-  liquid::String magic(liquid::ASSET_FILE_MAGIC_LENGTH, '$');
+  liquid::String magic(liquid::AssetFileMagicLength, '$');
   file.read(magic.data(), magic.length());
   file.read(header.version);
   file.read(header.type);

--- a/engine/tests/liquid-tests/asset/AssetManagerSkeleton.test.cpp
+++ b/engine/tests/liquid-tests/asset/AssetManagerSkeleton.test.cpp
@@ -71,7 +71,7 @@ TEST_F(AssetManagerTest, CreatesSkeletonFileFromSkeletonAsset) {
   EXPECT_TRUE(file.good());
 
   liquid::AssetFileHeader header;
-  liquid::String magic(liquid::ASSET_FILE_MAGIC_LENGTH, '$');
+  liquid::String magic(liquid::AssetFileMagicLength, '$');
   file.read(magic.data(), magic.length());
   file.read(header.version);
   file.read(header.type);

--- a/engine/tests/liquid-tests/core/EntityDeleter.test.cpp
+++ b/engine/tests/liquid-tests/core/EntityDeleter.test.cpp
@@ -10,9 +10,9 @@ public:
 };
 
 TEST_F(EntityDeleterTest, DeleteEntitiesThatHaveDeleteComponents) {
-  static constexpr size_t NUM_ENTITIES = 20;
+  static constexpr size_t NumEntities = 20;
 
-  std::vector<liquid::Entity> entities(NUM_ENTITIES, liquid::EntityNull);
+  std::vector<liquid::Entity> entities(NumEntities, liquid::EntityNull);
   for (size_t i = 0; i < entities.size(); ++i) {
     auto entity = entityDatabase.createEntity();
     entities.at(i) = entity;

--- a/engine/tests/liquid-tests/core/RingBuffer.test.cpp
+++ b/engine/tests/liquid-tests/core/RingBuffer.test.cpp
@@ -56,19 +56,19 @@ TEST_F(RingBufferDeathTest, PoppingFailsIfQueueIsEmpty) {
 TEST_F(RingBufferTest, ManyOperations) {
   liquid::RingBuffer<Data> bigBuffer(150);
 
-  static constexpr int NUM_ADDITIONS = 100;
-  for (int i = 0; i < NUM_ADDITIONS; ++i) {
+  static constexpr int NumAdditions = 100;
+  for (int i = 0; i < NumAdditions; ++i) {
     bigBuffer.push({i});
   }
 
   EXPECT_FALSE(bigBuffer.empty());
-  EXPECT_EQ(bigBuffer.size(), NUM_ADDITIONS);
+  EXPECT_EQ(bigBuffer.size(), NumAdditions);
   int i = 0;
   while (!bigBuffer.empty()) {
     EXPECT_EQ(bigBuffer.front().val, i++);
     bigBuffer.pop();
   }
 
-  EXPECT_EQ(i, NUM_ADDITIONS);
+  EXPECT_EQ(i, NumAdditions);
   EXPECT_TRUE(bigBuffer.empty());
 }

--- a/engine/tests/liquid-tests/core/SparseSet.test.cpp
+++ b/engine/tests/liquid-tests/core/SparseSet.test.cpp
@@ -7,7 +7,7 @@ class SparseSetTest : public ::testing::Test {
 public:
   liquid::SparseSet<uint32_t> sparseSet;
 
-  static constexpr size_t NUM_ITEMS = 20;
+  static constexpr size_t NumItems = 20;
 };
 
 using SparseSetDeathTest = SparseSetTest;
@@ -15,18 +15,18 @@ using SparseSetDeathTest = SparseSetTest;
 using SparseSetIteratorTest = SparseSetTest;
 
 TEST_F(SparseSetTest, PushesItemToTheEndOfTheListIfNoHoles) {
-  for (size_t i = 0; i < NUM_ITEMS; ++i) {
+  for (size_t i = 0; i < NumItems; ++i) {
     size_t index = sparseSet.insert(static_cast<uint32_t>(i) * 2);
     EXPECT_EQ(index, (sparseSet.size() - 1));
   }
 
-  for (size_t i = 0; i < NUM_ITEMS; ++i) {
+  for (size_t i = 0; i < NumItems; ++i) {
     EXPECT_EQ(sparseSet.at(i), static_cast<uint32_t>(i) * 2);
   }
 }
 
 TEST_F(SparseSetTest, ErasesItemAtIndex) {
-  for (uint32_t i = 0; i < NUM_ITEMS; ++i) {
+  for (uint32_t i = 0; i < NumItems; ++i) {
     size_t index = sparseSet.insert(i * 2);
     EXPECT_EQ(index, sparseSet.size() - 1);
   }
@@ -56,14 +56,14 @@ TEST_F(SparseSetTest, ErasesItemAtIndex) {
 
   EXPECT_FALSE(sparseSet.contains(17));
 
-  for (size_t i = 18; i < NUM_ITEMS; ++i) {
+  for (size_t i = 18; i < NumItems; ++i) {
     EXPECT_TRUE(sparseSet.contains(i));
     EXPECT_EQ(sparseSet.at(i), i * 2);
   }
 }
 
 TEST_F(SparseSetTest, FillsEmptyHolesOnInsertIfThereAreAny) {
-  for (size_t i = 0; i < NUM_ITEMS; ++i) {
+  for (size_t i = 0; i < NumItems; ++i) {
     size_t index = sparseSet.insert(static_cast<uint32_t>(i) * 2);
     EXPECT_EQ(index, sparseSet.size() - 1);
   }
@@ -87,7 +87,7 @@ TEST_F(SparseSetTest, FillsEmptyHolesOnInsertIfThereAreAny) {
 }
 
 TEST_F(SparseSetTest, GetsSize) {
-  for (uint32_t i = 0; i < NUM_ITEMS; ++i) {
+  for (uint32_t i = 0; i < NumItems; ++i) {
     size_t index = sparseSet.insert(i * 2);
     EXPECT_EQ(index, sparseSet.size() - 1);
   }
@@ -96,15 +96,15 @@ TEST_F(SparseSetTest, GetsSize) {
   sparseSet.erase(9);
   sparseSet.erase(17);
 
-  EXPECT_EQ(sparseSet.size(), NUM_ITEMS - 3);
+  EXPECT_EQ(sparseSet.size(), NumItems - 3);
 }
 
 TEST_F(SparseSetTest, EmptyReturnsTrueIfSetIsEmpty) {
-  for (uint32_t i = 0; i < NUM_ITEMS; ++i) {
+  for (uint32_t i = 0; i < NumItems; ++i) {
     sparseSet.insert(i * 2);
   }
 
-  for (uint32_t i = 0; i < NUM_ITEMS; ++i) {
+  for (uint32_t i = 0; i < NumItems; ++i) {
     sparseSet.erase(i);
   }
 
@@ -112,7 +112,7 @@ TEST_F(SparseSetTest, EmptyReturnsTrueIfSetIsEmpty) {
 }
 
 TEST_F(SparseSetTest, EmptyReturnsFalseIfSetIsNotEmpty) {
-  for (uint32_t i = 0; i < NUM_ITEMS; ++i) {
+  for (uint32_t i = 0; i < NumItems; ++i) {
     size_t index = sparseSet.insert(i * 2);
   }
 
@@ -124,7 +124,7 @@ TEST_F(SparseSetDeathTest, FailsGettingItemIfIndexOutOfBounds) {
 }
 
 TEST_F(SparseSetDeathTest, FailsGettingItemIfNoItemAtIndex) {
-  for (uint32_t i = 0; i < NUM_ITEMS; ++i) {
+  for (uint32_t i = 0; i < NumItems; ++i) {
     sparseSet.insert(i * 2);
   }
 
@@ -134,7 +134,7 @@ TEST_F(SparseSetDeathTest, FailsGettingItemIfNoItemAtIndex) {
 }
 
 TEST_F(SparseSetTest, FailsGettingItemIfNoItemAtIndex) {
-  for (uint32_t i = 0; i < NUM_ITEMS; ++i) {
+  for (uint32_t i = 0; i < NumItems; ++i) {
     sparseSet.insert(i * 2);
   }
 

--- a/engine/tests/liquid-tests/scene/SceneIO.test.cpp
+++ b/engine/tests/liquid-tests/scene/SceneIO.test.cpp
@@ -115,7 +115,7 @@ TEST_F(SceneIOTest, DoesNotCreateEntityFromNodeIfIdAlreadyExists) {
 }
 
 TEST_F(SceneIOTest, LoadingSceneFilesFromDirectoryCreatesOneEntityPerFile) {
-  constexpr uint64_t NumEntities = 9;
+  static constexpr uint64_t NumEntities = 9;
 
   for (uint64_t i = 1; i < NumEntities + 1; ++i) {
     createSimpleEntityFile(i);
@@ -130,7 +130,7 @@ TEST_F(SceneIOTest, LoadingSceneFilesFromDirectoryCreatesOneEntityPerFile) {
 }
 
 TEST_F(SceneIOTest, SavingSceneAfterLoadingCreatesEntityWithNonConflictingId) {
-  constexpr uint64_t NumEntities = 9;
+  static constexpr uint64_t NumEntities = 9;
 
   for (uint64_t i = 1; i < NumEntities + 1; ++i) {
     createSimpleEntityFile(i);
@@ -149,7 +149,7 @@ TEST_F(SceneIOTest, SavingSceneAfterLoadingCreatesEntityWithNonConflictingId) {
 }
 
 TEST_F(SceneIOTest, LoadingSetsParentsProperly) {
-  constexpr uint64_t NumEntities = 9;
+  static constexpr uint64_t NumEntities = 9;
 
   for (uint64_t i = 1; i < NumEntities + 1; ++i) {
     // set parent to next entity
@@ -167,7 +167,7 @@ TEST_F(SceneIOTest, LoadingSetsParentsProperly) {
 }
 
 TEST_F(SceneIOTest, LoadingSetsParentsFromPreviousSaveProperly) {
-  constexpr uint64_t NumEntities = 9;
+  static constexpr uint64_t NumEntities = 9;
 
   auto parent = entityDatabase.createEntity();
 

--- a/engine/tests/liquid-tests/scene/private/EntitySerializer.test.cpp
+++ b/engine/tests/liquid-tests/scene/private/EntitySerializer.test.cpp
@@ -126,7 +126,7 @@ TEST_F(EntitySerializerTest,
 }
 
 TEST_F(EntitySerializerTest, DoesNotCreateMeshFieldIfMeshAssetIsNotInRegistry) {
-  constexpr liquid::MeshAssetHandle NonExistentMeshHandle{45};
+  static constexpr liquid::MeshAssetHandle NonExistentMeshHandle{45};
 
   auto entity = entityDatabase.createEntity();
   entityDatabase.setComponent<liquid::MeshComponent>(entity,
@@ -160,7 +160,7 @@ TEST_F(EntitySerializerTest,
 
 TEST_F(EntitySerializerTest,
        DoesNotCreateSkinnedMeshFieldIfSkinnedMeshAssetIsNotInRegistry) {
-  constexpr liquid::SkinnedMeshAssetHandle NonExistentMeshHandle{45};
+  static constexpr liquid::SkinnedMeshAssetHandle NonExistentMeshHandle{45};
 
   auto entity = entityDatabase.createEntity();
   entityDatabase.setComponent<liquid::SkinnedMeshComponent>(
@@ -192,7 +192,7 @@ TEST_F(EntitySerializerTest,
 
 TEST_F(EntitySerializerTest,
        DoesNotCreateSkeletonFieldIfSkeletonAssetIsNotInRegistry) {
-  constexpr liquid::SkeletonAssetHandle NonExistentSkeletonHandle{45};
+  static constexpr liquid::SkeletonAssetHandle NonExistentSkeletonHandle{45};
 
   auto entity = entityDatabase.createEntity();
   liquid::SkeletonComponent component{};
@@ -300,7 +300,7 @@ TEST_F(EntitySerializerTest,
 
 TEST_F(EntitySerializerTest,
        DoesNotCreateAudioFieldIfAudioAssetIsNotInRegistry) {
-  constexpr liquid::AudioAssetHandle NonExistentHandle{45};
+  static constexpr liquid::AudioAssetHandle NonExistentHandle{45};
 
   auto entity = entityDatabase.createEntity();
   entityDatabase.setComponent<liquid::AudioSourceComponent>(
@@ -336,7 +336,7 @@ TEST_F(EntitySerializerTest,
 
 TEST_F(EntitySerializerTest,
        DoesNotCreateScriptFieldIfScriptAssetIsNotInRegistry) {
-  constexpr liquid::LuaScriptAssetHandle NonExistentHandle{45};
+  static constexpr liquid::LuaScriptAssetHandle NonExistentHandle{45};
 
   auto entity = entityDatabase.createEntity();
   entityDatabase.setComponent<liquid::ScriptingComponent>(entity,
@@ -385,7 +385,7 @@ TEST_F(EntitySerializerTest, DoesNotCreateTextFieldIfTextContentsAreEmpty) {
 }
 
 TEST_F(EntitySerializerTest, DoesNotCreateTextFieldIfFontAssetIsNotInRegistry) {
-  constexpr liquid::FontAssetHandle NonExistentHandle{45};
+  static constexpr liquid::FontAssetHandle NonExistentHandle{45};
 
   auto entity = entityDatabase.createEntity();
 
@@ -431,7 +431,7 @@ TEST_F(EntitySerializerTest,
 
 TEST_F(EntitySerializerTest,
        DoesNotCreateParentComponentIfParentEntityDoesNotExist) {
-  constexpr liquid::Entity NonExistentEntity{50};
+  static constexpr liquid::Entity NonExistentEntity{50};
 
   auto entity = entityDatabase.createEntity();
 
@@ -454,7 +454,7 @@ TEST_F(EntitySerializerTest,
 }
 
 TEST_F(EntitySerializerTest, CreatesEntityComponentIfParentIdExists) {
-  constexpr uint64_t ParentId{50};
+  static constexpr uint64_t ParentId{50};
 
   auto parent = entityDatabase.createEntity();
   entityDatabase.setComponent<liquid::IdComponent>(parent, {ParentId});

--- a/engine/tests/liquid-tests/scene/private/SceneLoader.test.cpp
+++ b/engine/tests/liquid-tests/scene/private/SceneLoader.test.cpp
@@ -344,9 +344,9 @@ TEST_F(SceneLoaderSkeletonTest,
        CreatesSkeletonComponentWithFileDataIfValidField) {
   liquid::AssetData<liquid::SkeletonAsset> data{};
 
-  constexpr uint32_t numJoints = 5;
+  static constexpr uint32_t NumJoints = 5;
 
-  for (uint32_t i = 0; i < numJoints; ++i) {
+  for (uint32_t i = 0; i < NumJoints; ++i) {
     float fi = static_cast<float>(i);
 
     data.data.jointLocalPositions.push_back(glm::vec3(fi));
@@ -370,8 +370,8 @@ TEST_F(SceneLoaderSkeletonTest,
       entityDatabase.getComponent<liquid::SkeletonComponent>(entity);
   EXPECT_EQ(skeleton.assetHandle, handle);
 
-  EXPECT_EQ(skeleton.numJoints, numJoints);
-  for (uint32_t i = 0; i < numJoints; ++i) {
+  EXPECT_EQ(skeleton.numJoints, NumJoints);
+  for (uint32_t i = 0; i < NumJoints; ++i) {
     float fi = static_cast<float>(i);
 
     EXPECT_EQ(skeleton.jointLocalPositions.at(i),
@@ -434,12 +434,12 @@ TEST_F(SceneLoaderLightTest,
 
 TEST_F(SceneLoaderLightTest,
        DoesNotCreateAnyLightComponentIfLightTypeIsUndefined) {
-  constexpr uint32_t invalidStart = 1;
+  static constexpr uint32_t InvalidStart = 1;
 
   // Check for 10 items
-  constexpr uint32_t size = 10;
+  static constexpr uint32_t Size = 10;
 
-  for (uint32_t i = invalidStart; i < invalidStart + size; ++i) {
+  for (uint32_t i = InvalidStart; i < InvalidStart + Size; ++i) {
     auto [node, entity] = createNode();
     node["components"]["light"]["type"] = i;
     sceneLoader.loadComponents(node, entity, entityIdCache).getData();
@@ -1008,11 +1008,11 @@ TEST_F(SceneLoaderParentTest,
 
 TEST_F(SceneLoaderParentTest,
        DoesNotCreateParentComponentIfParentDoesNotExist) {
-  constexpr uint64_t nonExistentId = 255;
+  static constexpr uint64_t NonExistentId = 255;
   auto [parentNode, parentEntity] = createNode();
 
   auto [node, entity] = createNode();
-  node["components"]["transform"]["parent"] = nonExistentId;
+  node["components"]["transform"]["parent"] = NonExistentId;
   sceneLoader.loadComponents(node, entity, entityIdCache).getData();
 
   EXPECT_FALSE(entityDatabase.hasComponent<liquid::ParentComponent>(entity));
@@ -1022,13 +1022,13 @@ TEST_F(SceneLoaderParentTest,
 
 TEST_F(SceneLoaderParentTest,
        DoesNotCreateParentComponentIfParentIsNotCreatedWithSceneLoader) {
-  constexpr uint64_t parentId = 255;
+  static constexpr uint64_t ParentId = 255;
 
   auto parentEntity = entityDatabase.createEntity();
-  entityDatabase.setComponent<liquid::IdComponent>(parentEntity, {parentId});
+  entityDatabase.setComponent<liquid::IdComponent>(parentEntity, {ParentId});
 
   auto [node, entity] = createNode();
-  node["components"]["transform"]["parent"] = parentId;
+  node["components"]["transform"]["parent"] = ParentId;
   sceneLoader.loadComponents(node, entity, entityIdCache).getData();
 
   EXPECT_FALSE(entityDatabase.hasComponent<liquid::ParentComponent>(entity));

--- a/engine/tests/liquid-tests/scripting/ScriptingSystem.test.cpp
+++ b/engine/tests/liquid-tests/scripting/ScriptingSystem.test.cpp
@@ -18,7 +18,7 @@ public:
 
 using ScriptingSystemDeathTest = ScriptingSystemTest;
 
-constexpr float DELTA_TIME = 0.2f;
+static constexpr float TimeDelta = 0.2f;
 
 TEST_F(ScriptingSystemTest, CallsScriptingUpdateFunctionOnUpdate) {
   auto handle = assetManager
@@ -36,9 +36,9 @@ TEST_F(ScriptingSystemTest, CallsScriptingUpdateFunctionOnUpdate) {
   scriptingSystem.start(entityDatabase);
   EXPECT_NE(component.scope.getLuaState(), nullptr);
 
-  scriptingSystem.update(DELTA_TIME, entityDatabase);
+  scriptingSystem.update(TimeDelta, entityDatabase);
   EXPECT_EQ(component.scope.getGlobal<int32_t>("value"), 0);
-  EXPECT_EQ(component.scope.getGlobal<float>("global_dt"), DELTA_TIME);
+  EXPECT_EQ(component.scope.getGlobal<float>("global_dt"), TimeDelta);
 }
 
 TEST_F(ScriptingSystemTest,
@@ -48,9 +48,9 @@ TEST_F(ScriptingSystemTest,
                                            "scripting-system-tester.lua")
                     .getData();
 
-  static constexpr size_t NUM_ENTITIES = 20;
+  static constexpr size_t NumEntities = 20;
 
-  std::vector<liquid::Entity> entities(NUM_ENTITIES, liquid::EntityNull);
+  std::vector<liquid::Entity> entities(NumEntities, liquid::EntityNull);
   for (size_t i = 0; i < entities.size(); ++i) {
     auto entity = entityDatabase.createEntity();
     entities.at(i) = entity;
@@ -62,7 +62,7 @@ TEST_F(ScriptingSystemTest,
   }
 
   scriptingSystem.start(entityDatabase);
-  scriptingSystem.update(DELTA_TIME, entityDatabase);
+  scriptingSystem.update(TimeDelta, entityDatabase);
 
   for (size_t i = 0; i < entities.size(); ++i) {
     auto entity = entities.at(i);
@@ -87,7 +87,7 @@ TEST_F(ScriptingSystemTest, CallsScriptingUpdateFunctionOnEveryUpdate) {
   EXPECT_NE(component.scope.getLuaState(), nullptr);
 
   for (size_t i = 0; i < 10; ++i) {
-    scriptingSystem.update(DELTA_TIME, entityDatabase);
+    scriptingSystem.update(TimeDelta, entityDatabase);
   }
 
   EXPECT_EQ(component.scope.getGlobal<int32_t>("value"), 9);
@@ -146,10 +146,10 @@ TEST_F(ScriptingSystemTest, RegistersEventsOnStart) {
 
   scriptingSystem.start(entityDatabase);
 
-  EXPECT_LT(component.onCollisionStart, liquid::EVENT_OBSERVER_MAX);
-  EXPECT_LT(component.onCollisionEnd, liquid::EVENT_OBSERVER_MAX);
-  EXPECT_LT(component.onKeyPress, liquid::EVENT_OBSERVER_MAX);
-  EXPECT_LT(component.onKeyRelease, liquid::EVENT_OBSERVER_MAX);
+  EXPECT_LT(component.onCollisionStart, liquid::EventObserverMax);
+  EXPECT_LT(component.onCollisionEnd, liquid::EventObserverMax);
+  EXPECT_LT(component.onKeyPress, liquid::EventObserverMax);
+  EXPECT_LT(component.onKeyRelease, liquid::EventObserverMax);
 }
 
 TEST_F(ScriptingSystemTest,


### PR DESCRIPTION
- Update doxygen comments
- Remove @brief command from structure fields
- Add missing brief tags for functions and classes
- Add docblocks to all shaders
- Enable doxygen validation for shaders
- Update casings for template parameters
- Update casings for static constants and constexprs
- Add clang-tidy rules for casings
- Remove or replace unnecessary constant variables