### PR TITLE
Show collidable shape outlines when selecting entities

### DIFF
--- a/editor/assets/shaders/collidable-shape.frag
+++ b/editor/assets/shaders/collidable-shape.frag
@@ -1,0 +1,8 @@
+#version 460
+
+layout(location = 0) out vec4 outColor;
+
+void main() {
+  outColor = vec4(1.0, 1.0, 0.0, 1.0);
+  gl_FragDepth = 0.0;
+}

--- a/editor/assets/shaders/collidable-shape.vert
+++ b/editor/assets/shaders/collidable-shape.vert
@@ -1,0 +1,39 @@
+#version 460
+
+layout(location = 0) in vec3 inPosition;
+
+layout(set = 0, binding = 0) uniform CameraData {
+  mat4 proj;
+  mat4 view;
+  mat4 viewProj;
+}
+uCameraData;
+
+layout(set = 0, binding = 1) uniform CollidableParams {
+  mat4 worldTransform;
+  uvec4 type;
+  vec4 params;
+}
+uCollidableParams;
+
+void main() {
+  vec3 finalPosition = inPosition;
+
+  if (uCollidableParams.type.x == 0) {
+    // Box
+    vec3 scale = vec3(uCollidableParams.params) * 2.0;
+    finalPosition *= scale;
+  } else if (uCollidableParams.type.x == 1) {
+    // Sphere
+    vec3 scale = vec3(uCollidableParams.params.x);
+    finalPosition *= scale;
+  } else if (uCollidableParams.type.x == 2) {
+    // Capsule
+    vec3 scale = vec3(uCollidableParams.params.x, uCollidableParams.params.y,
+                      uCollidableParams.params.x);
+    finalPosition *= scale;
+  }
+
+  gl_Position = uCameraData.viewProj * uCollidableParams.worldTransform *
+                vec4(finalPosition, 1.0);
+}

--- a/editor/premake5.lua
+++ b/editor/premake5.lua
@@ -20,6 +20,8 @@ project "Liquidator"
         "glslc ../../editor/assets/shaders/mouse-picking.vert -o %{cfg.buildtarget.directory}/assets/shaders/mouse-picking.vert.spv",
         "glslc ../../editor/assets/shaders/mouse-picking-skinned.vert -o %{cfg.buildtarget.directory}/assets/shaders/mouse-picking-skinned.vert.spv",
         "glslc ../../editor/assets/shaders/mouse-picking.frag -o %{cfg.buildtarget.directory}/assets/shaders/mouse-picking.frag.spv",
+        "glslc ../../editor/assets/shaders/collidable-shape.vert -o %{cfg.buildtarget.directory}/assets/shaders/collidable-shape.vert.spv",
+        "glslc ../../editor/assets/shaders/collidable-shape.frag -o %{cfg.buildtarget.directory}/assets/shaders/collidable-shape.frag.spv",
         "{MKDIR} %{cfg.buildtarget.directory}/assets/icons",
         "{COPYFILE} ../../editor/assets/icons/texture.png %{cfg.buildtarget.directory}/assets/icons/texture.png",
         "{COPYFILE} ../../editor/assets/icons/font.png %{cfg.buildtarget.directory}/assets/icons/font.png",

--- a/editor/src/liquidator/core/EditorRenderer.cpp
+++ b/editor/src/liquidator/core/EditorRenderer.cpp
@@ -11,6 +11,8 @@ EditorRenderer::EditorRenderer(liquid::rhi::ResourceRegistry &registry,
     : mRegistry(registry), mIconRegistry(iconRegistry),
       mShaderLibrary(shaderLibrary), mRenderStorage(device) {
 
+  createCollidableShapes();
+
   const auto shadersPath =
       std::filesystem::current_path() / "assets" / "shaders";
 
@@ -33,6 +35,13 @@ EditorRenderer::EditorRenderer(liquid::rhi::ResourceRegistry &registry,
   mShaderLibrary.addShader(
       "object-icons.frag",
       registry.setShader({shadersPath / "object-icons.frag.spv"}));
+
+  mShaderLibrary.addShader(
+      "collidable-shape.vert",
+      registry.setShader({shadersPath / "collidable-shape.vert.spv"}));
+  mShaderLibrary.addShader(
+      "collidable-shape.frag",
+      registry.setShader({shadersPath / "collidable-shape.frag.spv"}));
 }
 
 liquid::rhi::RenderGraphPass &
@@ -89,13 +98,62 @@ EditorRenderer::attach(liquid::rhi::RenderGraph &graph) {
                liquid::rhi::BlendFactor::DstAlpha,
                liquid::rhi::BlendOp::Add}}}});
 
