### PR TITLE
Use NDC where Y axis is up

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -1,0 +1,17 @@
+# Documentation
+
+Here lies the preliminary documentation for the engine
+
+## Coordinate system
+
+The engine uses the coordinate system below and normalizes it for
+all backends.
+
+NDC: +Y is up. Point(-1, -1) is at the bottom left corner
+Framebuffer coordinate: +Y is down. Origin(0, 0) is at the top left corner
+Texture coordinate: +Y is down. Origin(0, 0) is at the top left corner.
+
+> **Note:**
+> This coordinate system is based on modern APIs such as DX12, Metal, and WebGPU.
+> In Vulkan coordinate system, NDC +Y is down; so, the engine will invert this
+> automatically when Vulkan is used as a rendering backend.

--- a/demos/pong-3d/src/main.cpp
+++ b/demos/pong-3d/src/main.cpp
@@ -114,7 +114,6 @@ private:
     camera.projectionMatrix = glm::perspective(
         70.0f, static_cast<float>(fbSize.x) / static_cast<float>(fbSize.y),
         0.1f, 200.0f);
-    camera.projectionMatrix[1][1] *= -1.0f;
     camera.viewMatrix = glm::lookAt(glm::vec3{0.0f, 4.0f, -8.0f},
                                     {0.0f, 0.0f, 0.0f}, {0.0f, 1.0f, 0.0f});
     camera.projectionViewMatrix = camera.projectionMatrix * camera.viewMatrix;
@@ -124,7 +123,6 @@ private:
       camera.projectionMatrix = glm::perspective(
           70.0f, static_cast<float>(width) / static_cast<float>(height), 0.1f,
           200.0f);
-      camera.projectionMatrix[1][1] *= -1.0f;
       camera.projectionViewMatrix = camera.projectionMatrix * camera.viewMatrix;
     });
 

