### PR TITLE
Allow setting starting camera for the scene

### DIFF
--- a/.github/workflows/github-actions-pr.yml
+++ b/.github/workflows/github-actions-pr.yml
@@ -23,8 +23,8 @@ jobs:
     steps:
       - name: Install dependencies
         run: |
-          sudo wget -qO - http://packages.lunarg.com/lunarg-signing-key-pub.asc | sudo apt-key add -
-          sudo wget -qO /etc/apt/sources.list.d/lunarg-vulkan-focal.list http://packages.lunarg.com/vulkan/lunarg-vulkan-focal.list
+          wget -qO- https://packages.lunarg.com/lunarg-signing-key-pub.asc | sudo tee /etc/apt/trusted.gpg.d/lunarg.asc
+          sudo wget -qO /etc/apt/sources.list.d/lunarg-vulkan-jammy.list http://packages.lunarg.com/vulkan/lunarg-vulkan-jammy.list
           sudo apt update
           sudo apt install vulkan-sdk xorg-dev libx11-dev clang-tidy
 
@@ -50,8 +50,8 @@ jobs:
     steps:
       - name: Install dependencies
         run: |
-          sudo wget -qO - http://packages.lunarg.com/lunarg-signing-key-pub.asc | sudo apt-key add -
-          sudo wget -qO /etc/apt/sources.list.d/lunarg-vulkan-focal.list http://packages.lunarg.com/vulkan/lunarg-vulkan-focal.list
+          wget -qO- https://packages.lunarg.com/lunarg-signing-key-pub.asc | sudo tee /etc/apt/trusted.gpg.d/lunarg.asc
+          sudo wget -qO /etc/apt/sources.list.d/lunarg-vulkan-jammy.list http://packages.lunarg.com/vulkan/lunarg-vulkan-jammy.list
           sudo apt update
           sudo apt install vulkan-sdk xorg-dev libx11-dev clang-tidy doxygen
 
@@ -67,8 +67,8 @@ jobs:
     steps:
       - name: Install dependencies
         run: |
-          sudo wget -qO - http://packages.lunarg.com/lunarg-signing-key-pub.asc | sudo apt-key add -
-          sudo wget -qO /etc/apt/sources.list.d/lunarg-vulkan-focal.list http://packages.lunarg.com/vulkan/lunarg-vulkan-focal.list
+          wget -qO- https://packages.lunarg.com/lunarg-signing-key-pub.asc | sudo tee /etc/apt/trusted.gpg.d/lunarg.asc
+          sudo wget -qO /etc/apt/sources.list.d/lunarg-vulkan-jammy.list http://packages.lunarg.com/vulkan/lunarg-vulkan-jammy.list
           sudo apt update
           sudo apt install vulkan-sdk xorg-dev libx11-dev clang-tidy lcov
 

--- a/editor/src/liquidator/core/EditorSimulator.cpp
+++ b/editor/src/liquidator/core/EditorSimulator.cpp
@@ -14,8 +14,8 @@ EditorSimulator::EditorSimulator(liquid::EventSystem &eventSystem,
   useEditorUpdate();
 }
 
