### PR TITLE
Update imgui frame data directly by mapping the hardware buffer

### DIFF
--- a/engine/rhi/core/include/liquid/rhi/RenderDevice.h
+++ b/engine/rhi/core/include/liquid/rhi/RenderDevice.h
@@ -100,6 +100,13 @@ public:
   virtual Buffer createBuffer(const BufferDescription &description) = 0;
 
   /**
+   * @brief Destroy buffer
+   *
+   * @param handle Buffer handle
+   */
+  virtual void destroyBuffer(BufferHandle handle) = 0;
+
+  /**
    * @brief Create texture
    *
    * @param description Texture description

--- a/engine/rhi/vulkan/include/liquid/rhi-vulkan/VulkanRenderDevice.h
+++ b/engine/rhi/vulkan/include/liquid/rhi-vulkan/VulkanRenderDevice.h
@@ -97,6 +97,13 @@ public:
   Buffer createBuffer(const BufferDescription &description) override;
 
   /**
+   * @brief Destroy buffer
+   *
+   * @param handle Buffer handle
+   */
+  void destroyBuffer(BufferHandle handle) override;
+
+  /**
    * @brief Create texture
    *
    * @param description Texture description

--- a/engine/rhi/vulkan/src/VulkanRenderDevice.cpp
+++ b/engine/rhi/vulkan/src/VulkanRenderDevice.cpp
@@ -109,6 +109,10 @@ Buffer VulkanRenderDevice::createBuffer(const BufferDescription &description) {
   return Buffer{handle, mRegistry.getBuffers().at(handle).get()};
 }
 
+void VulkanRenderDevice::destroyBuffer(BufferHandle handle) {
+  mRegistry.deleteBuffer(handle);
+}
+
 ShaderHandle
 VulkanRenderDevice::createShader(const ShaderDescription &description) {
   return mRegistry.setShader(

--- a/engine/src/liquid/imgui/ImguiRenderer.h
+++ b/engine/src/liquid/imgui/ImguiRenderer.h
@@ -67,6 +67,8 @@ class ImguiRenderer {
 
   static constexpr const glm::vec4 DefaultClearColor{0.0f, 0.0f, 0.0f, 1.0f};
 
+  static constexpr size_t FramesInFlight = 2;
+
 public:
   /**
    * @brief Create imgui renderer
@@ -159,7 +161,7 @@ private:
 private:
   ShaderLibrary &mShaderLibrary;
   rhi::TextureHandle mFontTexture = rhi::TextureHandle::Invalid;
-  std::vector<FrameData> mFrameData;
+  std::array<FrameData, FramesInFlight> mFrameData;
   uint32_t mCurrentFrame = 0;
 
   glm::vec4 mClearColor{DefaultClearColor};

--- a/engine/tests/liquid-tests/mocks/MockRenderDevice.cpp
+++ b/engine/tests/liquid-tests/mocks/MockRenderDevice.cpp
@@ -41,6 +41,8 @@ liquid::rhi::Buffer MockRenderDevice::createBuffer(
   return liquid::rhi::Buffer(handle, &mBuffers.at(handle));
 }
 
+void MockRenderDevice::destroyBuffer(liquid::rhi::BufferHandle handle) {}
+
 liquid::rhi::TextureHandle MockRenderDevice::createTexture(
     const liquid::rhi::TextureDescription &description) {
   auto handle = getNewHandle<liquid::rhi::TextureHandle>();

--- a/engine/tests/liquid-tests/mocks/MockRenderDevice.h
+++ b/engine/tests/liquid-tests/mocks/MockRenderDevice.h
@@ -25,6 +25,8 @@ public:
   liquid::rhi::Buffer
   createBuffer(const liquid::rhi::BufferDescription &description);
 
+  void destroyBuffer(liquid::rhi::BufferHandle handle);
+
   liquid::rhi::TextureHandle
   createTexture(const liquid::rhi::TextureDescription &description);
 


### PR DESCRIPTION
- Remove intermediary buffer stored in memory
- Destroy hardware buffer from render device
- Delete imgui buffers on destruct