### PR TITLE
Abstract away Vulkan types

### DIFF
--- a/editor/src/liquidator/core/MousePickingGraph.cpp
+++ b/editor/src/liquidator/core/MousePickingGraph.cpp
@@ -28,7 +28,7 @@ MousePickingGraph::MousePickingGraph(liquid::ShaderLibrary &shaderLibrary,
   depthBufferDesc.width = FramebufferSizePercentage;
   depthBufferDesc.height = FramebufferSizePercentage;
   depthBufferDesc.layers = 1;
-  depthBufferDesc.format = VK_FORMAT_D32_SFLOAT;
+  depthBufferDesc.format = liquid::rhi::Format::Depth32Float;
   auto depthBuffer = mDevice->createTexture(depthBufferDesc);
 
   liquid::Entity nullEntity{0};
@@ -115,7 +115,7 @@ MousePickingGraph::MousePickingGraph(liquid::ShaderLibrary &shaderLibrary,
 
         if (indexed) {
           commandList.bindIndexBuffer(mesh.indexBuffers.at(g).getHandle(),
-                                      VK_INDEX_TYPE_UINT32);
+                                      liquid::rhi::IndexType::Uint32);
         }
 
         uint32_t indexCount =
@@ -170,7 +170,7 @@ MousePickingGraph::MousePickingGraph(liquid::ShaderLibrary &shaderLibrary,
             liquid::rhi::isHandleValid(mesh.indexBuffers.at(g).getHandle());
         if (indexed) {
           commandList.bindIndexBuffer(mesh.indexBuffers.at(g).getHandle(),
-                                      VK_INDEX_TYPE_UINT32);
+                                      liquid::rhi::IndexType::Uint32);
         }
 
         uint32_t indexCount =

--- a/editor/src/liquidator/screens/ProjectSelectorScreen.cpp
+++ b/editor/src/liquidator/screens/ProjectSelectorScreen.cpp
@@ -130,6 +130,7 @@ std::optional<Project> ProjectSelectorScreen::start() {
   mainLoop.run();
 
   mWindow.removeResizeHandler(resizeHandler);
+  mDevice->waitForIdle();
   return project;
 }
 

--- a/editor/src/main.cpp
+++ b/editor/src/main.cpp
@@ -22,7 +22,6 @@ int main() {
 
   auto project = projectSelector.start();
 
-  device->waitForIdle();
   device->destroyResources();
   if (project.has_value()) {
     liquidator::EditorScreen editor(window, eventSystem, device);

--- a/engine/rhi/core/include/liquid/rhi/AccessFlags.h
+++ b/engine/rhi/core/include/liquid/rhi/AccessFlags.h
@@ -1,0 +1,28 @@
+#pragma once
+
+namespace liquid::rhi {
+
+enum class Access {
+  None = 0,
+  IndirectCommandRead = 0x00000001,
+  IndexRead = 0x00000002,
+  VertexAttributeRead = 0x00000004,
+  UniformRead = 0x00000008,
+  InputAttachmentRead = 0x00000010,
+  ShaderRead = 0x00000020,
+  ShaderWrite = 0x00000040,
+  ColorAttachmentRead = 0x00000080,
+  ColorAttachmentWrite = 0x00000100,
+  DepthStencilAttachmentRead = 0x00000200,
+  DepthStencilAttachmentWrite = 0x00000400,
+  TransferRead = 0x00000800,
+  TransferWrite = 0x00001000,
+  HostRead = 0x00002000,
+  HostWrite = 0x00004000,
+  MemoryRead = 0x00008000,
+  MemoryWrite = 0x00010000,
+};
+
+EnableBitwiseEnum(Access)
+
+} // namespace liquid::rhi

--- a/engine/rhi/core/include/liquid/rhi/Format.h
+++ b/engine/rhi/core/include/liquid/rhi/Format.h
@@ -1,0 +1,19 @@
+#pragma once
+
+namespace liquid::rhi {
+
+enum Format {
+  Undefined = 0,
+  Rgba8Unorm,
+  Rgba8Srgb,
+  Bgra8Srgb,
+  Rgba16Float,
+  Rg32Float,
+  Rgb32Float,
+  Rgba32Float,
+  Rgba32Uint,
+  Depth16Unorm,
+  Depth32Float
+};
+
+} // namespace liquid::rhi

--- a/engine/rhi/core/include/liquid/rhi/ImageLayout.h
+++ b/engine/rhi/core/include/liquid/rhi/ImageLayout.h
@@ -1,0 +1,18 @@
+#pragma once
+
+namespace liquid::rhi {
+
+enum class ImageLayout {
+  Undefined = 0,
+  General = 1,
+  ColorAttachmentOptimal = 2,
+  DepthStencilAttachmentOptimal = 3,
+  DepthStencilReadOnlyOptimal = 4,
+  ShaderReadOnlyOptimal = 5,
+  TransferSourceOptimal = 6,
+  TransferDestinationOptimal = 7,
+  Preinitialized = 8,
+  PresentSource = 1000001002
+};
+
+} // namespace liquid::rhi

--- a/engine/rhi/core/include/liquid/rhi/IndexType.h
+++ b/engine/rhi/core/include/liquid/rhi/IndexType.h
@@ -1,0 +1,10 @@
+#pragma once
+
+namespace liquid::rhi {
+
+enum class IndexType {
+  Uint16 = 0,
+  Uint32 = 1,
+};
+
+} // namespace liquid::rhi

--- a/engine/rhi/core/include/liquid/rhi/NativeRenderCommandListInterface.h
+++ b/engine/rhi/core/include/liquid/rhi/NativeRenderCommandListInterface.h
@@ -3,8 +3,8 @@
 #include "liquid/rhi/Descriptor.h"
 #include "liquid/rhi/RenderHandle.h"
 #include "liquid/rhi/PipelineBarrier.h"
-
-#include <vulkan/vulkan.hpp>
+#include "liquid/rhi/StageFlags.h"
+#include "liquid/rhi/IndexType.h"
 
 namespace liquid::rhi {
 
@@ -80,20 +80,19 @@ public:
    * @param buffer Index buffer
    * @param indexType Index buffer data type
    */
-  virtual void bindIndexBuffer(BufferHandle buffer, VkIndexType indexType) = 0;
+  virtual void bindIndexBuffer(BufferHandle buffer, IndexType indexType) = 0;
 
   /**
    * @brief Push constants
    *
    * @param pipeline Pipeline
-   * @param stageFlags Stage flags
+   * @param shaderStage Shader stage
    * @param offset Offset
    * @param size Size
    * @param data Data
    */
-  virtual void pushConstants(PipelineHandle pipeline,
-                             VkShaderStageFlags stageFlags, uint32_t offset,
-                             uint32_t size, void *data) = 0;
+  virtual void pushConstants(PipelineHandle pipeline, ShaderStage shaderStage,
+                             uint32_t offset, uint32_t size, void *data) = 0;
 
   /**
    * @brief Draw
@@ -146,7 +145,7 @@ public:
    * @param imageBarriers Image barriers
    */
   virtual void
-  pipelineBarrier(VkPipelineStageFlags srcStage, VkPipelineStageFlags dstStage,
+  pipelineBarrier(PipelineStage srcStage, PipelineStage dstStage,
                   const std::vector<MemoryBarrier> &memoryBarriers,
                   const std::vector<ImageBarrier> &imageBarriers) = 0;
 };

--- a/engine/rhi/core/include/liquid/rhi/PipelineBarrier.h
+++ b/engine/rhi/core/include/liquid/rhi/PipelineBarrier.h
@@ -1,7 +1,8 @@
 #pragma once
 
-#include <vulkan/vulkan.h>
 #include "RenderHandle.h"
+#include "AccessFlags.h"
+#include "ImageLayout.h"
 
 namespace liquid::rhi {
 
@@ -12,12 +13,12 @@ struct MemoryBarrier {
   /**
    * Source access flags
    */
-  VkAccessFlags srcAccess = VK_ACCESS_NONE_KHR;
+  Access srcAccess{Access::None};
 
   /**
    * Destination access flags
    */
-  VkAccessFlags dstAccess = VK_ACCESS_NONE_KHR;
+  Access dstAccess{Access::None};
 };
 
 /**
@@ -27,22 +28,22 @@ struct ImageBarrier {
   /**
    * Source access flags
    */
-  VkAccessFlags srcAccess = VK_ACCESS_NONE_KHR;
+  Access srcAccess{Access::None};
 
   /**
    * Destination access flags
    */
-  VkAccessFlags dstAccess = VK_ACCESS_NONE_KHR;
+  Access dstAccess{Access::None};
 
   /**
    * Source image layout
    */
-  VkImageLayout srcLayout = VK_IMAGE_LAYOUT_MAX_ENUM;
+  ImageLayout srcLayout{ImageLayout::Undefined};
 
   /**
    * Destination image layout
    */
-  VkImageLayout dstLayout = VK_IMAGE_LAYOUT_MAX_ENUM;
+  ImageLayout dstLayout{ImageLayout::Undefined};
 
   /**
    * Texture

--- a/engine/rhi/core/include/liquid/rhi/PipelineBindPoint.h
+++ b/engine/rhi/core/include/liquid/rhi/PipelineBindPoint.h
@@ -1,0 +1,7 @@
+#pragma once
+
+namespace liquid::rhi {
+
+enum class PipelineBindPoint { Graphics, Compute };
+
+} // namespace liquid::rhi

--- a/engine/rhi/core/include/liquid/rhi/PipelineDescription.h
+++ b/engine/rhi/core/include/liquid/rhi/PipelineDescription.h
@@ -3,6 +3,7 @@
 #include "RenderHandle.h"
 #include "liquid/scene/Vertex.h"
 #include "liquid/scene/SkinnedVertex.h"
+#include "liquid/rhi/Format.h"
 
 namespace liquid::rhi {
 
@@ -120,7 +121,7 @@ struct PipelineVertexInputAttribute {
   /**
    * Attribute format
    */
-  uint32_t format = 0;
+  Format format = Format::Undefined;
 
   /**
    * Attribute offset
@@ -169,25 +170,20 @@ inline PipelineVertexInputLayout PipelineVertexInputLayout::create<Vertex>() {
   static constexpr uint32_t TexCoord0Slot = 4;
   static constexpr uint32_t TexCoord1Slot = 5;
 
-  // TODO: Create abstract format type
-  const uint32_t R32G32B32A32_SFLOAT = 109;
-  const uint32_t R32G32B32_SFLOAT = 106;
-  const uint32_t R32G32_SFLOAT = 103;
-
   return PipelineVertexInputLayout{
       {PipelineVertexInputBinding{0, sizeof(Vertex), VertexInputRate::Vertex}},
       {
-          PipelineVertexInputAttribute{PositionSlot, 0, R32G32B32_SFLOAT,
+          PipelineVertexInputAttribute{PositionSlot, 0, rhi::Format::Rgb32Float,
                                        offsetof(SkinnedVertex, x)},
-          PipelineVertexInputAttribute{NormalSlot, 0, R32G32B32_SFLOAT,
+          PipelineVertexInputAttribute{NormalSlot, 0, rhi::Format::Rgb32Float,
                                        offsetof(SkinnedVertex, nx)},
-          PipelineVertexInputAttribute{TangentSlot, 0, R32G32B32A32_SFLOAT,
+          PipelineVertexInputAttribute{TangentSlot, 0, rhi::Format::Rgba32Float,
                                        offsetof(SkinnedVertex, tx)},
-          PipelineVertexInputAttribute{ColorSlot, 0, R32G32B32_SFLOAT,
+          PipelineVertexInputAttribute{ColorSlot, 0, rhi::Format::Rgb32Float,
                                        offsetof(SkinnedVertex, r)},
-          PipelineVertexInputAttribute{TexCoord0Slot, 0, R32G32_SFLOAT,
+          PipelineVertexInputAttribute{TexCoord0Slot, 0, rhi::Format::Rg32Float,
                                        offsetof(SkinnedVertex, u0)},
-          PipelineVertexInputAttribute{TexCoord1Slot, 0, R32G32_SFLOAT,
+          PipelineVertexInputAttribute{TexCoord1Slot, 0, rhi::Format::Rg32Float,
                                        offsetof(SkinnedVertex, u1)},
       }};
 }
@@ -209,30 +205,24 @@ PipelineVertexInputLayout::create<SkinnedVertex>() {
   static constexpr uint32_t JointsSlot = 6;
   static constexpr uint32_t WeightsSlot = 7;
 
-  // TODO: Create abstract format type
-  static constexpr uint32_t R32G32B32A32_SFLOAT = 109;
-  static constexpr uint32_t R32G32B32_SFLOAT = 106;
-  static constexpr uint32_t R32G32_SFLOAT = 103;
-  static constexpr uint32_t R32G32B32A32_UINT = 107;
-
   return PipelineVertexInputLayout{
       {PipelineVertexInputBinding{0, sizeof(SkinnedVertex),
                                   VertexInputRate::Vertex}},
-      {PipelineVertexInputAttribute{PositionSlot, 0, R32G32B32_SFLOAT,
+      {PipelineVertexInputAttribute{PositionSlot, 0, rhi::Format::Rgb32Float,
                                     offsetof(SkinnedVertex, x)},
-       PipelineVertexInputAttribute{NormalSlot, 0, R32G32B32_SFLOAT,
+       PipelineVertexInputAttribute{NormalSlot, 0, rhi::Format::Rgb32Float,
                                     offsetof(SkinnedVertex, nx)},
-       PipelineVertexInputAttribute{TangentSlot, 0, R32G32B32A32_SFLOAT,
+       PipelineVertexInputAttribute{TangentSlot, 0, rhi::Format::Rgba32Float,
                                     offsetof(SkinnedVertex, tx)},
-       PipelineVertexInputAttribute{ColorSlot, 0, R32G32B32_SFLOAT,
+       PipelineVertexInputAttribute{ColorSlot, 0, rhi::Format::Rgb32Float,
                                     offsetof(SkinnedVertex, r)},
-       PipelineVertexInputAttribute{TexCoord0Slot, 0, R32G32_SFLOAT,
+       PipelineVertexInputAttribute{TexCoord0Slot, 0, rhi::Format::Rg32Float,
                                     offsetof(SkinnedVertex, u0)},
-       PipelineVertexInputAttribute{TexCoord1Slot, 0, R32G32_SFLOAT,
+       PipelineVertexInputAttribute{TexCoord1Slot, 0, rhi::Format::Rg32Float,
                                     offsetof(SkinnedVertex, u1)},
-       PipelineVertexInputAttribute{JointsSlot, 0, R32G32B32A32_UINT,
+       PipelineVertexInputAttribute{JointsSlot, 0, rhi::Format::Rgba32Uint,
                                     offsetof(SkinnedVertex, j0)},
-       PipelineVertexInputAttribute{WeightsSlot, 0, R32G32B32A32_SFLOAT,
+       PipelineVertexInputAttribute{WeightsSlot, 0, rhi::Format::Rgba32Float,
                                     offsetof(SkinnedVertex, w0)}}};
 }
 

--- a/engine/rhi/core/include/liquid/rhi/RenderCommandList.h
+++ b/engine/rhi/core/include/liquid/rhi/RenderCommandList.h
@@ -120,7 +120,7 @@ public:
    * @param buffer Index buffer
    * @param indexType Index buffer data type
    */
-  inline void bindIndexBuffer(BufferHandle buffer, VkIndexType indexType) {
+  inline void bindIndexBuffer(BufferHandle buffer, IndexType indexType) {
     mNativeRenderCommandList->bindIndexBuffer(buffer, indexType);
   }
 
@@ -128,15 +128,14 @@ public:
    * @brief Push constants
    *
    * @param pipeline Pipeline
-   * @param stageFlags Stage flags
+   * @param shaderStage Shader stage
    * @param offset Offset
    * @param size Size
    * @param data Data
    */
-  inline void pushConstants(PipelineHandle pipeline,
-                            VkShaderStageFlags stageFlags, uint32_t offset,
-                            uint32_t size, void *data) {
-    mNativeRenderCommandList->pushConstants(pipeline, stageFlags, offset, size,
+  inline void pushConstants(PipelineHandle pipeline, ShaderStage shaderStage,
+                            uint32_t offset, uint32_t size, void *data) {
+    mNativeRenderCommandList->pushConstants(pipeline, shaderStage, offset, size,
                                             data);
   }
 
@@ -200,8 +199,7 @@ public:
    * @param memoryBarriers Memory barriers
    * @param imageBarriers Image barriers
    */
-  void pipelineBarrier(VkPipelineStageFlags srcStage,
-                       VkPipelineStageFlags dstStage,
+  void pipelineBarrier(PipelineStage srcStage, PipelineStage dstStage,
                        const std::vector<MemoryBarrier> &memoryBarriers,
                        const std::vector<ImageBarrier> &imageBarriers) {
     mNativeRenderCommandList->pipelineBarrier(srcStage, dstStage,

--- a/engine/rhi/core/include/liquid/rhi/RenderGraphPass.h
+++ b/engine/rhi/core/include/liquid/rhi/RenderGraphPass.h
@@ -44,12 +44,12 @@ struct RenderTargetData {
   /**
    * Source image layout
    */
-  VkImageLayout srcLayout = VK_IMAGE_LAYOUT_MAX_ENUM;
+  ImageLayout srcLayout{ImageLayout::Undefined};
 
   /**
    * Destination image layout
    */
-  VkImageLayout dstLayout = VK_IMAGE_LAYOUT_MAX_ENUM;
+  ImageLayout dstLayout{ImageLayout::Undefined};
 };
 
 /**
@@ -64,12 +64,12 @@ struct RenderGraphPassBarrier {
   /**
    * Source pipeline stage
    */
-  VkPipelineStageFlags srcStage = VK_PIPELINE_STAGE_NONE_KHR;
+  PipelineStage srcStage{PipelineStage::None};
 
   /**
    * Destination pipeline stage
    */
-  VkPipelineStageFlags dstStage = VK_PIPELINE_STAGE_NONE_KHR;
+  PipelineStage dstStage{PipelineStage::None};
 
   /**
    * Memory barriers

--- a/engine/rhi/core/include/liquid/rhi/RenderPassDescription.h
+++ b/engine/rhi/core/include/liquid/rhi/RenderPassDescription.h
@@ -1,7 +1,8 @@
 #pragma once
 
 #include "liquid/rhi/RenderHandle.h"
-#include <vulkan/vulkan.hpp>
+#include "liquid/rhi/ImageLayout.h"
+#include "liquid/rhi/PipelineBindPoint.h"
 
 namespace liquid::rhi {
 
@@ -48,12 +49,12 @@ struct RenderPassAttachmentDescription {
   /**
    * Attachment image initial layout
    */
-  VkImageLayout initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+  ImageLayout initialLayout{ImageLayout::Undefined};
 
   /**
    * Attachment image layout
    */
-  VkImageLayout layout = VK_IMAGE_LAYOUT_MAX_ENUM;
+  ImageLayout layout{ImageLayout::Undefined};
 
   /**
    * Attachment clear value
@@ -73,7 +74,7 @@ struct RenderPassDescription {
   /**
    * Pipeline bind point
    */
-  VkPipelineBindPoint bindPoint;
+  PipelineBindPoint bindPoint;
 };
 
 } // namespace liquid::rhi

--- a/engine/rhi/core/include/liquid/rhi/StageFlags.h
+++ b/engine/rhi/core/include/liquid/rhi/StageFlags.h
@@ -1,0 +1,35 @@
+#pragma once
+
+namespace liquid::rhi {
+
+enum class ShaderStage {
+  Vertex = 0x00000001,
+  Fragment = 0x00000010,
+  Compute = 0x00000020,
+  AllGraphics = 0x0000001F,
+  All = 0x7FFFFFFF
+};
+
+EnableBitwiseEnum(ShaderStage);
+
+enum class PipelineStage {
+  PipeTop = 0x00000001,
+  DrawIndirect = 0x00000002,
+  VertexInput = 0x00000004,
+  VertexShader = 0x00000008,
+  FragmentShader = 0x00000080,
+  EarlyFragmentTests = 0x00000100,
+  LateFragmentTests = 0x00000200,
+  ColorAttachmentOutput = 0x00000400,
+  ComputeShader = 0x00000800,
+  Transfer = 0x00001000,
+  PipeBottom = 0x00002000,
+  Host = 0x00004000,
+  AllGraphics = 0x00008000,
+  AllCommands = 0x00010000,
+  None = 0
+};
+
+EnableBitwiseEnum(PipelineStage);
+
+} // namespace liquid::rhi

--- a/engine/rhi/core/include/liquid/rhi/TextureDescription.h
+++ b/engine/rhi/core/include/liquid/rhi/TextureDescription.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "liquid/rhi/Format.h"
+
 namespace liquid::rhi {
 
 enum class TextureType { Standard, Cubemap };
@@ -44,7 +46,7 @@ struct TextureDescription {
   /**
    * Texture format
    */
-  uint32_t format = 0;
+  Format format = Format::Undefined;
 
   /**
    * Texture width

--- a/engine/rhi/core/src/RenderGraphEvaluator.cpp
+++ b/engine/rhi/core/src/RenderGraphEvaluator.cpp
@@ -85,7 +85,7 @@ void RenderGraphEvaluator::buildPass(size_t index, RenderGraph &graph,
   }
 
   if (!renderPassDesc.attachments.empty()) {
-    renderPassDesc.bindPoint = VK_PIPELINE_BIND_POINT_GRAPHICS;
+    renderPassDesc.bindPoint = PipelineBindPoint::Graphics;
 
     bool renderPassExists = isHandleValid(pass.mRenderPass);
 

--- a/engine/rhi/vulkan/include/liquid/rhi-vulkan/VulkanCommandBuffer.h
+++ b/engine/rhi/vulkan/include/liquid/rhi-vulkan/VulkanCommandBuffer.h
@@ -93,18 +93,18 @@ public:
    * @param buffer Index buffer
    * @param indexType Index buffer data type
    */
-  void bindIndexBuffer(BufferHandle buffer, VkIndexType indexType) override;
+  void bindIndexBuffer(BufferHandle buffer, IndexType indexType) override;
 
   /**
    * @brief Push constants
    *
    * @param pipeline Pipeline
-   * @param stageFlags Stage flags
+   * @param shaderStage Shader stage
    * @param offset Offset
    * @param size Size
    * @param data Data
    */
-  void pushConstants(PipelineHandle pipeline, VkShaderStageFlags stageFlags,
+  void pushConstants(PipelineHandle pipeline, ShaderStage shaderStage,
                      uint32_t offset, uint32_t size, void *data) override;
 
   /**
@@ -157,8 +157,7 @@ public:
    * @param memoryBarriers Memory barriers
    * @param imageBarriers Image barriers
    */
-  void pipelineBarrier(VkPipelineStageFlags srcStage,
-                       VkPipelineStageFlags dstStage,
+  void pipelineBarrier(PipelineStage srcStage, PipelineStage dstStage,
                        const std::vector<MemoryBarrier> &memoryBarriers,
                        const std::vector<ImageBarrier> &imageBarriers) override;
 

--- a/engine/rhi/vulkan/include/liquid/rhi-vulkan/VulkanMapping.h
+++ b/engine/rhi/vulkan/include/liquid/rhi-vulkan/VulkanMapping.h
@@ -3,6 +3,11 @@
 #include "liquid/rhi/RenderPassDescription.h"
 #include "liquid/rhi/PipelineDescription.h"
 #include "liquid/rhi/Descriptor.h"
+#include "liquid/rhi/AccessFlags.h"
+#include "liquid/rhi/ImageLayout.h"
+#include "liquid/rhi/StageFlags.h"
+#include "liquid/rhi/IndexType.h"
+#include "liquid/rhi/Format.h"
 
 #include <vulkan/vulkan.hpp>
 
@@ -95,6 +100,64 @@ public:
    * @return Vulkan descriptor type
    */
   static VkDescriptorType getDescriptorType(DescriptorType descriptorType);
+
+  /**
+   * @brief Get Vulkan access flags
+   *
+   * @param access Access
+   * @return Vulkan access flags
+   */
+  static VkAccessFlags getAccessFlags(Access access);
+
+  /**
+   * @brief Get Vulkan image layout
+   *
+   * @param imageLayout Image layout
+   * @return Vulkan image layout
+   */
+  static VkImageLayout getImageLayout(ImageLayout imageLayout);
+
+  /**
+   * @brief Get Vulkan pipeline bind point
+   *
+   * @param pipelineBindPoint Pipeline bind point
+   * @return Vulkan pipeline bind point
+   */
+  static VkPipelineBindPoint
+  getPipelineBindPoint(PipelineBindPoint pipelineBindPoint);
+
+  /**
+   * @brief Get Vulkan shader stage flags
+   *
+   * @param shaderStage Shader stage
+   * @return Vulkan shader stage flags
+   */
+  static VkShaderStageFlags getShaderStageFlags(ShaderStage shaderStage);
+
+  /**
+   * @brief Get Vulkan pipeline stage flags
+   *
+   * @param pipelineStage Pipeline stage
+   * @return Vulkan pipeline stage flags
+   */
+  static VkPipelineStageFlags
+  getPipelineStageFlags(PipelineStage pipelineStage);
+
+  /**
+   * @brief Get Vulkan index type
+   *
+   * @param indexType Index type
+   * @return Vulkan index type
+   */
+  static VkIndexType getIndexType(IndexType indexType);
+
+  /**
+   * @brief Get Vulkan format
+   *
+   * @param format Format
+   * @return Vulkan format
+   */
+  static VkFormat getFormat(Format format);
 };
 
 } // namespace liquid::rhi

--- a/engine/rhi/vulkan/src/VulkanMapping.cpp
+++ b/engine/rhi/vulkan/src/VulkanMapping.cpp
@@ -176,4 +176,96 @@ VulkanMapping::getDescriptorType(DescriptorType descriptorType) {
   }
 }
 
+VkAccessFlags VulkanMapping::getAccessFlags(Access access) {
+  return static_cast<VkAccessFlags>(access);
+}
+
+VkImageLayout VulkanMapping::getImageLayout(ImageLayout imageLayout) {
+  switch (imageLayout) {
+  case ImageLayout::Undefined:
+    return VK_IMAGE_LAYOUT_UNDEFINED;
+  case ImageLayout::General:
+    return VK_IMAGE_LAYOUT_GENERAL;
+  case ImageLayout::ColorAttachmentOptimal:
+    return VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
+  case ImageLayout::DepthStencilAttachmentOptimal:
+    return VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL;
+  case ImageLayout::DepthStencilReadOnlyOptimal:
+    return VK_IMAGE_LAYOUT_DEPTH_STENCIL_READ_ONLY_OPTIMAL;
+  case ImageLayout::ShaderReadOnlyOptimal:
+    return VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
+  case ImageLayout::TransferSourceOptimal:
+    return VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL;
+  case ImageLayout::TransferDestinationOptimal:
+    return VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL;
+  case ImageLayout::Preinitialized:
+    return VK_IMAGE_LAYOUT_PREINITIALIZED;
+  case ImageLayout::PresentSource:
+    return VK_IMAGE_LAYOUT_PRESENT_SRC_KHR;
+  default:
+    return VK_IMAGE_LAYOUT_MAX_ENUM;
+  };
+}
+
+VkPipelineBindPoint
+VulkanMapping::getPipelineBindPoint(PipelineBindPoint pipelineBindPoint) {
+  switch (pipelineBindPoint) {
+  case PipelineBindPoint::Graphics:
+    return VK_PIPELINE_BIND_POINT_GRAPHICS;
+  case PipelineBindPoint::Compute:
+    return VK_PIPELINE_BIND_POINT_COMPUTE;
+  default:
+    return VK_PIPELINE_BIND_POINT_MAX_ENUM;
+  }
+}
+
+VkShaderStageFlags VulkanMapping::getShaderStageFlags(ShaderStage shaderStage) {
+  return static_cast<VkShaderStageFlags>(shaderStage);
+}
+
+VkPipelineStageFlags
+VulkanMapping::getPipelineStageFlags(PipelineStage pipelineStage) {
+  return static_cast<VkPipelineStageFlags>(pipelineStage);
+}
+
+VkIndexType VulkanMapping::getIndexType(IndexType indexType) {
+  switch (indexType) {
+  case IndexType::Uint16:
+    return VK_INDEX_TYPE_UINT16;
+  case IndexType::Uint32:
+    return VK_INDEX_TYPE_UINT32;
+  default:
+    return VK_INDEX_TYPE_MAX_ENUM;
+  }
+}
+
+VkFormat VulkanMapping::getFormat(Format format) {
+  switch (format) {
+  case rhi::Format::Rgba8Unorm:
+    return VK_FORMAT_R8G8B8A8_UNORM;
+  case rhi::Format::Rgba8Srgb:
+    return VK_FORMAT_R8G8B8A8_SRGB;
+  case rhi::Format::Bgra8Srgb:
+    return VK_FORMAT_B8G8R8A8_SRGB;
+  case rhi::Format::Rgba16Float:
+    return VK_FORMAT_R16G16B16A16_SFLOAT;
+  case rhi::Format::Rg32Float:
+    return VK_FORMAT_R32G32_SFLOAT;
+  case rhi::Format::Rgb32Float:
+    return VK_FORMAT_R32G32B32_SFLOAT;
+  case rhi::Format::Rgba32Float:
+    return VK_FORMAT_R32G32B32A32_SFLOAT;
+  case rhi::Format::Rgba32Uint:
+    return VK_FORMAT_R32G32B32A32_UINT;
+  case rhi::Format::Depth16Unorm:
+    return VK_FORMAT_D16_UNORM;
+  case rhi::Format::Depth32Float:
+    return VK_FORMAT_D32_SFLOAT;
+  case rhi::Format::Undefined:
+  default:
+    LIQUID_ASSERT(false, "Undefined format");
+    return VK_FORMAT_UNDEFINED;
+  }
+}
+
 } // namespace liquid::rhi

--- a/engine/rhi/vulkan/src/VulkanPipeline.cpp
+++ b/engine/rhi/vulkan/src/VulkanPipeline.cpp
@@ -219,7 +219,8 @@ VulkanPipeline::VulkanPipeline(const PipelineDescription &description,
     vertexInputDescriptions.at(i) = VkVertexInputAttributeDescription{
         description.inputLayout.attributes.at(i).slot,
         description.inputLayout.attributes.at(i).binding,
-        static_cast<VkFormat>(description.inputLayout.attributes.at(i).format),
+        VulkanMapping::getFormat(
+            description.inputLayout.attributes.at(i).format),
         description.inputLayout.attributes.at(i).offset,
     };
   }

--- a/engine/rhi/vulkan/src/VulkanRenderPass.cpp
+++ b/engine/rhi/vulkan/src/VulkanRenderPass.cpp
@@ -48,10 +48,9 @@ VulkanRenderPass::VulkanRenderPass(const RenderPassDescription &description,
       mClearValues.at(i).color.float32[3] =
           std::get<glm::vec4>(desc.clearValue).w;
 
-      attachment.initialLayout = desc.initialLayout;
-      attachment.finalLayout = desc.layout != VK_IMAGE_LAYOUT_MAX_ENUM
-                                   ? desc.layout
-                                   : VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
+      attachment.initialLayout =
+          VulkanMapping::getImageLayout(desc.initialLayout);
+      attachment.finalLayout = VulkanMapping::getImageLayout(desc.layout);
       ref.layout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
       colorReferences.push_back(ref);
     } else if ((texture->getDescription().usage & TextureUsage::Depth) ==
@@ -62,7 +61,8 @@ VulkanRenderPass::VulkanRenderPass(const RenderPassDescription &description,
       mClearValues.at(i).depthStencil.stencil =
           std::get<DepthStencilClear>(desc.clearValue).clearStencil;
 
-      attachment.initialLayout = desc.initialLayout;
+      attachment.initialLayout =
+          VulkanMapping::getImageLayout(desc.initialLayout);
       attachment.finalLayout = VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL;
       ref.layout = VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL;
       depthReference.emplace(ref);
@@ -79,7 +79,8 @@ VulkanRenderPass::VulkanRenderPass(const RenderPassDescription &description,
   subpass.pInputAttachments = nullptr;
   subpass.preserveAttachmentCount = 0;
   subpass.pPreserveAttachments = nullptr;
-  subpass.pipelineBindPoint = description.bindPoint;
+  subpass.pipelineBindPoint =
+      VulkanMapping::getPipelineBindPoint(description.bindPoint);
   subpass.pResolveAttachments = nullptr;
 
   VkRenderPassCreateInfo createInfo{};

--- a/engine/rhi/vulkan/src/VulkanTexture.cpp
+++ b/engine/rhi/vulkan/src/VulkanTexture.cpp
@@ -3,6 +3,7 @@
 #include "VulkanBuffer.h"
 #include "VulkanTexture.h"
 #include "VulkanError.h"
+#include "VulkanMapping.h"
 
 namespace liquid::rhi {
 
@@ -25,7 +26,7 @@ VulkanTexture::VulkanTexture(const TextureDescription &description,
                              VulkanUploadContext &uploadContext,
                              const glm::uvec2 &swapchainExtent)
     : mAllocator(allocator), mDevice(device),
-      mFormat(static_cast<VkFormat>(description.format)),
+      mFormat(VulkanMapping::getFormat(description.format)),
       mDescription(description) {
   LIQUID_ASSERT(
       description.type == TextureType::Cubemap ? description.layers == 6 : true,
@@ -35,7 +36,6 @@ VulkanTexture::VulkanTexture(const TextureDescription &description,
                             ? VK_IMAGE_CREATE_CUBE_COMPATIBLE_BIT
                             : 0;
 
-  VkFormat format = static_cast<VkFormat>(description.format);
   VkImageViewType imageViewType = VK_IMAGE_VIEW_TYPE_MAX_ENUM;
 
   if (description.type == TextureType::Cubemap) {
@@ -84,7 +84,7 @@ VulkanTexture::VulkanTexture(const TextureDescription &description,
   imageCreateInfo.pNext = nullptr;
   imageCreateInfo.flags = imageFlags;
   imageCreateInfo.imageType = VK_IMAGE_TYPE_2D;
-  imageCreateInfo.format = format;
+  imageCreateInfo.format = mFormat;
   imageCreateInfo.extent = extent;
   imageCreateInfo.mipLevels = 1;
   imageCreateInfo.arrayLayers = description.layers;
@@ -106,7 +106,7 @@ VulkanTexture::VulkanTexture(const TextureDescription &description,
   imageViewCreateInfo.flags = 0;
   imageViewCreateInfo.image = mImage;
   imageViewCreateInfo.viewType = imageViewType;
-  imageViewCreateInfo.format = format;
+  imageViewCreateInfo.format = mFormat;
   imageViewCreateInfo.subresourceRange.baseMipLevel = 0;
   imageViewCreateInfo.subresourceRange.baseArrayLayer = 0;
   imageViewCreateInfo.subresourceRange.layerCount = description.layers;

--- a/engine/src/liquid/asset/AssetRegistry.cpp
+++ b/engine/src/liquid/asset/AssetRegistry.cpp
@@ -57,7 +57,7 @@ void AssetRegistry::syncWithDevice(rhi::RenderDevice *device) {
       description.usage = rhi::TextureUsage::Color |
                           rhi::TextureUsage::TransferDestination |
                           rhi::TextureUsage::Sampled;
-      description.format = VK_FORMAT_R8G8B8A8_SRGB;
+      description.format = rhi::Format::Rgba8Srgb;
 
       font.data.deviceHandle = device->createTexture(description);
     }

--- a/engine/src/liquid/asset/TextureAsset.h
+++ b/engine/src/liquid/asset/TextureAsset.h
@@ -6,8 +6,6 @@ namespace liquid {
 
 enum class TextureAssetType { Standard, Cubemap };
 
-static constexpr uint32_t DefaultTextureFormat = 43;
-
 /**
  * @brief Texture asset data
  */
@@ -35,7 +33,7 @@ struct TextureAsset {
   /**
    * Texture format
    */
-  uint32_t format = DefaultTextureFormat;
+  rhi::Format format = rhi::Format::Rgba8Srgb;
 
   /**
    * Raw texture data

--- a/engine/src/liquid/core/Base.h
+++ b/engine/src/liquid/core/Base.h
@@ -50,6 +50,7 @@
 #include "Assert.h"
 #include "Profiler.h"
 #include "Errorable.h"
+#include "BitwiseEnum.h"
 
 namespace liquid {
 

--- a/engine/src/liquid/core/BitwiseEnum.h
+++ b/engine/src/liquid/core/BitwiseEnum.h
@@ -1,0 +1,41 @@
+#pragma once
+
+namespace liquid {
+
+#define EnableBitwiseEnum(TEnum)                                               \
+  constexpr inline TEnum operator~(TEnum a) {                                  \
+    using TUnder = typename std::underlying_type_t<TEnum>;                     \
+    return static_cast<TEnum>(~static_cast<TUnder>(a));                        \
+  }                                                                            \
+  constexpr inline TEnum operator|(TEnum a, TEnum b) {                         \
+    using TUnder = typename std::underlying_type_t<TEnum>;                     \
+    return static_cast<TEnum>(static_cast<TUnder>(a) |                         \
+                              static_cast<TUnder>(b));                         \
+  }                                                                            \
+  constexpr inline TEnum operator&(TEnum a, TEnum b) {                         \
+    using TUnder = typename std::underlying_type_t<TEnum>;                     \
+    return static_cast<TEnum>(static_cast<TUnder>(a) &                         \
+                              static_cast<TUnder>(b));                         \
+  }                                                                            \
+  constexpr inline TEnum operator^(TEnum a, TEnum b) {                         \
+    using TUnder = typename std::underlying_type_t<TEnum>;                     \
+    return static_cast<TEnum>(static_cast<TUnder>(a) ^                         \
+                              static_cast<TUnder>(b));                         \
+  }                                                                            \
+  constexpr inline TEnum &operator|=(TEnum &a, TEnum b) {                      \
+    using TUnder = typename std::underlying_type_t<TEnum>;                     \
+    a = static_cast<TEnum>(static_cast<TUnder>(a) | static_cast<TUnder>(b));   \
+    return a;                                                                  \
+  }                                                                            \
+  constexpr inline TEnum &operator&=(TEnum &a, TEnum b) {                      \
+    using TUnder = typename std::underlying_type_t<TEnum>;                     \
+    a = static_cast<TEnum>(static_cast<TUnder>(a) & static_cast<TUnder>(b));   \
+    return a;                                                                  \
+  }                                                                            \
+  constexpr inline TEnum &operator^=(TEnum &a, TEnum b) {                      \
+    using TUnder = typename std::underlying_type_t<TEnum>;                     \
+    a = static_cast<TEnum>(static_cast<TUnder>(a) ^ static_cast<TUnder>(b));   \
+    return a;                                                                  \
+  }
+
+} // namespace liquid

--- a/engine/src/liquid/loaders/ImageTextureLoader.cpp
+++ b/engine/src/liquid/loaders/ImageTextureLoader.cpp
@@ -3,7 +3,6 @@
 #define STB_IMAGE_IMPLEMENTATION
 #include <stb/stb_image.h>
 #include "ImageTextureLoader.h"
-#include <vulkan/vulkan.hpp>
 
 namespace liquid {
 
@@ -18,7 +17,7 @@ rhi::TextureHandle ImageTextureLoader::loadFromFile(const String &filename) {
       stbi_load(filename.c_str(), &width, &height, &channels, STBI_rgb_alpha);
   LIQUID_ASSERT(description.data, "Failed to load image: " + filename);
 
-  description.format = VK_FORMAT_R8G8B8A8_SRGB;
+  description.format = rhi::Format::Rgba8Srgb;
   description.width = width;
   description.height = height;
   description.usage = rhi::TextureUsage::Color |

--- a/engine/src/liquid/renderer/Presenter.cpp
+++ b/engine/src/liquid/renderer/Presenter.cpp
@@ -21,14 +21,14 @@ void Presenter::updateFramebuffers(const rhi::Swapchain &swapchain) {
   mExtent = swapchain.extent;
 
   rhi::RenderPassAttachmentDescription attachment{};
-  attachment.layout = VK_IMAGE_LAYOUT_PRESENT_SRC_KHR;
+  attachment.layout = rhi::ImageLayout::PresentSource;
   attachment.loadOp = rhi::AttachmentLoadOp::Clear;
   attachment.storeOp = rhi::AttachmentStoreOp::Store;
   attachment.texture = swapchain.textures.at(0);
   attachment.clearValue = rhi::AttachmentClearValue(glm::vec4{0.0f});
 
   rhi::RenderPassDescription renderPassDescription{};
-  renderPassDescription.bindPoint = VK_PIPELINE_BIND_POINT_GRAPHICS;
+  renderPassDescription.bindPoint = rhi::PipelineBindPoint::Graphics;
   renderPassDescription.attachments.push_back(attachment);
 
   if (mPresentPass != rhi::RenderPassHandle::Invalid) {
@@ -87,14 +87,14 @@ void Presenter::present(rhi::RenderCommandList &commandList,
 
   {
     rhi::ImageBarrier imageBarrier;
-    imageBarrier.srcLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
-    imageBarrier.dstLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
-    imageBarrier.srcAccess = VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT;
-    imageBarrier.dstAccess = VK_ACCESS_SHADER_READ_BIT;
+    imageBarrier.srcLayout = rhi::ImageLayout::ColorAttachmentOptimal;
+    imageBarrier.dstLayout = rhi::ImageLayout::ShaderReadOnlyOptimal;
+    imageBarrier.srcAccess = rhi::Access::ColorAttachmentWrite;
+    imageBarrier.dstAccess = rhi::Access::ShaderRead;
     imageBarrier.texture = handle;
 
-    commandList.pipelineBarrier(VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT,
-                                VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT, {},
+    commandList.pipelineBarrier(rhi::PipelineStage::ColorAttachmentOutput,
+                                rhi::PipelineStage::FragmentShader, {},
                                 {imageBarrier});
   }
 
@@ -117,15 +117,15 @@ void Presenter::present(rhi::RenderCommandList &commandList,
 
   {
     rhi::ImageBarrier imageBarrier;
-    imageBarrier.srcLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
-    imageBarrier.dstLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
+    imageBarrier.srcLayout = rhi::ImageLayout::ShaderReadOnlyOptimal;
+    imageBarrier.dstLayout = rhi::ImageLayout::ColorAttachmentOptimal;
     imageBarrier.texture = handle;
-    imageBarrier.srcAccess = VK_ACCESS_SHADER_READ_BIT;
-    imageBarrier.dstAccess = VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT;
+    imageBarrier.srcAccess = rhi::Access::ShaderRead;
+    imageBarrier.dstAccess = rhi::Access::ColorAttachmentWrite;
 
-    commandList.pipelineBarrier(VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT,
-                                VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT,
-                                {}, {imageBarrier});
+    commandList.pipelineBarrier(rhi::PipelineStage::FragmentShader,
+                                rhi::PipelineStage::ColorAttachmentOutput, {},
+                                {imageBarrier});
   }
 }
 

--- a/engine/src/liquid/renderer/SceneRenderer.cpp
+++ b/engine/src/liquid/renderer/SceneRenderer.cpp
@@ -64,7 +64,7 @@ SceneRenderPassData SceneRenderer::attach(rhi::RenderGraph &graph) {
   shadowMapDesc.width = ShadowMapDimensions;
   shadowMapDesc.height = ShadowMapDimensions;
   shadowMapDesc.layers = NumLights;
-  shadowMapDesc.format = VK_FORMAT_D16_UNORM;
+  shadowMapDesc.format = rhi::Format::Depth16Unorm;
   auto shadowmap = mDevice->createTexture(shadowMapDesc);
 
   rhi::TextureDescription sceneColorDesc{};
@@ -73,7 +73,7 @@ SceneRenderPassData SceneRenderer::attach(rhi::RenderGraph &graph) {
   sceneColorDesc.width = SwapchainSizePercentage;
   sceneColorDesc.height = SwapchainSizePercentage;
   sceneColorDesc.layers = 1;
-  sceneColorDesc.format = VK_FORMAT_B8G8R8A8_SRGB;
+  sceneColorDesc.format = rhi::Format::Bgra8Srgb;
   auto sceneColor = mDevice->createTexture(sceneColorDesc);
 
   rhi::TextureDescription depthBufferDesc{};
@@ -82,7 +82,7 @@ SceneRenderPassData SceneRenderer::attach(rhi::RenderGraph &graph) {
   depthBufferDesc.width = SwapchainSizePercentage;
   depthBufferDesc.height = SwapchainSizePercentage;
   depthBufferDesc.layers = 1;
-  depthBufferDesc.format = VK_FORMAT_D32_SFLOAT;
+  depthBufferDesc.format = rhi::Format::Depth32Float;
   auto depthBuffer = mDevice->createTexture(depthBufferDesc);
 
   {
@@ -125,7 +125,7 @@ SceneRenderPassData SceneRenderer::attach(rhi::RenderGraph &graph) {
              ++index) {
           glm::ivec4 pcIndex{index};
 
-          commandList.pushConstants(pipeline, VK_SHADER_STAGE_VERTEX_BIT, 0,
+          commandList.pushConstants(pipeline, rhi::ShaderStage::Vertex, 0,
                                     sizeof(glm::ivec4), &pcIndex);
           render(commandList, pipeline, false);
         }
@@ -140,7 +140,7 @@ SceneRenderPassData SceneRenderer::attach(rhi::RenderGraph &graph) {
              ++index) {
           glm::ivec4 pcIndex{index};
 
-          commandList.pushConstants(skinnedPipeline, VK_SHADER_STAGE_VERTEX_BIT,
+          commandList.pushConstants(skinnedPipeline, rhi::ShaderStage::Vertex,
                                     0, sizeof(glm::ivec4), &pcIndex);
           renderSkinned(commandList, skinnedPipeline, false);
           index++;
@@ -263,7 +263,7 @@ SceneRenderPassData SceneRenderer::attach(rhi::RenderGraph &graph) {
 
       commandList.bindVertexBuffer(cube.vertexBuffers.at(0).getHandle());
       commandList.bindIndexBuffer(cube.indexBuffers.at(0).getHandle(),
-                                  VK_INDEX_TYPE_UINT32);
+                                  rhi::IndexType::Uint32);
       commandList.drawIndexed(
           static_cast<uint32_t>(cube.geometries.at(0).indices.size()), 0, 0);
     });
@@ -393,7 +393,7 @@ void SceneRenderer::render(rhi::RenderCommandList &commandList,
       bool indexed = rhi::isHandleValid(mesh.indexBuffers.at(g).getHandle());
       if (indexed) {
         commandList.bindIndexBuffer(mesh.indexBuffers.at(g).getHandle(),
-                                    VK_INDEX_TYPE_UINT32);
+                                    rhi::IndexType::Uint32);
       }
 
       if (bindMaterialData) {
@@ -434,7 +434,7 @@ void SceneRenderer::renderSkinned(rhi::RenderCommandList &commandList,
       bool indexed = rhi::isHandleValid(mesh.indexBuffers.at(g).getHandle());
       if (indexed) {
         commandList.bindIndexBuffer(mesh.indexBuffers.at(g).getHandle(),
-                                    VK_INDEX_TYPE_UINT32);
+                                    rhi::IndexType::Uint32);
       }
 
       uint32_t indexCount =
@@ -485,7 +485,7 @@ void SceneRenderer::renderText(rhi::RenderCommandList &commandList,
       glm::uvec4 glyphStart{text.glyphStart};
 
       commandList.pushConstants(
-          pipeline, VK_SHADER_STAGE_VERTEX_BIT, 0, sizeof(glm::uvec4),
+          pipeline, rhi::ShaderStage::Vertex, 0, sizeof(glm::uvec4),
           static_cast<void *>(glm::value_ptr(glyphStart)));
 
       commandList.draw(QuadNumVertices * static_cast<uint32_t>(text.length), 0,

--- a/formats.txt
+++ b/formats.txt
@@ -1,0 +1,11 @@
+Undefined
+Rgba8Unorm
+Rgba8Srgb
+Bgra8Srgb
+Rgba16Float
+Rg32Float
+Rgb32Float
+Rgba32Float
+Rgba32Uint
+Depth16Unorm
+Depth32Float

--- a/scripts/generate-types.py
+++ b/scripts/generate-types.py
@@ -1,0 +1,84 @@
+from pathlib import Path
+import os
+import re
+
+FORMATS_PATH = Path(os.path.dirname(__file__), '..', 'formats.txt')
+FORMAT_PATTERN = '^([A-Za-z]+)(\d+)(\S+)$'
+
+formats = []
+
+with open(FORMATS_PATH, 'r', encoding = 'utf-8') as f:
+    contents = f.read()
+    lines = contents.splitlines()
+    for line in lines:
+        matches = re.search(FORMAT_PATTERN, line)
+        if matches is not None:
+            formats.append((line, matches.group(1), matches.group(2), matches.group(3)))
+
+def output_enum(formats):
+    ENUM_TEMPLATE = '''
+    enum Format {
+    Undefined = 0,
+    $enum_values
+    };'''
+    originals = [x[0] for x in formats]
+    enum_values = ',\n'.join(originals)
+    return ENUM_TEMPLATE.replace('$enum_values', enum_values)
+
+
+def output_vulkan_map(formats):
+    RHI_TO_VK_CASE_TEMPLATE = '''
+    case $original:
+        return $vulkan;'''
+    RHI_TO_VK_DEFAULT_TEMPLATE = '''
+    case rhi::Format::Undefined:
+    default:
+        LIQUID_ASSERT(false, "Undefined format");
+        return VK_FORMAT_UNDEFINED;'''
+
+    VK_TO_RHI_CASE_TEMPLATE = '''
+    case $vulkan:
+        return $original;'''
+    VK_TO_RHI_DEFAULT_TEMPLATE = '''
+    case VK_FORMAT_UNDEFINED:
+    default:
+        LIQUID_ASSERT(false, "Undefined format");
+        return rhi::Format::Undefined;
+    '''
+
+    TYPE_MAP = {
+        'Float': 'SFLOAT',
+    }        
+
+    rhi_to_vk = []
+    vk_to_rhi = []
+    for original, components, bits_per_component, data_type in formats:
+        if components == 'Depth':
+            vulkan_components = f'D{bits_per_component}'
+        else:
+            vulkan_components = ''.join([f'{x}{bits_per_component}' for x in components])
+
+        vulkan_type = TYPE_MAP.get(data_type) or data_type
+
+        rhi_format = f'rhi::Format::{original}'
+        vk_format = f'VK_FORMAT_{vulkan_components}_{vulkan_type}'.upper()
+
+        rhi_to_vk.append(RHI_TO_VK_CASE_TEMPLATE.replace('$original', rhi_format).replace('$vulkan', vk_format))
+        vk_to_rhi.append(VK_TO_RHI_CASE_TEMPLATE.replace('$original', rhi_format).replace('$vulkan', vk_format))
+
+    rhi_to_vk.append(RHI_TO_VK_DEFAULT_TEMPLATE)
+    vk_to_rhi.append(VK_TO_RHI_DEFAULT_TEMPLATE)
+
+    return (''.join(rhi_to_vk), ''.join(vk_to_rhi))
+
+
+
+rhi_to_vk, vk_to_rhi = output_vulkan_map(formats)
+print('VkFormat to RHI::Format')
+print(rhi_to_vk, '\n')
+print('RHI::Format to VkFormat')
+print(vk_to_rhi, '\n')
+
+enum_values = output_enum(formats)
+print('RHI::Format enum')
+print(enum_values, '\n')


### PR DESCRIPTION
- Create RHI type for pipeline stage
- Create RHI type for shader stage
- Create RHI type for pipeline bind point
- Create RHI type for access
- Create RHI type for index type
- Create RHI type for image layout
- Use the new types throughout the application
- Remove vulkan headers from non Vulkan related files