### PR TITLE
Add multiple frames in flight

### DIFF
--- a/editor/src/liquidator/core/EditorRenderer.h
+++ b/editor/src/liquidator/core/EditorRenderer.h
@@ -6,7 +6,7 @@
 #include "liquidator/editor-scene/EditorGrid.h"
 #include "liquidator/ui/IconRegistry.h"
 
-#include "EditorRendererStorage.h"
+#include "EditorRendererFrameData.h"
 
 namespace liquidator {
 
@@ -59,10 +59,11 @@ public:
    * @param camera Camera
    * @param editorGrid Editor grid
    * @param selectedEntity Selected entity
+   * @param frameIndex Frame index
    */
   void updateFrameData(liquid::EntityDatabase &entityDatabase,
                        liquid::Entity camera, const EditorGrid &editorGrid,
-                       liquid::Entity selectedEntity);
+                       liquid::Entity selectedEntity, uint32_t frameIndex);
 
 private:
   /**
@@ -71,7 +72,6 @@ private:
   void createCollidableShapes();
 
 private:
-  EditorRendererStorage mRenderStorage;
   liquid::rhi::RenderDevice *mDevice;
   liquid::ShaderLibrary mShaderLibrary;
   IconRegistry &mIconRegistry;
@@ -80,6 +80,9 @@ private:
   CollidableShapeDraw mCollidableCube;
   CollidableShapeDraw mCollidableSphere;
   CollidableShapeDraw mCollidableCapsule;
+
+  std::array<EditorRendererFrameData, liquid::rhi::RenderDevice::NumFrames>
+      mFrameData;
 };
 
 } // namespace liquidator

--- a/editor/src/liquidator/core/EditorRendererFrameData.h
+++ b/editor/src/liquidator/core/EditorRendererFrameData.h
@@ -12,9 +12,11 @@
 namespace liquidator {
 
 /**
- * @brief Storage for editor renderer
+ * @brief Frame data for editor renderer
+ *
+ * Store data for each frame
  */