+  static const float WireframeLineHeight = 3.0f;
+
+  auto collidableShapePipeline = mRegistry.setPipeline(
+      {mShaderLibrary.getShader("collidable-shape.vert"),
+       mShaderLibrary.getShader("collidable-shape.frag"),
+       liquid::rhi::PipelineVertexInputLayout::create<liquid::Vertex>(),
+       liquid::rhi::PipelineInputAssembly{
+           liquid::rhi::PrimitiveTopology::LineList},
+       liquid::rhi::PipelineRasterizer{
+           liquid::rhi::PolygonMode::Fill, liquid::rhi::CullMode::None,
+           liquid::rhi::FrontFace::Clockwise, WireframeLineHeight},
+       liquid::rhi::PipelineColorBlend{
+           {liquid::rhi::PipelineColorBlendAttachment{
+               true, liquid::rhi::BlendFactor::SrcAlpha,
+               liquid::rhi::BlendFactor::DstAlpha, liquid::rhi::BlendOp::Add,
+               liquid::rhi::BlendFactor::SrcAlpha,
+               liquid::rhi::BlendFactor::DstAlpha,
+               liquid::rhi::BlendOp::Add}}}});
+
   pass.addPipeline(editorGridPipeline);
   pass.addPipeline(skeletonLinesPipeline);
   pass.addPipeline(objectIconsPipeline);
