### PR TITLE
Fix crashing when window is minimized

### DIFF
--- a/editor/src/liquidator/ui/Layout.cpp
+++ b/editor/src/liquidator/ui/Layout.cpp
@@ -12,6 +12,9 @@ void Layout::setup() {
 
   const auto &viewport = ImGui::GetMainViewport();
 
+  if (viewport->Size.x <= 0.0f || viewport->Size.y <= 0.0f)
+    return;
+
   ImGui::SetNextWindowPos(
       ImVec2(viewport->Pos.x,
              viewport->Pos.y + ImGui::GetFrameHeight() + Toolbar::Height));

--- a/engine/src/liquid/loop/MainLoop.cpp
+++ b/engine/src/liquid/loop/MainLoop.cpp
@@ -51,7 +51,10 @@ void MainLoop::run() {
       accumulator -= TimeDelta;
     }
 
-    mRenderFn();
+    const auto &size = mWindow.getWindowSize();
+    if (size.x > 0.0f && size.y > 0.0f) {
+      mRenderFn();
+    }
 
     if (std::chrono::duration_cast<std::chrono::milliseconds>(currentTime -
                                                               prevFrameTime)

--- a/engine/src/liquid/scene/CameraAspectRatioUpdater.cpp
+++ b/engine/src/liquid/scene/CameraAspectRatioUpdater.cpp
@@ -10,6 +10,9 @@ void CameraAspectRatioUpdater::update(EntityDatabase &entityDatabase) {
   LIQUID_PROFILE_EVENT("CameraAspectRatioUpdater::update");
   const auto &size = mWindow.getWindowSize();
 
+  if (size.x <= 0.0f || size.y <= 0.0f)
+    return;
+
   entityDatabase
       .iterateEntities<PerspectiveLensComponent, AutoAspectRatioComponent>(
           [&size](auto entity, auto &lens, auto &_) {


### PR DESCRIPTION
- Disable rendering when window is minimized
- Do not update camera aspect ratios if window is minimized
- Do not update docking sizes when window is minimized