-class EditorRendererStorage {
+class EditorRendererFrameData {
   /**
    * @brief Maximum number of debug bones
    */
@@ -50,13 +52,13 @@ class EditorRendererStorage {
 
 public:
   /**
-   * @brief Create render storage
+   * @brief Create frame data
    *
    * @param device Render device
    * @param reservedSpace Reserved space for buffer data
    */
-  EditorRendererStorage(liquid::rhi::RenderDevice *device,
-                        size_t reservedSpace = DefaultReservedSpace);
+  EditorRendererFrameData(liquid::rhi::RenderDevice *device,
+                          size_t reservedSpace = DefaultReservedSpace);
 
   /**
    * @brief Add skeleton

--- a/editor/src/liquidator/core/MousePickingGraph.h
+++ b/editor/src/liquidator/core/MousePickingGraph.h
@@ -4,7 +4,7 @@
 #include "liquid/rhi/RenderDevice.h"
 #include "liquid/rhi/RenderGraphEvaluator.h"
 #include "liquid/renderer/ShaderLibrary.h"
-#include "liquid/renderer/RenderStorage.h"
+#include "liquid/renderer/SceneRendererFrameData.h"
 #include "liquid/asset/AssetRegistry.h"
 
 #include "liquid/window/Window.h"
@@ -24,14 +24,14 @@ public:
    * @brief Create mouse picking graph
    *
    * @param shaderLibrary Shader library
-   * @param renderStorage Render storage
+   * @param frameData Scene renderer frame data
    * @param assetRegistry Asset registry
    * @param device Render device
    */
-  MousePickingGraph(liquid::ShaderLibrary &shaderLibrary,
-                    const liquid::RenderStorage &renderStorage,
-                    liquid::AssetRegistry &assetRegistry,
-                    liquid::rhi::RenderDevice *device);
+  MousePickingGraph(
+      liquid::ShaderLibrary &shaderLibrary,
+      const std::array<liquid::SceneRendererFrameData, 2> &frameData,
+      liquid::AssetRegistry &assetRegistry, liquid::rhi::RenderDevice *device);
 
   ~MousePickingGraph();
 
@@ -88,7 +88,8 @@ private:
 
   liquid::rhi::RenderGraph mRenderGraph;
   liquid::rhi::RenderGraphEvaluator mGraphEvaluator;
-  const liquid::RenderStorage &mRenderStorage;
+  const std::array<liquid::SceneRendererFrameData,
+                   liquid::rhi::RenderDevice::NumFrames> &mFrameData;
   liquid::AssetRegistry &mAssetRegistry;
 
   liquid::rhi::Buffer mEntitiesBuffer;

--- a/editor/src/liquidator/screens/EditorScreen.cpp
+++ b/editor/src/liquidator/screens/EditorScreen.cpp
@@ -133,7 +133,7 @@ void EditorScreen::start(const Project &project) {
   renderer.getSceneRenderer().attachText(graph, scenePassGroup);
 
   MousePickingGraph mousePicking(renderer.getShaderLibrary(),
-                                 renderer.getSceneRenderer().getRenderStorage(),
+                                 renderer.getSceneRenderer().getFrameData(),
                                  assetManager.getRegistry(), mDevice);
 
   mousePicking.setFramebufferSize(mWindow);
@@ -282,11 +282,12 @@ void EditorScreen::start(const Project &project) {
     if (renderFrame.frameIndex < std::numeric_limits<uint32_t>::max()) {
       imgui.updateFrameData(renderFrame.frameIndex);
       sceneRenderer.updateFrameData(entityManager.getActiveEntityDatabase(),
-                                    camera);
+                                    camera, renderFrame.frameIndex);
       editorRenderer.updateFrameData(
           entityManager.getActiveEntityDatabase(), camera,
           editorManager.getEditorGrid(),
-          ui.getSceneHierarchyPanel().getSelectedEntity());
+          ui.getSceneHierarchyPanel().getSelectedEntity(),
+          renderFrame.frameIndex);
 
       if (mousePicking.isSelectionPerformedInFrame(renderFrame.frameIndex)) {
         auto entity = mousePicking.getSelectedEntity();
@@ -295,9 +296,8 @@ void EditorScreen::start(const Project &project) {
 
       mousePicking.compile();
 
-      renderer.render(graph, renderFrame.commandList);
+      renderer.render(graph, renderFrame.commandList, renderFrame.frameIndex);
 
-      bool mousePicked = false;
       if (mouseClicked) {
         auto mousePos = mWindow.getCurrentMousePosition();
 
@@ -323,6 +323,8 @@ void EditorScreen::start(const Project &project) {
 
   mainLoop.run();
   editorManager.saveEditorState(statePath);
+
+  mDevice->waitForIdle();
 }
 
 } // namespace liquidator

--- a/editor/src/liquidator/screens/ProjectSelectorScreen.cpp
+++ b/editor/src/liquidator/screens/ProjectSelectorScreen.cpp
@@ -117,7 +117,7 @@ std::optional<Project> ProjectSelectorScreen::start() {
 
     if (renderFrame.frameIndex < std::numeric_limits<uint32_t>::max()) {
       imgui.updateFrameData(renderFrame.frameIndex);
-      renderer.render(graph, renderFrame.commandList);
+      renderer.render(graph, renderFrame.commandList, renderFrame.frameIndex);
 
       presenter.present(renderFrame.commandList, imguiPassData.imguiColor,
                         renderFrame.swapchainImageIndex);

--- a/editor/src/main.cpp
+++ b/editor/src/main.cpp
@@ -26,7 +26,6 @@ int main() {
   if (project.has_value()) {
     liquidator::EditorScreen editor(window, eventSystem, device);
     editor.start(project.value());
-    device->waitForIdle();
   }
 
   return 0;

--- a/engine/rhi/core/include/liquid/rhi/Buffer.h
+++ b/engine/rhi/core/include/liquid/rhi/Buffer.h
@@ -39,12 +39,13 @@ public:
   /**
    * @brief Update buffer
    *
-   * Maps the buffer, copies data to it,
+   * Maps the buffer, copies data into it,
    * and unmaps it
    *
    * @param data New data
+   * @param size Size to copy
    */
-  void update(void *data);
+  void update(const void *data, size_t size);
 
   /**
    * @brief Resize buffer
@@ -66,7 +67,7 @@ public:
 
 private:
   BufferHandle mHandle = BufferHandle::Invalid;
-  NativeBuffer *mNativeBuffer;
+  NativeBuffer *mNativeBuffer = nullptr;
 };
 
 } // namespace liquid::rhi

--- a/engine/rhi/core/include/liquid/rhi/NativeBuffer.h
+++ b/engine/rhi/core/include/liquid/rhi/NativeBuffer.h
@@ -25,16 +25,6 @@ public:
   virtual void unmap() = 0;
 
   /**
-   * @brief Update buffer
-   *
-   * Maps the buffer, copies data to it,
-   * and unmaps it
-   *
-   * @param data New data
-   */
-  virtual void update(void *data) = 0;
-
-  /**
    * @brief Resize buffer
    *
    * Recreates the buffer with

--- a/engine/rhi/core/include/liquid/rhi/RenderDevice.h
+++ b/engine/rhi/core/include/liquid/rhi/RenderDevice.h
@@ -21,6 +21,12 @@ namespace liquid::rhi {
  */
 class RenderDevice {
 public:
+  /**
+   * @brief Number of frames
+   */
+  static constexpr size_t NumFrames = 2;
+
+public:
   RenderDevice(const RenderDevice &) = delete;
   RenderDevice &operator=(const RenderDevice &) = delete;
   RenderDevice(RenderDevice &&) = delete;

--- a/engine/rhi/core/include/liquid/rhi/RenderGraphEvaluator.h
+++ b/engine/rhi/core/include/liquid/rhi/RenderGraphEvaluator.h
@@ -40,8 +40,10 @@ public:
    *
    * @param commandList Command list
    * @param graph Render graph
+   * @param frameIndex Frame index
    */
-  void execute(RenderCommandList &commandList, RenderGraph &graph);
+  void execute(RenderCommandList &commandList, RenderGraph &graph,
+               uint32_t frameIndex);
 
 private:
   /**

--- a/engine/rhi/core/include/liquid/rhi/RenderGraphPass.h
+++ b/engine/rhi/core/include/liquid/rhi/RenderGraphPass.h
@@ -86,8 +86,8 @@ struct RenderGraphPassBarrier {
  * @brief Render graph pass
  */
 class RenderGraphPass {
-  using ExecutorFn =
-      std::function<void(RenderCommandList &, const RenderGraphRegistry &)>;
+  using ExecutorFn = std::function<void(RenderCommandList &,
+                                        const RenderGraphRegistry &, uint32_t)>;
   friend RenderGraph;
   friend RenderGraphEvaluator;
 
@@ -138,8 +138,9 @@ public:
    * @brief Execute pass
    *
    * @param commandList Command list
+   * @param frameIndex Frame index
    */
-  void execute(RenderCommandList &commandList);
+  void execute(RenderCommandList &commandList, uint32_t frameIndex);
 
   /**
    * @brief Set output texture

--- a/engine/rhi/core/src/Buffer.cpp
+++ b/engine/rhi/core/src/Buffer.cpp
@@ -12,7 +12,11 @@ void *Buffer::map() { return mNativeBuffer->map(); }
 
 void Buffer::unmap() { mNativeBuffer->unmap(); }
 
-void Buffer::update(void *data) { mNativeBuffer->update(data); }
+void Buffer::update(const void *data, size_t size) {
+  auto *mappedData = map();
+  memcpy(mappedData, data, size);
+  unmap();
+}
 
 void Buffer::resize(size_t size) { mNativeBuffer->resize(size); }
 

--- a/engine/rhi/core/src/RenderGraphEvaluator.cpp
+++ b/engine/rhi/core/src/RenderGraphEvaluator.cpp
@@ -24,7 +24,7 @@ void RenderGraphEvaluator::build(RenderGraph &graph) {
 }
 
 void RenderGraphEvaluator::execute(RenderCommandList &commandList,
-                                   RenderGraph &graph) {
+                                   RenderGraph &graph, uint32_t frameIndex) {
   LIQUID_PROFILE_EVENT("RenderGraphEvaluator::execute");
 
   for (auto &pass : graph.getCompiledPasses()) {
@@ -39,7 +39,7 @@ void RenderGraphEvaluator::execute(RenderCommandList &commandList,
     commandList.setViewport({0.0f, 0.0f}, glm::uvec2(pass.getDimensions()),
                             {0.0f, 1.0f});
     commandList.setScissor({0.0f, 0.0f}, glm::uvec2(pass.getDimensions()));
-    pass.execute(commandList);
+    pass.execute(commandList, frameIndex);
     commandList.endRenderPass();
 
     if (pass.mPostBarrier.enabled) {

--- a/engine/rhi/core/src/RenderGraphPass.cpp
+++ b/engine/rhi/core/src/RenderGraphPass.cpp
@@ -24,8 +24,9 @@ RenderGraphPass::addPipeline(const PipelineDescription &description) {
   return mRegistry.set(description);
 }
 
-void RenderGraphPass::execute(RenderCommandList &commandList) {
-  mExecutor(commandList, mRegistry);
+void RenderGraphPass::execute(RenderCommandList &commandList,
+                              uint32_t frameIndex) {
+  mExecutor(commandList, mRegistry, frameIndex);
 }
 
 } // namespace liquid::rhi

--- a/engine/rhi/vulkan/include/liquid/rhi-vulkan/VulkanBuffer.h
+++ b/engine/rhi/vulkan/include/liquid/rhi-vulkan/VulkanBuffer.h
@@ -45,16 +45,6 @@ public:
   void unmap();
 
   /**
-   * @brief Update buffer
-   *
-   * Maps the buffer, copies data to it,
-   * and unmaps it
-   *
-   * @param data New data
-   */
-  void update(void *data);
-
-  /**
    * @brief Resize buffer
    *
    * Recreates the buffer with
@@ -109,6 +99,7 @@ private:
   rhi::BufferType mType;
   rhi::BufferUsage mUsage;
   size_t mSize = 0;
+  void *mMappedData = nullptr;
 };
 
 } // namespace liquid::rhi

--- a/engine/rhi/vulkan/include/liquid/rhi-vulkan/VulkanFrameManager.h
+++ b/engine/rhi/vulkan/include/liquid/rhi-vulkan/VulkanFrameManager.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "liquid/rhi/RenderDevice.h"
 #include "VulkanDeviceObject.h"
 
 namespace liquid::rhi {
@@ -12,12 +13,6 @@ namespace liquid::rhi {
  * the frame
  */
 class VulkanFrameManager {
-public:
-  /**
-   * @brief Number of frames
-   */
-  static constexpr uint32_t NUM_FRAMES = 2;
-
 public:
   /**
    * @brief Create frame manager
@@ -92,9 +87,9 @@ private:
 private:
   VulkanDeviceObject &mDevice;
 
-  std::array<VkFence, NUM_FRAMES> mFrameFences{};
-  std::array<VkSemaphore, NUM_FRAMES> mImageAvailableSemaphores{};
-  std::array<VkSemaphore, NUM_FRAMES> mRenderFinishedSemaphores{};
+  std::array<VkFence, RenderDevice::NumFrames> mFrameFences{};
+  std::array<VkSemaphore, RenderDevice::NumFrames> mImageAvailableSemaphores{};
+  std::array<VkSemaphore, RenderDevice::NumFrames> mRenderFinishedSemaphores{};
 
   uint32_t mFrameIndex = 0;
 };

--- a/engine/rhi/vulkan/src/VulkanBuffer.cpp
+++ b/engine/rhi/vulkan/src/VulkanBuffer.cpp
@@ -29,12 +29,6 @@ void VulkanBuffer::resize(size_t size) {
   createBuffer({mType, mSize, nullptr, mUsage});
 }
 
-void VulkanBuffer::update(void *data) {
-  void *mappedData = map();
-  memcpy(mappedData, data, mSize);
-  unmap();
-}
-
 void VulkanBuffer::createBuffer(const BufferDescription &description) {
   mSize = description.size;
   mType = description.type;

--- a/engine/rhi/vulkan/src/VulkanCommandBuffer.cpp
+++ b/engine/rhi/vulkan/src/VulkanCommandBuffer.cpp
@@ -20,7 +20,6 @@ void VulkanCommandBuffer::beginRenderPass(rhi::RenderPassHandle renderPass,
                                           FramebufferHandle framebuffer,
                                           const glm::ivec2 &renderAreaOffset,
                                           const glm::uvec2 &renderAreaSize) {
-
   const auto &vulkanRenderPass = mRegistry.getRenderPasses().at(renderPass);
 
   VkRenderPassBeginInfo beginInfo{};

--- a/engine/rhi/vulkan/src/VulkanCommandPool.cpp
+++ b/engine/rhi/vulkan/src/VulkanCommandPool.cpp
@@ -49,7 +49,6 @@ VulkanCommandPool::createCommandLists(uint32_t count) {
       "Failed to allocate command buffers");
 
   for (size_t i = 0; i < count; ++i) {
-
     renderCommandLists.at(i) =
         std::move(RenderCommandList(new VulkanCommandBuffer(
             commandBuffers.at(i), mRegistry, mDescriptorManager, mStats)));

--- a/engine/rhi/vulkan/src/VulkanFrameManager.cpp
+++ b/engine/rhi/vulkan/src/VulkanFrameManager.cpp
@@ -13,7 +13,7 @@ VulkanFrameManager::VulkanFrameManager(VulkanDeviceObject &device)
 }
 
 VulkanFrameManager::~VulkanFrameManager() {
-  for (uint32_t i = 0; i < NUM_FRAMES; ++i) {
+  for (uint32_t i = 0; i < RenderDevice::NumFrames; ++i) {
     if (mFrameFences.at(i)) {
       vkDestroyFence(mDevice, mFrameFences.at(i), nullptr);
       mFrameFences.at(i) = VK_NULL_HANDLE;
@@ -21,7 +21,7 @@ VulkanFrameManager::~VulkanFrameManager() {
   }
   LOG_DEBUG("[Vulkan] Frame fences destroyed");
 
-  for (uint32_t i = 0; i < NUM_FRAMES; ++i) {
+  for (uint32_t i = 0; i < RenderDevice::NumFrames; ++i) {
     if (mImageAvailableSemaphores.at(i)) {
       vkDestroySemaphore(mDevice, mImageAvailableSemaphores.at(i), nullptr);
       mImageAvailableSemaphores.at(i) = VK_NULL_HANDLE;
@@ -36,7 +36,7 @@ VulkanFrameManager::~VulkanFrameManager() {
 }
 
 void VulkanFrameManager::nextFrame() {
-  mFrameIndex = (mFrameIndex + 1) % NUM_FRAMES;
+  mFrameIndex = (mFrameIndex + 1) % RenderDevice::NumFrames;
 }
 
 void VulkanFrameManager::waitForFrame() {
@@ -51,7 +51,7 @@ void VulkanFrameManager::createSemaphores() {
   semaphoreInfo.pNext = nullptr;
   semaphoreInfo.flags = 0;
 
-  for (uint32_t i = 0; i < NUM_FRAMES; ++i) {
+  for (uint32_t i = 0; i < RenderDevice::NumFrames; ++i) {
     checkForVulkanError(vkCreateSemaphore(mDevice, &semaphoreInfo, nullptr,
                                           &mImageAvailableSemaphores.at(i)),
                         "Failed to create image available semaphore");
@@ -70,7 +70,7 @@ void VulkanFrameManager::createFences() {
   fenceInfo.pNext = nullptr;
   fenceInfo.flags = VK_FENCE_CREATE_SIGNALED_BIT;
 
-  for (uint32_t i = 0; i < NUM_FRAMES; ++i) {
+  for (uint32_t i = 0; i < RenderDevice::NumFrames; ++i) {
     checkForVulkanError(
         vkCreateFence(mDevice, &fenceInfo, nullptr, &mFrameFences.at(i)),
         "Failed to create render fence");

--- a/engine/rhi/vulkan/src/VulkanRenderContext.cpp
+++ b/engine/rhi/vulkan/src/VulkanRenderContext.cpp
@@ -15,7 +15,7 @@ VulkanRenderContext::VulkanRenderContext(VulkanDeviceObject &device,
       mPresentQueue(presentQueue) {
 
   mRenderCommandLists =
-      std::move(pool.createCommandLists(VulkanFrameManager::NUM_FRAMES));
+      std::move(pool.createCommandLists(RenderDevice::NumFrames));
 }
 
 VkResult VulkanRenderContext::present(VulkanFrameManager &frameManager,

--- a/engine/src/liquid/imgui/ImguiRenderer.h
+++ b/engine/src/liquid/imgui/ImguiRenderer.h
@@ -67,8 +67,6 @@ class ImguiRenderer {
 
   static constexpr const glm::vec4 DefaultClearColor{0.0f, 0.0f, 0.0f, 1.0f};
 
-  static constexpr size_t FramesInFlight = 2;
-
 public:
   /**
    * @brief Create imgui renderer
@@ -134,8 +132,10 @@ public:
    *
    * @param commandList Command list
    * @param pipeline Pipeline
+   * @param frameIndex Frame index
    */
-  void draw(rhi::RenderCommandList &commandList, rhi::PipelineHandle pipeline);
+  void draw(rhi::RenderCommandList &commandList, rhi::PipelineHandle pipeline,
+            uint32_t frameIndex);
 
   /**
    * @brief Use config path for saving settings
@@ -153,16 +153,16 @@ private:
    * @param fbWidth Framebuffer width
    * @param fbHeight Framebuffer height
    * @param pipeline Pipeline
+   * @param frameIndex Frame index
    */
   void setupRenderStates(ImDrawData *data, rhi::RenderCommandList &commandList,
                          int fbWidth, int fbHeight,
-                         rhi::PipelineHandle pipeline);
+                         rhi::PipelineHandle pipeline, uint32_t frameIndex);
 
 private:
   ShaderLibrary &mShaderLibrary;
   rhi::TextureHandle mFontTexture = rhi::TextureHandle::Invalid;
-  std::array<FrameData, FramesInFlight> mFrameData;
-  uint32_t mCurrentFrame = 0;
+  std::array<FrameData, rhi::RenderDevice::NumFrames> mFrameData;
 
   glm::vec4 mClearColor{DefaultClearColor};
 

--- a/engine/src/liquid/renderer/Material.cpp
+++ b/engine/src/liquid/renderer/Material.cpp
@@ -44,8 +44,8 @@ void Material::updateProperty(StringView name, const Property &value) {
   }
 
   mProperties.at(index) = value;
-  updateBufferData();
-  mBuffer.update(mData);
+  auto size = updateBufferData();
+  mBuffer.update(mData, size);
 }
 
 size_t Material::updateBufferData() {

--- a/engine/src/liquid/renderer/Renderer.cpp
+++ b/engine/src/liquid/renderer/Renderer.cpp
@@ -20,12 +20,13 @@ Renderer::Renderer(AssetRegistry &assetRegistry, Window &window,
       mSceneRenderer(mShaderLibrary, mAssetRegistry, device) {}
 
 void Renderer::render(rhi::RenderGraph &graph,
-                      rhi::RenderCommandList &commandList) {
+                      rhi::RenderCommandList &commandList,
+                      uint32_t frameIndex) {
   graph.compile(mDevice);
 
   mGraphEvaluator.build(graph);
 
-  mGraphEvaluator.execute(commandList, graph);
+  mGraphEvaluator.execute(commandList, graph, frameIndex);
 }
 
 } // namespace liquid

--- a/engine/src/liquid/renderer/Renderer.h
+++ b/engine/src/liquid/renderer/Renderer.h
@@ -5,7 +5,6 @@
 #include "ShaderLibrary.h"
 #include "MaterialPBR.h"
 #include "SceneRenderer.h"
-#include "RenderStorage.h"
 #include "liquid/imgui/ImguiRenderer.h"
 #include "liquid/entity/EntityDatabase.h"
 #include "liquid/asset/AssetRegistry.h"
@@ -95,8 +94,10 @@ public:
    *
    * @param graph Render graph
    * @param commandList Render command list
+   * @param frameIndex Frame index
    */
-  void render(rhi::RenderGraph &graph, rhi::RenderCommandList &commandList);
+  void render(rhi::RenderGraph &graph, rhi::RenderCommandList &commandList,
+              uint32_t frameIndex);
 
   /**
    * @brief Wait for device

--- a/engine/src/liquid/renderer/SceneRenderer.h
+++ b/engine/src/liquid/renderer/SceneRenderer.h
@@ -3,7 +3,7 @@
 #include "liquid/rhi/RenderCommandList.h"
 #include "liquid/rhi/RenderGraph.h"
 #include "liquid/asset/AssetRegistry.h"
-#include "RenderStorage.h"
+#include "SceneRendererFrameData.h"
 #include "ShaderLibrary.h"
 
 namespace liquid {
@@ -68,16 +68,18 @@ public:
    *
    * @param entityDatabase Entity database
    * @param camera Camera entity
+   * @param frameIndex Frame index
    */
-  void updateFrameData(EntityDatabase &entityDatabase, Entity camera);
+  void updateFrameData(EntityDatabase &entityDatabase, Entity camera,
+                       uint32_t frameIndex);
 
   /**
-   * @brief Get render storage
+   * @brief Get frame data
    *
-   * @return Render storage
+   * @return Scene renderer frame data
    */
-  inline const RenderStorage &getRenderStorage() const {
-    return mRenderStorage;
+  inline const std::array<SceneRendererFrameData, 2> &getFrameData() const {
+    return mFrameData;
   }
 
 private:
@@ -87,9 +89,10 @@ private:
    * @param commandList Command list
    * @param pipeline Pipeline handle
    * @param bindMaterialData Bind material data
+   * @param frameIndex Frame index
    */
   void render(rhi::RenderCommandList &commandList, rhi::PipelineHandle pipeline,
-              bool bindMaterialData = false);
+              bool bindMaterialData, uint32_t frameIndex);
 
   /**
    * @brief Render skinned meshes
@@ -97,26 +100,28 @@ private:
    * @param commandList Command list
    * @param pipeline Pipeline handle
    * @param bindMaterialData Bind material data
+   * @param frameIndex Frame index
    */
   void renderSkinned(rhi::RenderCommandList &commandList,
-                     rhi::PipelineHandle pipeline,
-                     bool bindMaterialData = true);
+                     rhi::PipelineHandle pipeline, bool bindMaterialData,
+                     uint32_t frameIndex);
 
   /**
    * @brief Render texts
    *
    * @param commandList Command list
    * @param pipeline Pipeline handle
+   * @param frameIndex Frame index
    */
   void renderText(rhi::RenderCommandList &commandList,
-                  rhi::PipelineHandle pipeline);
+                  rhi::PipelineHandle pipeline, uint32_t frameIndex);
 
 private:
   glm::vec4 mClearColor{DefaultClearColor};
   ShaderLibrary &mShaderLibrary;
-  RenderStorage mRenderStorage;
   AssetRegistry &mAssetRegistry;
   rhi::RenderDevice *mDevice;
+  std::array<SceneRendererFrameData, rhi::RenderDevice::NumFrames> mFrameData;
 };
 
 } // namespace liquid

--- a/engine/src/liquid/renderer/SceneRendererFrameData.h
+++ b/engine/src/liquid/renderer/SceneRendererFrameData.h
@@ -9,12 +9,12 @@
 namespace liquid {
 
 /**
- * @brief Render storage
+ * @brief Scene renderer frame data
  *
  * Stores everything necessary to
- * render the scene
+ * render a frame
  */
-class RenderStorage {
+class SceneRendererFrameData {
 public:
   /**
    * Default reserved space for buffers
@@ -121,13 +121,13 @@ public:
 
 public:
   /**
-   * @brief Create render storage
+   * @brief Create frame data
    *
    * @param device Render device
    * @param reservedSpace Reserved space for buffer data
    */
-  RenderStorage(rhi::RenderDevice *device,
-                size_t reservedSpace = DefaultReservedSpace);
+  SceneRendererFrameData(rhi::RenderDevice *device,
+                         size_t reservedSpace = DefaultReservedSpace);
 
   /**
    * @brief Update storage buffers

--- a/runtime/src/runtime/Runtime.cpp
+++ b/runtime/src/runtime/Runtime.cpp
@@ -97,10 +97,10 @@ void Runtime::start() {
     const auto &renderFrame = device->beginFrame();
 
     if (renderFrame.frameIndex < std::numeric_limits<uint32_t>::max()) {
-      renderer.getSceneRenderer().updateFrameData(scene.entityDatabase,
-                                                  scene.activeCamera);
+      renderer.getSceneRenderer().updateFrameData(
+          scene.entityDatabase, scene.activeCamera, renderFrame.frameIndex);
 
-      renderer.render(graph, renderFrame.commandList);
+      renderer.render(graph, renderFrame.commandList, renderFrame.frameIndex);
 
       presenter.present(renderFrame.commandList, passData.sceneColor,
                         renderFrame.swapchainImageIndex);


### PR DESCRIPTION
- Pass frame index to render graph executor
- Store frame data for two frames in scene renderer
- Store frame data for two frames in editor renderer
- Store frame data for two frames in mouse picking graph
- Fix imgui cleanup for editor screen
- Remove native buffer update function
- Add size argument to buffer update function
- Update only the available data from frame data buffers
- Rename render storage to frame data