+  pass.addPipeline(collidableShapePipeline);
 
   pass.setExecutor([editorGridPipeline, skeletonLinesPipeline,
-                    objectIconsPipeline,
+                    objectIconsPipeline, collidableShapePipeline,
                     this](liquid::rhi::RenderCommandList &commandList) {
+    // Collidable shapes
+    if (mRenderStorage.isCollidableEntitySelected() &&
+        mRenderStorage.getCollidableShapeType() !=
+            liquid::PhysicsGeometryType::Plane) {
+      LIQUID_PROFILE_EVENT("EditorPass::CollidableShapes");
+
+      commandList.bindPipeline(collidableShapePipeline);
+      liquid::rhi::Descriptor sceneDescriptor;
+      sceneDescriptor.bind(0, mRenderStorage.getActiveCameraBuffer(),
+                           liquid::rhi::DescriptorType::UniformBuffer);
+      sceneDescriptor.bind(1, mRenderStorage.getCollidableParamsBuffer(),
+                           liquid::rhi::DescriptorType::UniformBuffer);
+
+      commandList.bindDescriptor(collidableShapePipeline, 0, sceneDescriptor);
+
+      auto type = mRenderStorage.getCollidableShapeType();
+
+      if (type == liquid::PhysicsGeometryType::Box) {
+        commandList.bindVertexBuffer(mCollidableCube.buffer.getHandle());
+        commandList.draw(mCollidableCube.vertexCount, 0);
+      } else if (type == liquid::PhysicsGeometryType::Sphere) {
+        commandList.bindVertexBuffer(mCollidableSphere.buffer.getHandle());
+        commandList.draw(mCollidableSphere.vertexCount, 0);
+      } else if (type == liquid::PhysicsGeometryType::Capsule) {
+        commandList.bindVertexBuffer(mCollidableCapsule.buffer.getHandle());
+        commandList.draw(mCollidableCapsule.vertexCount, 0);
+      }
+    }
+
     // Editor grid
     {
       LIQUID_PROFILE_EVENT("EditorPass::EditorGrid");
@@ -176,9 +234,17 @@ EditorRenderer::attach(liquid::rhi::RenderGraph &graph) {
 
 void EditorRenderer::updateFrameData(liquid::EntityDatabase &entityDatabase,
                                      liquid::Entity camera,
-                                     const EditorGrid &editorGrid) {
+                                     const EditorGrid &editorGrid,
+                                     liquid::Entity selectedEntity) {
   LIQUID_PROFILE_EVENT("EditorRenderer::update");
   mRenderStorage.clear();
+
+  if (entityDatabase.has<liquid::CollidableComponent>(selectedEntity)) {
+    mRenderStorage.setCollidable(
+        selectedEntity,
+        entityDatabase.get<liquid::CollidableComponent>(selectedEntity),
+        entityDatabase.get<liquid::WorldTransformComponent>(selectedEntity));
+  }
 
   mRenderStorage.setActiveCamera(
       entityDatabase.get<liquid::CameraComponent>(camera));
@@ -212,6 +278,159 @@ void EditorRenderer::updateFrameData(liquid::EntityDatabase &entityDatabase,
       });
 
   mRenderStorage.updateBuffers();
+}
+
+void EditorRenderer::createCollidableShapes() {
+  // NOLINTBEGIN(cppcoreguidelines-avoid-magic-numbers)
+  static constexpr float Pi = glm::pi<float>();
+
+  using V = liquid::Vertex;
+
+  // Box shape
+  {
+    std::vector<liquid::Vertex> CollidableBoxVertices{
+        // clang-format off
+      V{-0.5f, -0.5f, -0.5f}, V{0.5f, -0.5f, -0.5f},
+      V{-0.5f, -0.5f, -0.5f}, V{-0.5f, 0.5f, -0.5f},
+      V{0.5f, -0.5f, -0.5f}, V{0.5f, 0.5f, -0.5f},
+      V{-0.5f, 0.5f, -0.5f}, V{0.5f, 0.5f, -0.5f},
+
+      // Top
+      V{-0.5f, -0.5f, -0.5f}, V{-0.5f, -0.5f, 0.5f},
+      V{-0.5f, -0.5f, 0.5f}, V{0.5f, -0.5f, 0.5f},
+      V{0.5f, -0.5f, -0.5f}, V{0.5f, -0.5f, 0.5f},
+
+      // Front
+      V{-0.5f, -0.5f, 0.5f}, V{-0.5f, 0.5f, 0.5f},
+      V{-0.5f, 0.5f, 0.5f}, V{0.5f, 0.5f, 0.5f},
+      V{0.5f, -0.5f, 0.5f}, V{0.5f, 0.5f, 0.5f},
+
+      // Bottom
+      V{0.5f, 0.5f, -0.5f}, V{0.5f, 0.5f, 0.5f},
+      V{-0.5f, 0.5f, -0.5f}, V{-0.5f, 0.5f, 0.5f}
+        // clang-format on
+    };
+
+    mCollidableCube.buffer = mRenderStorage.getRenderDevice()->createBuffer(
+        {liquid::rhi::BufferType::Vertex,
+         CollidableBoxVertices.size() * sizeof(liquid::Vertex),
+         static_cast<const void *>(CollidableBoxVertices.data())});
+    mCollidableCube.vertexCount =
+        static_cast<uint32_t>(CollidableBoxVertices.size());
+  }
+
+  using CalculationFn = std::function<float(float)>;
+
+  static constexpr float Radius = 1.0f;
+
+  auto cSinCenter = [](float center) {
+    return [center](float angle) { return Radius * sin(angle) + center; };
+  };
+  auto cCosCenter = [](float center) {
+    return [center](float angle) { return Radius * cos(angle) + center; };
+  };
+
+  auto cSin = cSinCenter(0.0f);
+  auto cCos = cCosCenter(0.0f);
+  auto cZero = [](float angle) { return 0.0f; };
+
+  // Sphere shape
+  {
+    auto drawUnitCircle = [](std::vector<liquid::Vertex> &vertices,
+                             uint32_t numSegments, CalculationFn cX,
+                             CalculationFn cY, CalculationFn cZ) {
+      const float SegmentDelta = 2.0f * Pi / static_cast<float>(numSegments);
+      float segmentAngle = SegmentDelta;
+
+      V start{cX(0.0f), cY(0.0f), cZ(0.0f)};
+
+      vertices.push_back(start);
+
+      for (uint32_t i = 0; i < numSegments; ++i) {
+        V vertex{cX(segmentAngle), cY(segmentAngle), cZ(segmentAngle)};
+
+        vertices.push_back(vertex);
+        vertices.push_back(vertex);
+
+        segmentAngle += SegmentDelta;
+      }
+
+      vertices.push_back(start);
+    };
+
+    static constexpr uint32_t NumSegments = 12;
+    std::vector<liquid::Vertex> CollidableSphereVertices;
+
+    drawUnitCircle(CollidableSphereVertices, NumSegments, cZero, cSin, cCos);
+    drawUnitCircle(CollidableSphereVertices, NumSegments, cSin, cCos, cZero);
+
+    mCollidableSphere.buffer = mRenderStorage.getRenderDevice()->createBuffer(
+        {liquid::rhi::BufferType::Vertex,
+         CollidableSphereVertices.size() * sizeof(liquid::Vertex),
+         static_cast<const void *>(CollidableSphereVertices.data())});
+    mCollidableSphere.vertexCount =
+        static_cast<uint32_t>(CollidableSphereVertices.size());
+  }
+
+  // Capsule shape
+  {
+    auto drawUnitHalfCircle = [](std::vector<liquid::Vertex> &vertices,
+                                 uint32_t numSegments, CalculationFn cX,
+                                 CalculationFn cY, CalculationFn cZ,
+                                 float circleAngle) {
+      const float SegmentDelta = circleAngle / static_cast<float>(numSegments);
+      float segmentAngle = SegmentDelta;
+
+      V start{cX(0.0f), cY(0.0f), cZ(0.0f)};
+
+      vertices.push_back(start);
+
+      for (uint32_t i = 0; i < numSegments; ++i) {
+        V v{cX(segmentAngle), cY(segmentAngle), cZ(segmentAngle)};
+
+        vertices.push_back(v);
+        vertices.push_back(v);
+
+        segmentAngle += SegmentDelta;
+      }
+
+      vertices.push_back(vertices.at(vertices.size() - 1));
+    };
+
+    static constexpr uint32_t NumSegments = 12;
+    std::vector<liquid::Vertex> CollidableCapsuleVertices;
+
+    drawUnitHalfCircle(CollidableCapsuleVertices, NumSegments, cCos,
+                       cSinCenter(0.5f), cZero, Pi);
+    drawUnitHalfCircle(CollidableCapsuleVertices, NumSegments, cZero,
+                       cSinCenter(0.5f), cCos, Pi);
+
+    CollidableCapsuleVertices.push_back(V{-1.0f, 0.5f, 0.0f});
+    CollidableCapsuleVertices.push_back(V{-1.0f, -0.5f, 0.0f});
+
+    CollidableCapsuleVertices.push_back(V{0.0f, 0.5f, 1.0f});
+    CollidableCapsuleVertices.push_back(V{0.0f, -0.5f, 1.0f});
+
+    CollidableCapsuleVertices.push_back(V{1.0f, 0.5f, 0.0f});
+    CollidableCapsuleVertices.push_back(V{1.0f, -0.5f, 0.0f});
+
+    CollidableCapsuleVertices.push_back(V{0.0f, 0.5f, -1.0f});
+    CollidableCapsuleVertices.push_back(V{0.0f, -0.5f, -1.0f});
+
+    drawUnitHalfCircle(CollidableCapsuleVertices, NumSegments, cCos,
+                       cSinCenter(-0.5f), cZero, -Pi);
+    drawUnitHalfCircle(CollidableCapsuleVertices, NumSegments, cZero,
+                       cSinCenter(-0.5f), cCos, -Pi);
+
+    mCollidableCapsule.buffer = mRenderStorage.getRenderDevice()->createBuffer(
+        {liquid::rhi::BufferType::Vertex,
+         CollidableCapsuleVertices.size() * sizeof(liquid::Vertex),
+         static_cast<const void *>(CollidableCapsuleVertices.data())});
+    mCollidableCapsule.vertexCount =
+        static_cast<uint32_t>(CollidableCapsuleVertices.size());
+  }
+
+  // NOLINTEND(cppcoreguidelines-avoid-magic-numbers)
 }
 
 } // namespace liquidator

--- a/editor/src/liquidator/core/EditorRenderer.h
+++ b/editor/src/liquidator/core/EditorRenderer.h
@@ -16,6 +16,23 @@ namespace liquidator {
  * Creates editor shaders and render pass
  */
 class EditorRenderer {
+  /**
+   * @brief Collidable shape draw information
+   */
+  struct CollidableShapeDraw {
+    /**
+     * @brief Vertex buffer that holds shape data
+     */
+    liquid::rhi::Buffer buffer;
+
+    /**
+     * @brief Number of vertices
+     *
+     * Used when recording draw command
+     */
+    uint32_t vertexCount = 0;
+  };
+
 public:
   /**
    * @brief Create editor renderer
@@ -41,17 +58,30 @@ public:
    * @brief Update frame data
    *
    * @param entityDatabase Entity database
-   * @param camera Camerae
+   * @param camera Camera
    * @param editorGrid Editor grid
+   * @param selectedEntity Selected entity
    */
   void updateFrameData(liquid::EntityDatabase &entityDatabase,
-                       liquid::Entity camera, const EditorGrid &editorGrid);
+                       liquid::Entity camera, const EditorGrid &editorGrid,
+                       liquid::Entity selectedEntity);
+
+private:
+  /**
+   * @brief Create buffers for collidable shapes
+   */
+  void createCollidableShapes();
 
 private:
   EditorRendererStorage mRenderStorage;
   liquid::rhi::ResourceRegistry &mRegistry;
   liquid::ShaderLibrary mShaderLibrary;
   IconRegistry &mIconRegistry;
+  liquid::Entity mSelectedEntity = liquid::EntityNull;
+
+  CollidableShapeDraw mCollidableCube;
+  CollidableShapeDraw mCollidableSphere;
+  CollidableShapeDraw mCollidableCapsule;
 };
 
 } // namespace liquidator

--- a/editor/src/liquidator/core/EditorRendererStorage.h
+++ b/editor/src/liquidator/core/EditorRendererStorage.h
@@ -7,6 +7,8 @@
 #include "liquid/scene/CameraComponent.h"
 #include "liquidator/editor-scene/EditorGrid.h"
 
+#include "liquid/entity/EntityDatabase.h"
+
 namespace liquidator {
 
 /**
@@ -22,6 +24,29 @@ class EditorRendererStorage {
    * @brief Default reserved space for buffers
    */
   static constexpr size_t DefaultReservedSpace = 2000;
+
+  /**
+   * @brief Collidable entity data for buffers
+   */
+  struct CollidableEntity {
+    /**
+     * @brief Entity world transform matrix
+     */
+    glm::mat4 worldTransform;
+
+    /**
+     * @brief Entity type
+     */
+    glm::uvec4 type;
+
+    /**
+     * @brief Collidable parameters
+     *
+     * Parameters differ between different
+     * shape types
+     */
+    glm::vec4 params;
+  };
 
 public:
   /**
@@ -139,6 +164,53 @@ public:
    */
   void clear();
 
+  /**
+   * @brief Set collidable entity
+   *
+   * @param entity Entity
+   * @param collidable Collidable component
+   * @param worldTransform World transform
+   */
+  void setCollidable(liquid::Entity entity,
+                     const liquid::CollidableComponent &collidable,
+                     const liquid::WorldTransformComponent &worldTransform);
+
+  /**
+   * @brief Get collidable parameters buffer
+   *
+   * @return Collidable parameters buffer handle
+   */
+  inline liquid::rhi::BufferHandle getCollidableParamsBuffer() const {
+    return mCollidableEntityBuffer.getHandle();
+  }
+
+  /**
+   * @brief Check if entity is set
+   *
+   * @retval true Collidable entity is set
+   * @retval false Collidable entity is not set
+   */
+  inline bool isCollidableEntitySelected() const {
+    return mCollidableEntity != liquid::EntityNull;
+  }
+
+  /**
+   * @brief Get render device
+   *
+   * @return Render device
+   */
+  inline liquid::rhi::RenderDevice *getRenderDevice() { return mDevice; }
+
+  /**
+   * @brief Get collidable shape type
+   *
+   * @return Collidable shape type
+   */
+  inline liquid::PhysicsGeometryType getCollidableShapeType() const {
+    return static_cast<liquid::PhysicsGeometryType>(
+        mCollidableEntityParams.type.x);
+  }
+
 private:
   size_t mReservedSpace = 0;
 
@@ -162,6 +234,12 @@ private:
   std::vector<glm::mat4> mGizmoTransforms;
   std::unordered_map<liquid::rhi::TextureHandle, uint32_t> mGizmoCounts;
   liquid::rhi::Buffer mGizmoTransformsBuffer;
+
+  // Collidable shape
+  liquid::Entity mCollidableEntity = liquid::EntityNull;
+  CollidableEntity mCollidableEntityParams{};
+
+  liquid::rhi::Buffer mCollidableEntityBuffer;
 
   liquid::rhi::RenderDevice *mDevice;
 };

--- a/editor/src/liquidator/screens/EditorScreen.cpp
+++ b/editor/src/liquidator/screens/EditorScreen.cpp
@@ -296,9 +296,10 @@ void EditorScreen::start(const Project &project) {
       imgui.updateFrameData(renderFrame.frameIndex);
       sceneRenderer.updateFrameData(entityManager.getActiveEntityDatabase(),
                                     editorManager.getCamera());
-      editorRenderer.updateFrameData(entityManager.getActiveEntityDatabase(),
-                                     editorManager.getCamera(),
-                                     editorManager.getEditorGrid());
+      editorRenderer.updateFrameData(
+          entityManager.getActiveEntityDatabase(), editorManager.getCamera(),
+          editorManager.getEditorGrid(),
+          ui.getSceneHierarchyPanel().getSelectedEntity());
 
       if (mousePicking.isSelectionPerformedInFrame(renderFrame.frameIndex)) {
         auto entity = mousePicking.getSelectedEntity();

--- a/editor/src/liquidator/ui/EntityPanel.cpp
+++ b/editor/src/liquidator/ui/EntityPanel.cpp
@@ -683,11 +683,9 @@ void EntityPanel::renderAddComponent(liquid::AssetRegistry &assetRegistry) {
     if (!mEntityManager.getActiveEntityDatabase()
              .has<liquid::CollidableComponent>(mSelectedEntity) &&
         ImGui::Selectable("Collidable")) {
-      static constexpr glm::vec3 DefaultValue(0.5f);
-
       mEntityManager.getActiveEntityDatabase().set<liquid::CollidableComponent>(
-          mSelectedEntity, {liquid::PhysicsGeometryType::Box,
-                            liquid::PhysicsGeometryBox{DefaultValue}});
+          mSelectedEntity,
+          {liquid::PhysicsGeometryType::Box, liquid::PhysicsGeometryBox{}});
       mEntityManager.save(mSelectedEntity);
     }
 

--- a/engine/rhi/core/include/liquid/rhi/BufferDescription.h
+++ b/engine/rhi/core/include/liquid/rhi/BufferDescription.h
@@ -42,7 +42,7 @@ struct BufferDescription {
   /**
    * Buffer data
    */
-  void *data = nullptr;
+  const void *data = nullptr;
 
   /**
    * @brief Buffer usage

--- a/engine/rhi/core/include/liquid/rhi/PipelineDescription.h
+++ b/engine/rhi/core/include/liquid/rhi/PipelineDescription.h
@@ -54,6 +54,11 @@ struct PipelineRasterizer {
    * Front face direction
    */
   FrontFace frontFace = FrontFace::Clockwise;
+
+  /**
+   * @brief Line width
+   */
+  float lineWidth = 1.0f;
 };
 
 enum class BlendFactor {

--- a/engine/rhi/vulkan/src/VulkanPipeline.cpp
+++ b/engine/rhi/vulkan/src/VulkanPipeline.cpp
@@ -123,7 +123,7 @@ VulkanPipeline::VulkanPipeline(const PipelineDescription &description,
       VulkanMapping::getCullMode(description.rasterizer.cullMode);
   rasterizer.frontFace =
       VulkanMapping::getFrontFace(description.rasterizer.frontFace);
-  rasterizer.lineWidth = 1.0f;
+  rasterizer.lineWidth = description.rasterizer.lineWidth;
   rasterizer.depthClampEnable = VK_FALSE;
   rasterizer.rasterizerDiscardEnable = VK_FALSE;
   rasterizer.depthBiasEnable = VK_FALSE;

--- a/engine/src/liquid/physics/PhysicsObjects.h
+++ b/engine/src/liquid/physics/PhysicsObjects.h
@@ -25,7 +25,7 @@ struct PhysicsMaterialDesc {
 /**
  * @brief Geometry types
  */
-enum class PhysicsGeometryType { Sphere, Plane, Capsule, Box };
+enum class PhysicsGeometryType { Box, Sphere, Capsule, Plane };
 
 /**
  * @brief Get physics geometry type string
@@ -35,14 +35,14 @@ enum class PhysicsGeometryType { Sphere, Plane, Capsule, Box };
  */
 inline String getPhysicsGeometryTypeString(PhysicsGeometryType type) {
   switch (type) {
-  case PhysicsGeometryType::Sphere:
-    return "sphere";
-  case PhysicsGeometryType::Plane:
-    return "plane";
-  case PhysicsGeometryType::Capsule:
-    return "capsule";
   case PhysicsGeometryType::Box:
     return "box";
+  case PhysicsGeometryType::Sphere:
+    return "sphere";
+  case PhysicsGeometryType::Capsule:
+    return "capsule";
+  case PhysicsGeometryType::Plane:
+    return "plane";
   default:
     return "unknown";
   }
@@ -107,7 +107,7 @@ struct PhysicsGeometryDesc {
   /**
    * Geometry parameters
    */
-  PhysicsGeometryParams params = PhysicsGeometryBox{{0.0f, 0.0f, 0.0f}};
+  PhysicsGeometryParams params = PhysicsGeometryBox{};
 };
 
 /**

--- a/engine/tests/liquid-tests/renderer/Material.test.cpp
+++ b/engine/tests/liquid-tests/renderer/Material.test.cpp
@@ -9,7 +9,7 @@ public:
   MockBuffer(const liquid::rhi::BufferDescription &description)
       : size(description.size), data(description.data) {}
 
-  void *map() { return data; }
+  void *map() { return const_cast<void *>(data); }
 
   void unmap() {}
 
@@ -19,7 +19,7 @@ public:
 
 public:
   size_t size = 0;
-  void *data = data;
+  const void *data = nullptr;
 };
 
 class MockDevice : public liquid::rhi::RenderDevice {
@@ -39,11 +39,6 @@ public:
         "MockGPU", liquid::rhi::PhysicalDeviceType::Unknown, {}, {}};
   }
 
-  /**
-   * @brief Get device stats
-   *
-   * @return Device stats
-   */
   const liquid::rhi::DeviceStats &getDeviceStats() const { return stats; }
 
   void destroyResources() {}
@@ -91,10 +86,11 @@ TEST_F(MaterialTest, SetsBuffersAndTextures) {
   EXPECT_EQ(material.getDescriptor().getBindings().at(1).type,
             liquid::rhi::DescriptorType::CombinedImageSampler);
 
-  char *data = static_cast<char *>(device->mockBuffer->data);
+  const char *data = static_cast<const char *>(device->mockBuffer->data);
 
-  auto specularVal = *reinterpret_cast<glm::vec3 *>(data);
-  auto diffuseVal = *reinterpret_cast<glm::vec4 *>(data + sizeof(glm::vec4));
+  auto specularVal = *reinterpret_cast<const glm::vec3 *>(data);
+  auto diffuseVal =
+      *reinterpret_cast<const glm::vec4 *>(data + sizeof(glm::vec4));
 
   EXPECT_TRUE(specularVal == glm::vec3(0.5, 0.2, 0.3));
   EXPECT_TRUE(diffuseVal == glm::vec4(1.0, 1.0, 1.0, 1.0));
@@ -141,10 +137,10 @@ TEST_F(MaterialTest, DoesNotUpdatePropertyIfPropertyDoesNotExist) {
     EXPECT_TRUE(properties.at(1).getValue<float>() == testReal);
 
     EXPECT_EQ(device->mockBuffer->size, sizeof(glm::vec3) * 2);
-    auto *data = static_cast<char *>(device->mockBuffer->data);
+    const auto *data = static_cast<const char *>(device->mockBuffer->data);
 
-    EXPECT_TRUE(*reinterpret_cast<glm::vec3 *>(data) == testVec3);
-    EXPECT_TRUE(*reinterpret_cast<float *>(data + sizeof(glm::vec3)) ==
+    EXPECT_TRUE(*reinterpret_cast<const glm::vec3 *>(data) == testVec3);
+    EXPECT_TRUE(*reinterpret_cast<const float *>(data + sizeof(glm::vec3)) ==
                 testReal);
   }
 
@@ -155,10 +151,10 @@ TEST_F(MaterialTest, DoesNotUpdatePropertyIfPropertyDoesNotExist) {
     EXPECT_TRUE(properties.at(0).getValue<glm::vec3>() == testVec3);
     EXPECT_TRUE(properties.at(1).getValue<float>() == testReal);
     EXPECT_EQ(device->mockBuffer->size, sizeof(glm::vec3) * 2);
-    auto *data = static_cast<char *>(device->mockBuffer->data);
+    const auto *data = static_cast<const char *>(device->mockBuffer->data);
 
-    EXPECT_TRUE(*reinterpret_cast<glm::vec3 *>(data) == testVec3);
-    EXPECT_TRUE(*reinterpret_cast<float *>(data + sizeof(glm::vec3)) ==
+    EXPECT_TRUE(*reinterpret_cast<const glm::vec3 *>(data) == testVec3);
+    EXPECT_TRUE(*reinterpret_cast<const float *>(data + sizeof(glm::vec3)) ==
                 testReal);
   }
 }
@@ -181,10 +177,10 @@ TEST_F(MaterialTest, DoesNotUpdatePropertyIfNewPropertyTypeIsDifferent) {
     EXPECT_TRUE(properties.at(1).getValue<float>() == testReal);
 
     EXPECT_EQ(device->mockBuffer->size, sizeof(glm::vec3) * 2);
-    auto *data = static_cast<char *>(device->mockBuffer->data);
+    const auto *data = static_cast<const char *>(device->mockBuffer->data);
 
-    EXPECT_TRUE(*reinterpret_cast<glm::vec3 *>(data) == testVec3);
-    EXPECT_TRUE(*reinterpret_cast<float *>(data + sizeof(glm::vec3)) ==
+    EXPECT_TRUE(*reinterpret_cast<const glm::vec3 *>(data) == testVec3);
+    EXPECT_TRUE(*reinterpret_cast<const float *>(data + sizeof(glm::vec3)) ==
                 testReal);
   }
 
@@ -196,10 +192,10 @@ TEST_F(MaterialTest, DoesNotUpdatePropertyIfNewPropertyTypeIsDifferent) {
     EXPECT_TRUE(properties.at(1).getValue<float>() == testReal);
 
     EXPECT_EQ(device->mockBuffer->size, sizeof(glm::vec3) * 2);
-    auto *data = static_cast<char *>(device->mockBuffer->data);
+    const auto *data = static_cast<const char *>(device->mockBuffer->data);
 
-    EXPECT_TRUE(*reinterpret_cast<glm::vec3 *>(data) == testVec3);
-    EXPECT_TRUE(*reinterpret_cast<float *>(data + sizeof(glm::vec3)) ==
+    EXPECT_TRUE(*reinterpret_cast<const glm::vec3 *>(data) == testVec3);
+    EXPECT_TRUE(*reinterpret_cast<const float *>(data + sizeof(glm::vec3)) ==
                 testReal);
   }
 }
@@ -222,10 +218,10 @@ TEST_F(MaterialTest, UpdatesPropertyIfNameAndTypeMatch) {
     EXPECT_TRUE(properties.at(1).getValue<float>() == testReal);
 
     EXPECT_EQ(device->mockBuffer->size, sizeof(glm::vec3) * 2);
-    auto *data = static_cast<char *>(device->mockBuffer->data);
+    const auto *data = static_cast<const char *>(device->mockBuffer->data);
 
-    EXPECT_TRUE(*reinterpret_cast<glm::vec3 *>(data) == testVec3);
-    EXPECT_TRUE(*reinterpret_cast<float *>(data + sizeof(glm::vec3)) ==
+    EXPECT_TRUE(*reinterpret_cast<const glm::vec3 *>(data) == testVec3);
+    EXPECT_TRUE(*reinterpret_cast<const float *>(data + sizeof(glm::vec3)) ==
                 testReal);
   }
 
@@ -240,10 +236,10 @@ TEST_F(MaterialTest, UpdatesPropertyIfNameAndTypeMatch) {
     EXPECT_TRUE(properties.at(1).getValue<float>() == newTestReal);
 
     EXPECT_EQ(device->mockBuffer->size, sizeof(glm::vec3) * 2);
-    auto *data = static_cast<char *>(device->mockBuffer->data);
+    const auto *data = static_cast<const char *>(device->mockBuffer->data);
 
-    EXPECT_TRUE(*reinterpret_cast<glm::vec3 *>(data) == newTestVec3);
-    EXPECT_TRUE(*reinterpret_cast<float *>(data + sizeof(glm::vec3)) ==
+    EXPECT_TRUE(*reinterpret_cast<const glm::vec3 *>(data) == newTestVec3);
+    EXPECT_TRUE(*reinterpret_cast<const float *>(data + sizeof(glm::vec3)) ==
                 newTestReal);
   }
 }

--- a/engine/tests/liquid-tests/renderer/MaterialPBR.test.cpp
+++ b/engine/tests/liquid-tests/renderer/MaterialPBR.test.cpp
@@ -19,7 +19,7 @@ public:
 
 public:
   size_t size = 0;
-  void *data = data;
+  const void *data = nullptr;
 };
 
 class MockDevice : public liquid::rhi::RenderDevice {
@@ -39,11 +39,6 @@ public:
         "MockGPU", liquid::rhi::PhysicalDeviceType::Unknown, {}, {}};
   }
 
-  /**
-   * @brief Get device stats
-   *
-   * @return Device stats
-   */
   const liquid::rhi::DeviceStats &getDeviceStats() const { return stats; }
 
   void destroyResources() {}


### PR DESCRIPTION
- Create collidable shape geometries for unit box, sphere, and capsule
- Add collidable shape shader that scales the unit shape
- Apply scale to PhysX objects when switching or updating shapes
- Allow modifying pipeline line height