--- a/editor/src/liquidator/editor-scene/EditorCamera.cpp
+++ b/editor/src/liquidator/editor-scene/EditorCamera.cpp
@@ -131,7 +131,6 @@ void EditorCamera::update() {
 
   camera.projectionMatrix =
       glm::perspective(glm::radians(mFov), getAspectRatio(), mNear, mFar);
-  camera.projectionMatrix[1][1] *= -1.0f;
 
   camera.viewMatrix = glm::lookAt(mEye, mCenter, mUp);
   camera.projectionViewMatrix = camera.projectionMatrix * camera.viewMatrix;

--- a/editor/src/liquidator/screens/EditorScreen.cpp
+++ b/editor/src/liquidator/screens/EditorScreen.cpp
@@ -256,7 +256,6 @@ void EditorScreen::start(const Project &project) {
             editorManager.getCamera());
 
         auto gizmoPerspective = camera.projectionMatrix;
-        gizmoPerspective[1][1] *= -1.0f;
 
         if (ImGuizmo::Manipulate(
                 glm::value_ptr(camera.viewMatrix),

--- a/engine/assets/shaders/fullscreen-quad.vert
+++ b/engine/assets/shaders/fullscreen-quad.vert
@@ -4,5 +4,5 @@ layout(location = 0) out vec2 outTexCoord;
 
 void main() {
   outTexCoord = vec2((gl_VertexIndex << 1) & 2, gl_VertexIndex & 2);
-  gl_Position = vec4(outTexCoord * 2.0 - 1.0, 0.0, 1.0);
+  gl_Position = vec4(outTexCoord * vec2(2.0, -2.0) + vec2(-1.0, 1.0), 0.0, 1.0);
 }

--- a/engine/assets/shaders/imgui.vert
+++ b/engine/assets/shaders/imgui.vert
@@ -7,15 +7,11 @@ layout(location = 2) in vec4 inColor;
 layout(location = 0) out vec4 outColor;
 layout(location = 1) out vec2 outUV;
 
-layout(push_constant) uniform TransformConstant {
-  vec2 scale;
-  vec2 translate;
-}
+layout(push_constant) uniform TransformConstant { mat4 uiTransform; }
 pcTransform;
 
 void main() {
   outColor = inColor;
   outUV = inUV;
-  gl_Position =
-      vec4(inPosition * pcTransform.scale + pcTransform.translate, 0, 1);
+  gl_Position = pcTransform.uiTransform * vec4(inPosition, 0.0, 1.0);
 }

--- a/engine/rhi/vulkan/src/VulkanCommandBuffer.cpp
+++ b/engine/rhi/vulkan/src/VulkanCommandBuffer.cpp
@@ -111,8 +111,9 @@ void VulkanCommandBuffer::drawIndexed(uint32_t indexCount, uint32_t firstIndex,
 void VulkanCommandBuffer::setViewport(const glm::vec2 &offset,
                                       const glm::vec2 &size,
                                       const glm::vec2 &depthRange) {
-  VkViewport viewport{offset.x, offset.y,     size.x,
-                      size.y,   depthRange.x, depthRange.y};
+  // Using negative height to flip the viewport
+  VkViewport viewport{offset.x, size.y - offset.y, size.x,
+                      -size.y,  depthRange.x,      depthRange.y};
 
   vkCmdSetViewport(mCommandBuffer, 0, 1, &viewport);
   mStats.addCommandCall();

--- a/engine/src/liquid/imgui/ImguiRenderer.cpp
+++ b/engine/src/liquid/imgui/ImguiRenderer.cpp
@@ -261,20 +261,33 @@ void ImguiRenderer::setupRenderStates(ImDrawData *data,
 
   commandList.setViewport({0, 0}, {fbWidth, fbHeight}, {0.0f, 1.0f});
 
-  const float SCALE_FACTOR = 2.0f;
-  std::array<float, 2> scale{SCALE_FACTOR / data->DisplaySize.x,
-                             SCALE_FACTOR / data->DisplaySize.y};
-  std::array<float, 2> translate{-1.0f - data->DisplayPos.x * scale[0],
-                                 -1.0f - data->DisplayPos.y * scale[1]};
+  float L = data->DisplayPos.x;
+  float R = data->DisplayPos.x + data->DisplaySize.x;
+  float T = data->DisplayPos.y;
+  float B = data->DisplayPos.y + data->DisplaySize.y;
 
-  uint32_t scaleDataSize = static_cast<uint32_t>(sizeof(float) * scale.size());
-  uint32_t translateDataSize =
-      static_cast<uint32_t>(sizeof(float) * translate.size());
+  const float SCALE_FACTOR = 2.0f;
+  std::array<float, 16> mvp{SCALE_FACTOR / (R - L),
+                            0.0f,
+                            0.0f,
+                            0.0f,
+                            0.0f,
+                            SCALE_FACTOR / (T - B),
+                            0.0f,
+                            0.0f,
+                            0.0f,
+                            0.0f,
+                            1.0f / SCALE_FACTOR,
+                            0.0f,
+                            (R + L) / (L - R),
+                            (T + B) / (B - T),
+                            0.5f,
+                            1.0f
+
+  };
 
   commandList.pushConstants(pipeline, VK_SHADER_STAGE_VERTEX_BIT, 0,
-                            scaleDataSize, scale.data());
-  commandList.pushConstants(pipeline, VK_SHADER_STAGE_VERTEX_BIT, scaleDataSize,
-                            translateDataSize, translate.data());
+                            sizeof(float) * 16, mvp.data());
 }
 
 void ImguiRenderer::useConfigPath(const String &path) {

--- a/engine/src/liquid/renderer/RenderStorage.cpp
+++ b/engine/src/liquid/renderer/RenderStorage.cpp
@@ -104,8 +104,8 @@ void RenderStorage::addLight(const DirectionalLightComponent &light) {
   glm::vec3 mPosition{-light.direction - light.direction * DIR_LIGHT_SIZE};
   mPosition.z = DIR_LIGHT_Z;
   glm::mat4 lightProjectionMatrix =
-      glm::ortho(-DIR_LIGHT_SIZE, DIR_LIGHT_SIZE, -DIR_LIGHT_SIZE,
-                 DIR_LIGHT_SIZE, DIR_LIGHT_NEAR, DIR_LIGHT_FAR);
+      glm::ortho(-DIR_LIGHT_SIZE, DIR_LIGHT_SIZE, DIR_LIGHT_SIZE,
+                 -DIR_LIGHT_SIZE, DIR_LIGHT_NEAR, DIR_LIGHT_FAR);
   glm::mat4 lightViewMatrix = glm::lookAt(
       mPosition,
       mPosition + light.direction - glm::vec3(0.0f, 0.0f, DIR_LIGHT_Z),

--- a/engine/src/liquid/scene/SceneUpdater.cpp
+++ b/engine/src/liquid/scene/SceneUpdater.cpp
@@ -57,8 +57,6 @@ void SceneUpdater::updateCameras(EntityDatabase &entityDatabase) {
         camera.projectionMatrix = glm::perspective(
             glm::radians(lens.fovY), lens.aspectRatio, lens.near, lens.far);
 
-        camera.projectionMatrix[1][1] *= -1.0f;
-
         camera.viewMatrix = glm::inverse(world.worldTransform);
         camera.projectionViewMatrix =
             camera.projectionMatrix * camera.viewMatrix;

--- a/engine/tests/liquid-tests/scene/Scene.test.cpp
+++ b/engine/tests/liquid-tests/scene/Scene.test.cpp
@@ -103,7 +103,6 @@ TEST_F(SceneUpdaterTest, UpdatesCameraBasedOnTransformAndPerspectiveLens) {
 
   auto expectedPerspective = glm::perspective(
       glm::radians(lens.fovY), lens.aspectRatio, lens.near, lens.far);
-  expectedPerspective[1][1] *= -1.0f;
 
   EXPECT_EQ(camera.viewMatrix, glm::inverse(transform.worldTransform));
   EXPECT_EQ(camera.projectionMatrix, expectedPerspective);


### PR DESCRIPTION
- This NDC is based on DX12, Metal, and WebGPU
- Remove multiplying projection matrices [1][1] by -1
- Flip the Y axis in light orthographic matrix calculation
- Use negative height in Vulkan to flip the viewport
- Update shaders to be based on NDC where Y axis is up
- Add preliminary docs that defines these specifications