-void EditorSimulator::update(float dt, liquid::EntityDatabase &entityDatabase) {
-  mUpdater(dt, entityDatabase);
+void EditorSimulator::update(float dt, liquid::Scene &scene) {
+  mUpdater(dt, scene);
 }
 
 void EditorSimulator::cleanupSimulationDatabase(
@@ -26,30 +26,31 @@ void EditorSimulator::cleanupSimulationDatabase(
 }
 
 void EditorSimulator::useSimulationUpdate() {
-  mUpdater = [this](float dt, liquid::EntityDatabase &entityDatabase) {
-    updateSimulation(dt, entityDatabase);
+  mUpdater = [this](float dt, liquid::Scene &scene) {
+    updateSimulation(dt, scene);
   };
 }
 
 void EditorSimulator::useEditorUpdate() {
-  mUpdater = [this](float dt, liquid::EntityDatabase &entityDatabase) {
-    updateEditor(dt, entityDatabase);
+  mUpdater = [this](float dt, liquid::Scene &scene) {
+    updateEditor(dt, scene);
   };
 }
 
-void EditorSimulator::updateEditor(float dt,
-                                   liquid::EntityDatabase &entityDatabase) {
+void EditorSimulator::updateEditor(float dt, liquid::Scene &scene) {
+  auto &entityDatabase = scene.entityDatabase;
   mCameraAspectRatioUpdater.update(entityDatabase);
   mEditorCamera.update();
 
   mSkeletonUpdater.update(entityDatabase);
   mSceneUpdater.update(entityDatabase);
 
-  mEntityDeleter.update(entityDatabase);
+  mEntityDeleter.update(scene);
 }
 
-void EditorSimulator::updateSimulation(float dt,
-                                       liquid::EntityDatabase &entityDatabase) {
+void EditorSimulator::updateSimulation(float dt, liquid::Scene &scene) {
+  auto &entityDatabase = scene.entityDatabase;
+
   mCameraAspectRatioUpdater.update(entityDatabase);
 
   mScriptingSystem.start(entityDatabase);
@@ -62,7 +63,7 @@ void EditorSimulator::updateSimulation(float dt,
   mPhysicsSystem.update(dt, entityDatabase);
   mAudioSystem.output(entityDatabase);
 
-  mEntityDeleter.update(entityDatabase);
+  mEntityDeleter.update(scene);
 }
 
 } // namespace liquidator

--- a/editor/src/liquidator/core/EditorSimulator.h
+++ b/editor/src/liquidator/core/EditorSimulator.h
@@ -43,9 +43,9 @@ public:
    * updates
    *
    * @param dt Time delta
-   * @param entityDatabase Entity database
+   * @param scene Scene
    */
-  void update(float dt, liquid::EntityDatabase &entityDatabase);
+  void update(float dt, liquid::Scene &scene);
 
   /**
    * @brief Cleanup simulation database
@@ -76,20 +76,20 @@ private:
    * @brief Editor updater
    *
    * @param dt Time delta
-   * @param entityDatabase Entity database
+   * @param scene Scene
    */
-  void updateEditor(float dt, liquid::EntityDatabase &entityDatabase);
+  void updateEditor(float dt, liquid::Scene &scene);
 
   /**
    * @brief Simulation updater
    *
    * @param dt Time delta
-   * @param entityDatabase Entity database
+   * @param scene Scene
    */
-  void updateSimulation(float dt, liquid::EntityDatabase &entityDatabase);
+  void updateSimulation(float dt, liquid::Scene &scene);
 
 private:
-  std::function<void(float, liquid::EntityDatabase &)> mUpdater;
+  std::function<void(float, liquid::Scene &)> mUpdater;
 
   EditorCamera &mEditorCamera;
   liquid::CameraAspectRatioUpdater mCameraAspectRatioUpdater;

--- a/editor/src/liquidator/editor-scene/EditorManager.cpp
+++ b/editor/src/liquidator/editor-scene/EditorManager.cpp
@@ -110,19 +110,6 @@ void EditorManager::loadEditorState(const std::filesystem::path &path) {
   }
 }
 
-void EditorManager::setActiveCamera(liquid::Entity camera) {
-  if (!mEntityManager.getActiveEntityDatabase().has<liquid::CameraComponent>(
-          camera)) {
-    return;
-  }
-
-  mCameraEntity = camera;
-}
-
-void EditorManager::switchToEditorCamera() {
-  mCameraEntity = mEditorCamera.getCamera();
-}
-
 void EditorManager::createNewScene() {
   static constexpr glm::vec3 LightStartPos(0.0f, 5.0f, 0.0f);
 
@@ -142,7 +129,6 @@ void EditorManager::createNewScene() {
 
 void EditorManager::loadOrCreateScene() {
   mEditorCamera.reset();
-  mCameraEntity = mEditorCamera.getCamera();
 
   if (!mEntityManager.loadScene()) {
     createNewScene();

--- a/editor/src/liquidator/editor-scene/EditorManager.h
+++ b/editor/src/liquidator/editor-scene/EditorManager.h
@@ -63,46 +63,6 @@ public:
   inline EditorGrid &getEditorGrid() { return mEditorGrid; }
 
   /**
-   * @brief Get camera
-   *
-   * @return Camera entity
-   */
-  inline liquid::Entity getCamera() { return mCameraEntity; }
-
-  /**
-   * @brief Set active camera
-   *
-   * @param camera Camera entity
-   */
-  void setActiveCamera(liquid::Entity camera);
-
-  /**
-   * @brief Switch to editor camera
-   */
-  void switchToEditorCamera();
-
-  /**
-   * @brief Check if editor camera is active
-   *
-   * @retval true Editor camera is active
-   * @retval false Editor camera is not active
-   */
-  inline bool isUsingEditorCamera() const {
-    return mCameraEntity == mEditorCamera.getCamera();
-  }
-
-  /**
-   * @brief Check if camera is active
-   *
-   * @param camera Camera entity
-   * @retval true Using the camera
-   * @retval false Not using the camera
-   */
-  inline liquid::Entity isUsingCamera(liquid::Entity camera) const {
-    return mCameraEntity == camera;
-  }
-
-  /**
    * @brief Creates a new scene and sets it as active
    */
   void createNewScene();
@@ -166,7 +126,6 @@ private:
   TransformOperation mTransformOperation = TransformOperation::Move;
 
   liquid::Entity mEnvironmentEntity = liquid::EntityNull;
-  liquid::Entity mCameraEntity = liquid::EntityNull;
 };
 
 } // namespace liquidator

--- a/editor/src/liquidator/editor-scene/EntityManager.h
+++ b/editor/src/liquidator/editor-scene/EntityManager.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "liquid/scene/Scene.h"
 #include "liquid/entity/EntityDatabase.h"
 #include "liquid/asset/AssetManager.h"
 #include "liquid/renderer/Renderer.h"
@@ -179,7 +180,8 @@ public:
    * @return Active entity database
    */
   inline liquid::EntityDatabase &getActiveEntityDatabase() {
-    return mInSimulation ? mSimulationEntityDatabase : mEntityDatabase;
+    return mInSimulation ? mSimulationScene.entityDatabase
+                         : mScene.entityDatabase;
   }
 
   /**
@@ -200,6 +202,36 @@ public:
    */
   inline bool isUsingSimulationDatabase() const { return mInSimulation; }
 
+  /**
+   * @brief Get active camera in simulation
+   *
+   * @return Active simulation camera
+   */
+  liquid::Entity getActiveSimulationCamera();
+
+  /**
+   * @brief Get starting camera
+   *
+   * @return Starting camera entity
+   */
+  liquid::Entity getStartingCamera();
+
+  /**
+   * @brief Set starting camera
+   *
+   * @param camera Camera entity
+   */
+  void setStartingCamera(liquid::Entity camera);
+
+  /**
+   * @brief Get active scene
+   *
+   * @return Active scene
+   */
+  inline liquid::Scene &getActiveScene() {
+    return mInSimulation ? mSimulationScene : mScene;
+  }
+
 private:
   /**
    * @brief Get transform from camera
@@ -210,17 +242,10 @@ private:
   liquid::LocalTransformComponent
   getTransformFromCamera(EditorCamera &camera) const;
 
-  /**
-   * @brief Update simulation entity database
-   *
-   * Copies entity database to simulation
-   * entity database
-   */
-  void updateSimulationEntityDatabase();
-
 private:
-  liquid::EntityDatabase mEntityDatabase;
-  liquid::EntityDatabase mSimulationEntityDatabase;
+  liquid::Scene mScene;
+  liquid::Scene mSimulationScene;
+
   liquid::AssetManager &mAssetManager;
   liquid::SceneIO mSceneIO;
   bool mInSimulation = false;

--- a/editor/src/liquidator/project/ProjectManager.cpp
+++ b/editor/src/liquidator/project/ProjectManager.cpp
@@ -26,22 +26,40 @@ bool ProjectManager::createProjectInPath() {
   std::filesystem::create_directory(mProject.assetsPath);
   std::filesystem::create_directory(mProject.settingsPath);
   std::filesystem::create_directory(mProject.scenesPath);
+  std::filesystem::create_directory(mProject.scenesPath / "entities");
 
-  YAML::Node projectObj;
-  projectObj["name"] = mProject.name;
-  projectObj["version"] = mProject.version;
-  projectObj["paths"]["assets"] =
-      std::filesystem::relative(mProject.assetsPath, projectPath).string();
-  projectObj["paths"]["settings"] =
-      std::filesystem::relative(mProject.settingsPath, projectPath).string();
-  projectObj["paths"]["scenes"] =
-      std::filesystem::relative(mProject.scenesPath, projectPath).string();
+  {
+    YAML::Node sceneObj;
+    sceneObj["name"] = "MainScene";
 
-  auto projectFile = projectPath / (mProject.name + ".lqproj");
+    YAML::Node mainZone;
+    mainZone["name"] = "MainZone";
+    mainZone["entities"] = "./entities";
+    sceneObj["zones"][0] = mainZone;
+    sceneObj["persistentZone"] = 0;
 
-  std::ofstream out(projectFile, std::ios::out);
-  out << projectObj;
-  out.close();
+    std::ofstream stream(mProject.scenesPath / "main.lqscene");
+    stream << sceneObj;
+    stream.close();
+  }
+
+  {
+    YAML::Node projectObj;
+    projectObj["name"] = mProject.name;
+    projectObj["version"] = mProject.version;
+    projectObj["paths"]["assets"] =
+        std::filesystem::relative(mProject.assetsPath, projectPath).string();
+    projectObj["paths"]["settings"] =
+        std::filesystem::relative(mProject.settingsPath, projectPath).string();
+    projectObj["paths"]["scenes"] =
+        std::filesystem::relative(mProject.scenesPath, projectPath).string();
+
+    auto projectFile = projectPath / (mProject.name + ".lqproj");
+
+    std::ofstream stream(projectFile, std::ios::out);
+    stream << projectObj;
+    stream.close();
+  }
 
   return true;
 }

--- a/editor/src/liquidator/ui/EntityPanel.cpp
+++ b/editor/src/liquidator/ui/EntityPanel.cpp
@@ -214,9 +214,12 @@ void EntityPanel::renderCamera(EditorManager &editorManager) {
       }
     }
 
-    if (!editorManager.isUsingCamera(mSelectedEntity) &&
-        ImGui::Button("Set as active camera")) {
-      editorManager.setActiveCamera(mSelectedEntity);
+    if (mEntityManager.getStartingCamera() != mSelectedEntity) {
+      if (ImGui::Button("Set as starting camera")) {
+        mEntityManager.setStartingCamera(mSelectedEntity);
+      }
+    } else {
+      ImGui::Text("Is the starting camera");
     }
   }
 }
@@ -229,7 +232,7 @@ void EntityPanel::renderTransform() {
     return;
   }
 
-  if (widgets::Section("Transform")) {
+  if (auto _ = widgets::Section("Transform")) {
     auto &component =
         entityDatabase.get<liquid::LocalTransformComponent>(mSelectedEntity);
     auto &world =

--- a/engine/src/liquid/core/EntityDeleter.cpp
+++ b/engine/src/liquid/core/EntityDeleter.cpp
@@ -14,14 +14,22 @@ void addToDeleteList(Entity entity, EntityDatabase &entityDatabase,
   deleteList.push_back(entity);
 }
 
-void EntityDeleter::update(EntityDatabase &entityDatabase) {
+void EntityDeleter::update(Scene &scene) {
+  auto &entityDatabase = scene.entityDatabase;
+  auto activeCamera = scene.activeCamera;
+
   auto count = entityDatabase.getEntityCountForComponent<DeleteComponent>();
 
   std::vector<Entity> deleteList;
   deleteList.reserve(count);
 
+  bool cameraDeleted = false;
+
   entityDatabase.iterateEntities<DeleteComponent>(
-      [&deleteList, &entityDatabase](auto entity, auto &) {
+      [&deleteList, &entityDatabase, &activeCamera,
+       &cameraDeleted](auto entity, auto &) mutable {
+        cameraDeleted = cameraDeleted || (activeCamera == entity);
+
         if (entityDatabase.has<ParentComponent>(entity)) {
           auto parent = entityDatabase.get<ParentComponent>(entity).parent;
 
@@ -38,6 +46,10 @@ void EntityDeleter::update(EntityDatabase &entityDatabase) {
 
         addToDeleteList(entity, entityDatabase, deleteList);
       });
+
+  if (cameraDeleted) {
+    scene.activeCamera = scene.dummyCamera;
+  }
 
   for (auto entity : deleteList) {
     entityDatabase.deleteEntity(entity);

--- a/engine/src/liquid/core/EntityDeleter.h
+++ b/engine/src/liquid/core/EntityDeleter.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "liquid/entity/EntityDatabase.h"
+#include "liquid/scene/Scene.h"
 
 namespace liquid {
 
@@ -15,9 +15,9 @@ public:
   /**
    * @brief Delete entities
    *
-   * @param entityDatabase Entity database
+   * @param scene Scene
    */
-  void update(EntityDatabase &entityDatabase);
+  void update(Scene &scene);
 };
 
 } // namespace liquid

--- a/engine/src/liquid/scene/Scene.h
+++ b/engine/src/liquid/scene/Scene.h
@@ -1,0 +1,32 @@
+#pragma once
+
+#include "liquid/entity/EntityDatabase.h"
+
+namespace liquid {
+
+/**
+ * @brief Scene structure
+ *
+ * Stores entities and metadata about the scene
+ */
+struct Scene {
+  /**
+   * Entity database
+   */
+  EntityDatabase entityDatabase;
+
+  /**
+   * Active camera in the scene
+   */
+  Entity activeCamera = EntityNull;
+
+  /**
+   * @brief Dummy camera
+   *
+   * Used as a fallback if there
+   * are no cameras in the scene
+   */
+  Entity dummyCamera = EntityNull;
+};
+
+} // namespace liquid

--- a/engine/src/liquid/scene/SceneIO.h
+++ b/engine/src/liquid/scene/SceneIO.h
@@ -4,9 +4,7 @@
 #include "liquid/asset/Result.h"
 #include "liquid/yaml/Yaml.h"
 #include "liquid/entity/EntityDatabase.h"
-
-#include "private/SceneLoader.h"
-#include "private/EntitySerializer.h"
+#include "liquid/scene/Scene.h"
 
 namespace liquid {
 
@@ -19,9 +17,9 @@ public:
    * @brief Create scene IO
    *
    * @param assetRegistry Asset registry
-   * @param entityDatabase Entity database
+   * @param scene Scene
    */
-  SceneIO(AssetRegistry &assetRegistry, EntityDatabase &entityDatabase);
+  SceneIO(AssetRegistry &assetRegistry, Scene &scene);
 
   /**
    * @brief Load scene from a path
@@ -40,12 +38,29 @@ public:
   void saveEntity(Entity entity, const Path &path);
 
   /**
+   * @brief Save starting camera
+   *
+   * @param entity Camera entity
+   * @param path Scene path
+   * @return Save result
+   */
+  Result<bool> saveStartingCamera(Entity entity, const Path &path);
+
+  /**
    * @brief Delete entity
    *
    * @param entity Entity
    * @param path Scene path
    */
   void deleteEntityFilesAndRelations(Entity entity, const Path &path);
+
+  /**
+   * @brief Reset everything
+   *
+   * Clear cache, destroy the entity database,
+   * and create dummy camera component
+   */
+  void reset();
 
 private:
   /**
@@ -73,9 +88,8 @@ private:
   Result<Entity> createEntityFromNode(const YAML::Node &node);
 
 private:
-  EntityDatabase &mEntityDatabase;
-  detail::SceneLoader mLoader;
-  detail::EntitySerializer mDeserializer;
+  Scene &mScene;
+  AssetRegistry &mAssetRegistry;
 
   std::unordered_map<uint64_t, Entity> mEntityIdCache;
   uint64_t mLastId = 1;

--- a/engine/src/liquid/scene/private/SceneLoader.h
+++ b/engine/src/liquid/scene/private/SceneLoader.h
@@ -33,6 +33,18 @@ public:
   Result<bool> loadComponents(const YAML::Node &node, Entity entity,
                               EntityIdCache &entityIdCache);
 
+  /**
+   * @brief Load starting camera
+   *
+   * @param node YAML node
+   * @param entityIdCache Entity ID cache
+   * @param excludeEntity Entity to exclude from search
+   * @return Found starting camera
+   */
+  Result<Entity> loadStartingCamera(const YAML::Node &node,
+                                    EntityIdCache &entityIdCache,
+                                    Entity excludeEntity);
+
 private:
   AssetRegistry &mAssetRegistry;
   EntityDatabase &mEntityDatabase;

--- a/engine/tests/liquid-tests/scene/private/SceneLoader.test.cpp
+++ b/engine/tests/liquid-tests/scene/private/SceneLoader.test.cpp
@@ -1415,3 +1415,111 @@ TEST_F(SceneLoaderParentTest,
                 .children.at(1),
             entity);
 }
+
+using SceneLoaderActiveCameraTest = SceneLoaderTest;
+
+TEST_F(
+    SceneLoaderActiveCameraTest,
+    ReturnsLastFoundCameraEntityInTheDatabaseIfStartingCameraInSceneNodeIsNotScalar) {
+
+  auto camera1 = createNode(true).second;
+  entityDatabase.set<liquid::PerspectiveLensComponent>(camera1, {});
+
+  auto camera2 = createNode(true).second;
+  entityDatabase.set<liquid::PerspectiveLensComponent>(camera2, {});
+
+  {
+    YAML::Node node(YAML::NodeType::Null);
+
+    auto res =
+        sceneLoader.loadStartingCamera(node, entityIdCache, liquid::EntityNull);
+    EXPECT_TRUE(res.hasData());
+    EXPECT_EQ(res.getData(), camera2);
+  }
+
+  {
+    YAML::Node node(YAML::NodeType::Map);
+
+    auto res =
+        sceneLoader.loadStartingCamera(node, entityIdCache, liquid::EntityNull);
+    EXPECT_TRUE(res.hasData());
+    EXPECT_EQ(res.getData(), camera2);
+  }
+
+  {
+    YAML::Node node(YAML::NodeType::Sequence);
+
+    auto res =
+        sceneLoader.loadStartingCamera(node, entityIdCache, liquid::EntityNull);
+    EXPECT_TRUE(res.hasData());
+    EXPECT_EQ(res.getData(), camera2);
+  }
+
+  {
+    YAML::Node node(YAML::NodeType::Undefined);
+
+    auto res =
+        sceneLoader.loadStartingCamera(node, entityIdCache, liquid::EntityNull);
+    EXPECT_TRUE(res.hasData());
+    EXPECT_EQ(res.getData(), camera2);
+  }
+}
+
+TEST_F(
+    SceneLoaderActiveCameraTest,
+    ReturnsLastFoundCameraEntityInTheDatabaseIfStartingCameraInSceneNodeDoesNotExistInDatabase) {
+
+  auto camera1 = createNode(true).second;
+  entityDatabase.set<liquid::PerspectiveLensComponent>(camera1, {});
+
+  auto camera2 = createNode(true).second;
+  entityDatabase.set<liquid::PerspectiveLensComponent>(camera2, {});
+
+  {
+    YAML::Node node(23232);
+
+    auto res =
+        sceneLoader.loadStartingCamera(node, entityIdCache, liquid::EntityNull);
+    EXPECT_TRUE(res.hasData());
+    EXPECT_EQ(res.getData(), camera2);
+  }
+}
+
+TEST_F(
+    SceneLoaderActiveCameraTest,
+    ReturnsLastFoundCameraEntityInTheDatabaseIfStartingCameraInSceneNodeDoesNotHaveACameraComponent) {
+  auto idNode = createNode(true).first;
+
+  auto camera1 = createNode(true).second;
+  entityDatabase.set<liquid::PerspectiveLensComponent>(camera1, {});
+
+  auto camera2 = createNode(true).second;
+  entityDatabase.set<liquid::PerspectiveLensComponent>(camera2, {});
+
+  {
+    auto res = sceneLoader.loadStartingCamera(idNode["id"], entityIdCache,
+                                              liquid::EntityNull);
+    EXPECT_TRUE(res.hasData());
+    EXPECT_EQ(res.getData(), camera2);
+  }
+}
+
+TEST_F(SceneLoaderActiveCameraTest,
+       ReturnsStartingCameraEntityFromSceneNodeIfEntityHasACameraComponent) {
+  auto startingCameraNode = createNode(true);
+  entityDatabase.set<liquid::PerspectiveLensComponent>(
+      startingCameraNode.second, {});
+
+  auto camera1 = createNode(true).second;
+  entityDatabase.set<liquid::PerspectiveLensComponent>(camera1, {});
+
+  auto camera2 = createNode(true).second;
+  entityDatabase.set<liquid::PerspectiveLensComponent>(camera2, {});
+
+  {
+    auto res = sceneLoader.loadStartingCamera(
+        startingCameraNode.first["id"], entityIdCache, liquid::EntityNull);
+    EXPECT_TRUE(res.hasData());
+    EXPECT_EQ(res.getData(), startingCameraNode.second);
+  }
+}


### PR DESCRIPTION
- Create scene object
- Create scene file
- Save starting camera in the scene file
- Handle active camera deletion using scene io and entity deleter
- Use starting camera in runtime
- Use starting camera in editor simulation
- Remove setting active camera in editor
- Set initial camera in the editor
- Fix section UI for the transform component in entity panel
- Update Vulkan for CI/CD to use Ubuntu 22.04