### PR TITLE
Use path instead of string for engine assets paths

### DIFF
--- a/demos/pong-3d/src/main.cpp
+++ b/demos/pong-3d/src/main.cpp
@@ -291,8 +291,7 @@ private:
 };
 
 int main() {
-  liquid::Engine::setAssetsPath(
-      std::filesystem::path("./engine/assets").string());
+  liquid::Engine::setPath(std::filesystem::current_path() / "engine");
   Game game;
   return game.run();
 }

--- a/editor/src/liquidator/core/EditorRenderer.cpp
+++ b/editor/src/liquidator/core/EditorRenderer.cpp
@@ -11,26 +11,28 @@ EditorRenderer::EditorRenderer(liquid::rhi::ResourceRegistry &registry,
     : mRegistry(registry), mIconRegistry(iconRegistry),
       mShaderLibrary(shaderLibrary), mRenderStorage(device) {
 
-  mShaderLibrary.addShader(
-      "editor-grid.vert",
-      registry.setShader({"assets/shaders/editor-grid.vert.spv"}));
-  mShaderLibrary.addShader(
-      "editor-grid.frag",
-      registry.setShader({"assets/shaders/editor-grid.frag.spv"}));
+  const auto shadersPath =
+      std::filesystem::current_path() / "assets" / "shaders";
 
   mShaderLibrary.addShader(
+      "editor-grid.vert",
+      registry.setShader({shadersPath / "editor-grid.vert.spv"}));
+  mShaderLibrary.addShader(
+      "editor-grid.frag",
+      registry.setShader({shadersPath / "editor-grid.frag.spv"}));
+  mShaderLibrary.addShader(
       "skeleton-lines.vert",
-      registry.setShader({"assets/shaders/skeleton-lines.vert.spv"}));
+      registry.setShader({shadersPath / "skeleton-lines.vert.spv"}));
   mShaderLibrary.addShader(
       "skeleton-lines.frag",
-      registry.setShader({"assets/shaders/skeleton-lines.frag.spv"}));
+      registry.setShader({shadersPath / "skeleton-lines.frag.spv"}));
 
   mShaderLibrary.addShader(
       "object-icons.vert",
-      registry.setShader({"assets/shaders/object-icons.vert.spv"}));
+      registry.setShader({shadersPath / "object-icons.vert.spv"}));
   mShaderLibrary.addShader(
       "object-icons.frag",
-      registry.setShader({"assets/shaders/object-icons.frag.spv"}));
+      registry.setShader({shadersPath / "object-icons.frag.spv"}));
 }
 
 liquid::rhi::RenderGraphPass &

--- a/editor/src/liquidator/ui/Theme.cpp
+++ b/editor/src/liquidator/ui/Theme.cpp
@@ -90,8 +90,7 @@ static void setImguiStyles() {
  * @brief Add fonts
  */
 static void addFonts() {
-  liquid::Path fontPath = liquid::Path(liquid::Engine::getAssetsPath()) /
-                          "fonts" / "Roboto-Regular.ttf";
+  liquid::Path fontPath = liquid::Engine::getFontsPath() / "Roboto-Regular.ttf";
   auto &io = ImGui::GetIO();
   io.Fonts->AddFontFromFileTTF(fontPath.string().c_str(), FontSize);
 }

--- a/editor/src/main.cpp
+++ b/editor/src/main.cpp
@@ -9,7 +9,7 @@ int main() {
   static constexpr uint32_t InitialWidth = 1024;
   static constexpr uint32_t InitialHeight = 768;
 
-  liquid::Engine::setAssetsPath(liquid::Path("./engine/assets").string());
+  liquid::Engine::setPath(std::filesystem::current_path() / "engine");
 
   liquid::EventSystem eventSystem;
   liquid::Window window("Liquidator", InitialWidth, InitialHeight, eventSystem);

--- a/engine/rhi/core/include/liquid/rhi/ShaderDescription.h
+++ b/engine/rhi/core/include/liquid/rhi/ShaderDescription.h
@@ -9,7 +9,7 @@ struct ShaderDescription {
   /**
    * Path to shader file
    */
-  String path;
+  Path path;
 };
 
 } // namespace liquid::rhi

--- a/engine/rhi/vulkan/include/liquid/rhi-vulkan/VulkanShader.h
+++ b/engine/rhi/vulkan/include/liquid/rhi-vulkan/VulkanShader.h
@@ -77,16 +77,14 @@ private:
    * @param filepath File path
    * @return Shader data in bytes
    */
-  static std::vector<char> readShaderFile(const String &filepath);
+  static std::vector<char> readShaderFile(const Path &filepath);
 
   /**
    * @brief Create reflection info
    *
    * @param bytes SpirV Bytes
-   * @param filepath File path
    */
-  void createReflectionInfo(const std::vector<char> &bytes,
-                            const String &filepath);
+  void createReflectionInfo(const std::vector<char> &bytes);
 
 private:
   VulkanDeviceObject &mDevice;
@@ -95,7 +93,7 @@ private:
   VkShaderStageFlagBits mStage = VK_SHADER_STAGE_FLAG_BITS_MAX_ENUM;
 
   ReflectionData mReflectionData{};
-  String mPath;
+  Path mPath;
 };
 
 } // namespace liquid::rhi

