### PR TITLE
Fix editor bugs

### DIFF
--- a/editor/src/liquidator/editor-scene/EditorCamera.cpp
+++ b/editor/src/liquidator/editor-scene/EditorCamera.cpp
@@ -20,17 +20,11 @@ EditorCamera::EditorCamera(liquid::EntityDatabase &entityDatabase,
 
   mMouseButtonPressHandler = mEventSystem.observe(
       liquid::MouseButtonEvent::Pressed, [this](const auto &data) {
-        if (data.button != GLFW_MOUSE_BUTTON_MIDDLE) {
+        if (data.button != GLFW_MOUSE_BUTTON_MIDDLE || !mCaptureMouse) {
           return;
         }
 
         const auto &cursorPos = mWindow.getCurrentMousePosition();
-
-        // Do not trigger action if cursor is outside
-        // Imgui window viewport
-        if (!isWithinViewport(cursorPos)) {
-          return;
-        }
 
         if (mWindow.isKeyPressed(GLFW_KEY_LEFT_SHIFT)) {
           mInputState = InputState::Pan;
@@ -86,6 +80,9 @@ EditorCamera::EditorCamera(liquid::EntityDatabase &entityDatabase,
 
   mMouseScrollHandler = mEventSystem.observe(
       liquid::MouseScrollEvent::Scroll, [this](const auto &event) {
+        if (!mCaptureMouse)
+          return;
+
         const auto &pos = mWindow.getCurrentMousePosition();
         if (pos.x < mX || pos.x > mX + mWidth || pos.y < mY ||
             pos.y > mY + mHeight) {
@@ -216,11 +213,13 @@ void EditorCamera::zoom() {
   mPrevMousePos = mousePos;
 }
 
-void EditorCamera::setViewport(float x, float y, float width, float height) {
+void EditorCamera::setViewport(float x, float y, float width, float height,
+                               bool captureMouse) {
   mX = x;
   mY = y;
   mWidth = width;
   mHeight = height;
+  mCaptureMouse = captureMouse;
 }
 
 } // namespace liquidator

--- a/editor/src/liquidator/editor-scene/EditorCamera.h
+++ b/editor/src/liquidator/editor-scene/EditorCamera.h
@@ -196,8 +196,10 @@ public:
    * @param y Viewport y position
    * @param width Viewport width
    * @param height Viewport height
+   * @param captureMouse Capture mouse for camera controls
    */
-  void setViewport(float x, float y, float width, float height);
+  void setViewport(float x, float y, float width, float height,
+                   bool captureMouse);
 
   /**
    * @brief Check if position is within viewport
@@ -251,6 +253,7 @@ private:
   float mY = 0.0f;
   float mWidth = 0.0f;
   float mHeight = 0.0f;
+  bool mCaptureMouse = false;
 
   InputState mInputState = InputState::None;
   glm::vec2 mPrevMousePos{};

--- a/editor/src/liquidator/ui/SceneHierarchyPanel.cpp
+++ b/editor/src/liquidator/ui/SceneHierarchyPanel.cpp
@@ -4,6 +4,7 @@
 #include "ConfirmationDialog.h"
 #include "SceneHierarchyPanel.h"
 #include "Widgets.h"
+#include "StyleStack.h"
 
 namespace liquidator {
 
@@ -11,7 +12,18 @@ SceneHierarchyPanel::SceneHierarchyPanel(EntityManager &entityManager)
     : mEntityManager(entityManager) {}
 
 void SceneHierarchyPanel::render(EditorManager &editorManager) {
+  static constexpr ImVec2 TreeNodeItemPadding{4.0f, 8.0f};
+  static constexpr float TreeNodeIndentSpacing = 10.0f;
+
   if (auto _ = widgets::Window("Hierarchy")) {
+    StyleStack stack;
+    stack.pushColor(ImGuiCol_Header,
+                    ImGui::GetStyleColorVec4(ImGuiCol_HeaderHovered));
+    stack.pushStyle(ImGuiStyleVar_ItemSpacing,
+                    ImVec2(ImGui::GetStyle().ItemSpacing.x, 0.0f));
+    stack.pushStyle(ImGuiStyleVar_FramePadding, TreeNodeItemPadding);
+    stack.pushStyle(ImGuiStyleVar_IndentSpacing, TreeNodeIndentSpacing);
+
     auto &entityDatabase = mEntityManager.getActiveEntityDatabase();
 
     entityDatabase.iterateEntities<liquid::LocalTransformComponent>(
@@ -53,6 +65,8 @@ void SceneHierarchyPanel::renderEntity(liquid::Entity entity, int flags,
   if (mSelectedEntity == entity) {
     treeNodeFlags |= ImGuiTreeNodeFlags_Selected;
   }
+
+  treeNodeFlags |= ImGuiTreeNodeFlags_FramePadding;
 
   ConfirmationDialog confirmDeleteSceneNode(
       "Delete entity", "Are you sure you want to delete node \"" + name + "\"?",

--- a/editor/src/liquidator/ui/StyleStack.cpp
+++ b/editor/src/liquidator/ui/StyleStack.cpp
@@ -10,12 +10,34 @@ StyleStack::~StyleStack() {
     ImGui::PopStyleColor(static_cast<int>(mPushedColors));
     mPushedColors = 0;
   }
+
+  if (mPushedStyles > 0) {
+    ImGui::PopStyleVar(static_cast<int>(mPushedStyles));
+    mPushedStyles = 0;
+  }
 }
 
 void StyleStack::pushColor(uint32_t colorIndex, const glm::vec4 &color) {
-  ImGui::PushStyleColor(static_cast<ImGuiCol>(colorIndex),
-                        ImVec4(color.x, color.y, color.z, color.w));
+  pushColor(colorIndex, ImVec4(color.x, color.y, color.z, color.w));
+}
+
+void StyleStack::pushColor(uint32_t colorIndex, const ImVec4 &color) {
+  ImGui::PushStyleColor(static_cast<ImGuiCol>(colorIndex), color);
   mPushedColors++;
+}
+
+void StyleStack::pushStyle(uint32_t styleIndex, float value) {
+  ImGui::PushStyleVar(static_cast<ImGuiStyleVar>(styleIndex), value);
+  mPushedStyles++;
+}
+
+void StyleStack::pushStyle(uint32_t styleIndex, const glm::vec2 &value) {
+  pushStyle(styleIndex, ImVec2(value.x, value.y));
+}
+
+void StyleStack::pushStyle(uint32_t styleIndex, const ImVec2 &value) {
+  ImGui::PushStyleVar(static_cast<ImGuiStyleVar>(styleIndex), value);
+  mPushedStyles++;
 }
 
 } // namespace liquidator

--- a/editor/src/liquidator/ui/StyleStack.h
+++ b/editor/src/liquidator/ui/StyleStack.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "liquid/imgui/Imgui.h"
+
 namespace liquidator {
 
 /**
@@ -33,8 +35,41 @@ public:
    */
   void pushColor(uint32_t colorIndex, const glm::vec4 &color);
 
+  /**
+   * @brief Push color to the stack
+   *
+   * @param colorIndex Color index
+   * @param color Color value
+   */
+  void pushColor(uint32_t colorIndex, const ImVec4 &color);
+
+  /**
+   * @brief Push style to the stack
+   *
+   * @param styleIndex Style index
+   * @param value Style value
+   */
+  void pushStyle(uint32_t styleIndex, float value);
+
+  /**
+   * @brief Push style to the stack
+   *
+   * @param styleIndex Style index
+   * @param value Style value
+   */
+  void pushStyle(uint32_t styleIndex, const glm::vec2 &value);
+
+  /**
+   * @brief Push style to the stack
+   *
+   * @param styleIndex Style index
+   * @param value Style value
+   */
+  void pushStyle(uint32_t styleIndex, const ImVec2 &value);
+
 private:
   uint32_t mPushedColors = 0;
+  uint32_t mPushedStyles = 0;
 };
 
 } // namespace liquidator

--- a/editor/src/liquidator/ui/TransformOperationControl.cpp
+++ b/editor/src/liquidator/ui/TransformOperationControl.cpp
@@ -1,10 +1,10 @@
 #include "liquid/core/Base.h"
-#include "TransformOperationControl.h"
-#include "StyleStack.h"
 
 #include "liquid/imgui/Imgui.h"
 #include "liquid/imgui/ImguiUtils.h"
 
+#include "TransformOperationControl.h"
+#include "StyleStack.h"
 #include "Theme.h"
 
 namespace liquidator {


### PR DESCRIPTION
- Do not append lua extension when creating directories from asset browser
- Cancel asset creation when asset filename is empty in asset browser
- Show staging asset at the end of window when creating assets in asset browser
- Highlight selected entity in scene hierarchy panel
- Provide padding and better indentation for tree items in scene hierarchy panel
- Contol editor camera only when mouse is over the scene view
- Perform mouse picking only when clicking on the scene view