--- a/engine/src/liquid/asset/DefaultObjects.cpp
+++ b/engine/src/liquid/asset/DefaultObjects.cpp
@@ -103,8 +103,8 @@ AssetData<MaterialAsset> createDefaultMaterial() {
 AssetData<FontAsset> createDefaultFont() {
   MsdfLoader loader;
 
-  auto font = loader.loadFontData(Path(Engine::getAssetsPath()) / "fonts" /
-                                  "Roboto-Regular.ttf");
+  auto font =
+      loader.loadFontData(Engine::getFontsPath() / "Roboto-Regular.ttf");
 
   font.getData().path = "liquid::engine/fonts/Roboto-Regular.ttf";
   font.getData().relativePath = "liquid::engine/fonts/Roboto-Regular.ttf";

--- a/engine/src/liquid/core/Engine.cpp
+++ b/engine/src/liquid/core/Engine.cpp
@@ -6,8 +6,13 @@ namespace liquid {
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 Engine Engine::engine;
 
-void Engine::setAssetsPath(const String &path) { engine.mAssetsPath = path; }
+void Engine::setPath(const Path &path) {
+  engine.mEnginePath = path;
+  engine.mAssetsPath = engine.mEnginePath / "assets";
+}
 
-const String &Engine::getAssetsPath() { return engine.mAssetsPath; }
+const Path Engine::getShadersPath() { return engine.mAssetsPath / "shaders"; }
+
+const Path Engine::getFontsPath() { return engine.mAssetsPath / "fonts"; }
 
 } // namespace liquid

--- a/engine/src/liquid/core/Engine.h
+++ b/engine/src/liquid/core/Engine.h
@@ -17,18 +17,25 @@ private:
 
 public:
   /**
-   * @brief Set assets path for engine
+   * @brief Set path for engine data
    *
-   * @param path Assets path
+   * @param path Engine path
    */
-  static void setAssetsPath(const String &path);
+  static void setPath(const Path &path);
 
   /**
-   * @brief Get assets path for engine
+   * @brief Get path for engine shaders
    *
-   * @return Assets path
+   * @return Engine shaders path
    */
-  static const String &getAssetsPath();
+  static const Path getShadersPath();
+
+  /**
+   * @brief Get path for engine fonts
+   *
+   * @return Engine fonts path
+   */
+  static const Path getFontsPath();
 
 private:
   /**
@@ -40,7 +47,8 @@ private:
   Engine() = default;
 
 private:
-  String mAssetsPath;
+  Path mAssetsPath;
+  Path mEnginePath;
 };
 
 } // namespace liquid

--- a/engine/src/liquid/imgui/ImguiRenderer.cpp
+++ b/engine/src/liquid/imgui/ImguiRenderer.cpp
@@ -40,12 +40,12 @@ ImguiRenderer::ImguiRenderer(Window &window, ShaderLibrary &shaderLibrary,
 
   LOG_DEBUG("[ImGui] ImGui initialized with Vulkan backend");
 
-  mShaderLibrary.addShader("__engine.imgui.default.vertex",
-                           mRegistry.setShader({Engine::getAssetsPath() +
-                                                "/shaders/imgui.vert.spv"}));
-  mShaderLibrary.addShader("__engine.imgui.default.fragment",
-                           mRegistry.setShader({Engine::getAssetsPath() +
-                                                "/shaders/imgui.frag.spv"}));
+  mShaderLibrary.addShader(
+      "__engine.imgui.default.vertex",
+      mRegistry.setShader({Engine::getShadersPath() / "imgui.vert.spv"}));
+  mShaderLibrary.addShader(
+      "__engine.imgui.default.fragment",
+      mRegistry.setShader({Engine::getShadersPath() / "imgui.frag.spv"}));
 
   for (auto &x : mFrameData) {
     x.vertexBuffer =

--- a/engine/src/liquid/renderer/Presenter.cpp
+++ b/engine/src/liquid/renderer/Presenter.cpp
@@ -9,14 +9,12 @@ namespace liquid {
 Presenter::Presenter(ShaderLibrary &shaderLibrary,
                      rhi::ResourceRegistry &registry)
     : mRegistry(registry), mShaderLibrary(shaderLibrary) {
-  mShaderLibrary.addShader(
-      "__engine.fullscreenQuad.default.vertex",
-      mRegistry.setShader(
-          {Engine::getAssetsPath() + "/shaders/fullscreenQuad.vert.spv"}));
-  mShaderLibrary.addShader(
-      "__engine.fullscreenQuad.default.fragment",
-      mRegistry.setShader(
-          {Engine::getAssetsPath() + "/shaders/fullscreenQuad.frag.spv"}));
+  mShaderLibrary.addShader("__engine.fullscreenQuad.default.vertex",
+                           mRegistry.setShader({Engine::getShadersPath() /
+                                                "fullscreenQuad.vert.spv"}));
+  mShaderLibrary.addShader("__engine.fullscreenQuad.default.fragment",
+                           mRegistry.setShader({Engine::getShadersPath() /
+                                                "fullscreenQuad.frag.spv"}));
 }
 
 void Presenter::updateFramebuffers(const rhi::Swapchain &swapchain) {

--- a/engine/src/liquid/renderer/SceneRenderer.cpp
+++ b/engine/src/liquid/renderer/SceneRenderer.cpp
@@ -13,41 +13,40 @@ SceneRenderer::SceneRenderer(ShaderLibrary &shaderLibrary,
     : mShaderLibrary(shaderLibrary), mRegistry(resourceRegistry),
       mAssetRegistry(assetRegistry), mDevice(device), mRenderStorage(device) {
 
-  auto assetsPath = Engine::getAssetsPath();
+  auto shadersPath = Engine::getShadersPath();
 
   mShaderLibrary.addShader(
       "__engine.geometry.default.vertex",
-      mRegistry.setShader({assetsPath + "/shaders/geometry.vert.spv"}));
+      mRegistry.setShader({shadersPath / "geometry.vert.spv"}));
   mShaderLibrary.addShader(
       "__engine.geometry.skinned.vertex",
-      mRegistry.setShader({assetsPath + "/shaders/skinnedGeometry.vert.spv"}));
-  mShaderLibrary.addShader(
-      "__engine.pbr.default.fragment",
-      mRegistry.setShader({assetsPath + "/shaders/pbr.frag.spv"}));
+      mRegistry.setShader({shadersPath / "skinnedGeometry.vert.spv"}));
+  mShaderLibrary.addShader("__engine.pbr.default.fragment",
+                           mRegistry.setShader({shadersPath / "pbr.frag.spv"}));
   mShaderLibrary.addShader(
       "__engine.skybox.default.vertex",
-      mRegistry.setShader({assetsPath + "/shaders/skybox.vert.spv"}));
+      mRegistry.setShader({shadersPath / "skybox.vert.spv"}));
   mShaderLibrary.addShader(
       "__engine.skybox.default.fragment",
-      mRegistry.setShader({assetsPath + "/shaders/skybox.frag.spv"}));
+      mRegistry.setShader({shadersPath / "skybox.frag.spv"}));
   mShaderLibrary.addShader(
       "__engine.shadowmap.default.vertex",
-      mRegistry.setShader({assetsPath + "/shaders/shadowmap.vert.spv"}));
+      mRegistry.setShader({shadersPath / "shadowmap.vert.spv"}));
   mShaderLibrary.addShader(
       "__engine.shadowmap.skinned.vertex",
-      mRegistry.setShader({assetsPath + "/shaders/skinnedShadowmap.vert.spv"}));
+      mRegistry.setShader({shadersPath / "skinnedShadowmap.vert.spv"}));
 
   mShaderLibrary.addShader(
       "__engine.shadowmap.default.fragment",
-      mRegistry.setShader({assetsPath + "/shaders/shadowmap.frag.spv"}));
+      mRegistry.setShader({shadersPath / "shadowmap.frag.spv"}));
 
   mShaderLibrary.addShader(
       "__engine.text.default.vertex",
-      mRegistry.setShader({assetsPath + "/shaders/text.vert.spv"}));
+      mRegistry.setShader({shadersPath / "text.vert.spv"}));
 
   mShaderLibrary.addShader(
       "__engine.text.default.fragment",
-      mRegistry.setShader({assetsPath + "/shaders/text.frag.spv"}));
+      mRegistry.setShader({shadersPath / "text.frag.spv"}));
 }
 
 void SceneRenderer::setClearColor(const glm::vec4 &clearColor) {


### PR DESCRIPTION
- Create functions in Engine for shaders and fonts path
- Remove getAssetsPath
- Use shaders and fonts path to find engine paths
- Update all shader paths to use Path syntax instead of string
- Replace set assets path with set path to denote non assets as well