### PR TITLE
Keep frame data buffers always mapped

### DIFF
--- a/editor/src/liquidator/core/EditorRendererFrameData.cpp
+++ b/editor/src/liquidator/core/EditorRendererFrameData.cpp
@@ -11,28 +11,45 @@ EditorRendererFrameData::EditorRendererFrameData(
   mGizmoTransforms.reserve(reservedSpace);
   mSkeletonVector.reset(new glm::mat4[mReservedSpace * MaxNumBones]);
 
-  mCameraBuffer = mDevice->createBuffer(
-      {liquid::rhi::BufferType::Uniform, sizeof(liquid::CameraComponent)});
+  liquid::rhi::BufferDescription defaultDesc{};
+  defaultDesc.type = liquid::rhi::BufferType::Storage;
+  defaultDesc.size = mReservedSpace * sizeof(glm::mat4);
+  defaultDesc.mapped = true;
 
-  mEditorGridBuffer = mDevice->createBuffer(
-      {liquid::rhi::BufferType::Uniform, sizeof(EditorGridData)});
+  mSkeletonTransformsBuffer = mDevice->createBuffer(defaultDesc);
 
-  mSkeletonTransformsBuffer = mDevice->createBuffer({
-      liquid::rhi::BufferType::Storage,
-      mReservedSpace * sizeof(glm::mat4),
-  });
+  {
+    auto desc = defaultDesc;
+    desc.type = liquid::rhi::BufferType::Uniform;
+    desc.size = sizeof(liquid::CameraComponent);
+    mCameraBuffer = mDevice->createBuffer(desc);
+  }
 
-  mSkeletonBoneTransformsBuffer = mDevice->createBuffer({
-      liquid::rhi::BufferType::Storage,
-      mReservedSpace * MaxNumBones * sizeof(glm::mat4),
-  });
+  {
+    auto desc = defaultDesc;
+    desc.type = liquid::rhi::BufferType::Uniform;
+    desc.size = sizeof(EditorGridData);
+    mEditorGridBuffer = mDevice->createBuffer(desc);
+  }
 
-  mGizmoTransformsBuffer = mDevice->createBuffer(
-      {liquid::rhi::BufferType::Storage, sizeof(glm::mat4) * mReservedSpace,
-       mGizmoTransforms.data()});
+  {
+    auto desc = defaultDesc;
+    desc.size = mReservedSpace * MaxNumBones * sizeof(glm::mat4);
+    mSkeletonBoneTransformsBuffer = mDevice->createBuffer(desc);
+  }
 
-  mCollidableEntityBuffer = mDevice->createBuffer(
-      {liquid::rhi::BufferType::Uniform, sizeof(CollidableEntity)});
+  {
+    auto desc = defaultDesc;
+    desc.data = mGizmoTransforms.data();
+    mGizmoTransformsBuffer = mDevice->createBuffer(desc);
+  }
+
+  {
+    auto desc = defaultDesc;
+    desc.size = sizeof(CollidableEntity);
+    desc.type = liquid::rhi::BufferType::Uniform;
+    mCollidableEntityBuffer = mDevice->createBuffer(desc);
+  }
 }
 
 void EditorRendererFrameData::addSkeleton(

--- a/editor/src/liquidator/core/MousePickingGraph.cpp
+++ b/editor/src/liquidator/core/MousePickingGraph.cpp
@@ -36,19 +36,19 @@ MousePickingGraph::MousePickingGraph(
       {liquid::rhi::BufferType::Storage, sizeof(liquid::Entity), &nullEntity,
        liquid::rhi::BufferUsage::HostRead});
 
-  mEntitiesBuffer = device->createBuffer(
-      {liquid::rhi::BufferType::Storage,
-       sizeof(liquid::Entity) * mFrameData.at(0).getReservedSpace()});
+  liquid::rhi::BufferDescription defaultDesc{};
+  defaultDesc.type = liquid::rhi::BufferType::Storage;
+  defaultDesc.size =
+      sizeof(liquid::Entity) * mFrameData.at(0).getReservedSpace();
+  defaultDesc.mapped = true;
 
-  mSkinnedEntitiesBuffer = device->createBuffer(
-      {liquid::rhi::BufferType::Storage,
-       sizeof(liquid::Entity) * mFrameData.at(0).getReservedSpace()});
+  mEntitiesBuffer = device->createBuffer(defaultDesc);
+  mSkinnedEntitiesBuffer = device->createBuffer(defaultDesc);
 
   auto &pass = mRenderGraph.addPass("MousePicking");
   pass.write(depthBuffer, liquid::rhi::DepthStencilClear({1.0f, 0}));
 
   // Normal meshes
-
   auto vPipeline = pass.addPipeline(liquid::rhi::PipelineDescription{
       shaderLibrary.getShader("mouse-picking.default.vertex"),
       shaderLibrary.getShader("mouse-picking.selector.fragment"),

--- a/editor/src/liquidator/editor-scene/EditorCamera.cpp
+++ b/editor/src/liquidator/editor-scene/EditorCamera.cpp
@@ -3,14 +3,13 @@
 
 #include <GLFW/glfw3.h>
 
-using liquid::Renderer;
 using liquid::Window;
 
 namespace liquidator {
 
 EditorCamera::EditorCamera(liquid::EntityDatabase &entityDatabase,
                            liquid::EventSystem &eventSystem,
-                           liquid::Renderer &renderer, liquid::Window &window)
+                           liquid::Window &window)
     : mEntityDatabase(entityDatabase), mEventSystem(eventSystem),
       mWindow(window) {
 

--- a/editor/src/liquidator/editor-scene/EditorCamera.h
+++ b/editor/src/liquidator/editor-scene/EditorCamera.h
@@ -62,12 +62,10 @@ public:
    *
    * @param entityDatabase Entity database
    * @param eventSystem Event system
-   * @param renderer Renderer
    * @param window Window
    */
   EditorCamera(liquid::EntityDatabase &entityDatabase,
-               liquid::EventSystem &eventSystem, liquid::Renderer &renderer,
-               liquid::Window &window);
+               liquid::EventSystem &eventSystem, liquid::Window &window);
 
   EditorCamera(const EditorCamera &) = delete;
   EditorCamera &operator=(const EditorCamera &) = delete;

--- a/editor/src/liquidator/screens/EditorScreen.cpp
+++ b/editor/src/liquidator/screens/EditorScreen.cpp
@@ -95,7 +95,7 @@ void EditorScreen::start(const Project &project) {
   liquidator::EntityManager entityManager(assetManager, renderer,
                                           project.scenesPath);
   liquidator::EditorCamera editorCamera(entityManager.getActiveEntityDatabase(),
-                                        mEventSystem, renderer, mWindow);
+                                        mEventSystem, mWindow);
   liquidator::EditorGrid editorGrid;
   liquidator::EditorManager editorManager(editorCamera, editorGrid,
                                           entityManager, project);

--- a/engine/rhi/core/include/liquid/rhi/BufferDescription.h
+++ b/engine/rhi/core/include/liquid/rhi/BufferDescription.h
@@ -17,13 +17,7 @@ enum class BufferUsage : uint8_t {
   HostRead = 1 << 1
 };
 
-constexpr inline BufferUsage operator|(BufferUsage a, BufferUsage b) {
-  return BufferUsage(static_cast<uint8_t>(a) | static_cast<uint8_t>(b));
-}
-
-constexpr inline BufferUsage operator&(BufferUsage a, BufferUsage b) {
-  return BufferUsage(static_cast<uint8_t>(a) & static_cast<uint8_t>(b));
-}
+EnableBitwiseEnum(BufferUsage);
 
 /**
  * @brief Buffer description
@@ -48,6 +42,11 @@ struct BufferDescription {
    * @brief Buffer usage
    */
   BufferUsage usage = rhi::BufferUsage::HostWrite;
+
+  /**
+   * @brief Keep buffer always mapped
+   */
+  bool mapped = false;
 };
 
 } // namespace liquid::rhi

--- a/engine/rhi/vulkan/include/liquid/rhi-vulkan/VulkanBuffer.h
+++ b/engine/rhi/vulkan/include/liquid/rhi-vulkan/VulkanBuffer.h
@@ -98,6 +98,7 @@ private:
   VmaAllocation mAllocation = VK_NULL_HANDLE;
   rhi::BufferType mType;
   rhi::BufferUsage mUsage;
+  bool mMapped = false;
   size_t mSize = 0;
   void *mMappedData = nullptr;
 };

--- a/engine/src/liquid/imgui/ImguiRenderer.cpp
+++ b/engine/src/liquid/imgui/ImguiRenderer.cpp
@@ -44,9 +44,17 @@ ImguiRenderer::ImguiRenderer(Window &window, ShaderLibrary &shaderLibrary,
       mDevice->createShader({Engine::getShadersPath() / "imgui.frag.spv"}));
 
   for (auto &x : mFrameData) {
-    x.vertexBuffer =
-        mDevice->createBuffer({liquid::rhi::BufferType::Vertex, 1});
-    x.indexBuffer = mDevice->createBuffer({liquid::rhi::BufferType::Index, 1});
+    liquid::rhi::BufferDescription vertexDesc{};
+    vertexDesc.type = liquid::rhi::BufferType::Vertex;
+    vertexDesc.size = 1;
+    vertexDesc.mapped = true;
+    x.vertexBuffer = mDevice->createBuffer(vertexDesc);
+
+    liquid::rhi::BufferDescription indexDesc{};
+    indexDesc.type = liquid::rhi::BufferType::Index;
+    indexDesc.size = 1;
+    indexDesc.mapped = true;
+    x.indexBuffer = mDevice->createBuffer(indexDesc);
   }
 }
 

--- a/engine/src/liquid/profiler/ImguiDebugLayer.cpp
+++ b/engine/src/liquid/profiler/ImguiDebugLayer.cpp
@@ -58,28 +58,47 @@ void ImguiDebugLayer::renderUsageMetrics() {
   ImGui::Begin("Usage Metrics", &mUsageMetricsVisible,
                ImGuiWindowFlags_NoDocking);
 
+  static const std::array<String, 3> Units{"bytes", "Kb", "Mb"};
+  static constexpr float Kilo = 1024.0f;
+
+  auto getSizeString = [](size_t size) {
+    if (size < static_cast<size_t>(Kilo)) {
+      return std::to_string(size) + " " + Units.at(0);
+    }
+    float humanReadableSize = static_cast<float>(size);
+
+    size_t i = 1;
+    for (; i < Units.size() && humanReadableSize >= Kilo; ++i) {
+      humanReadableSize /= Kilo;
+    }
+
+    std::stringstream ss;
+    ss << std::fixed << std::setprecision(2) << humanReadableSize << " "
+       << Units.at(i - 1) << " (" << size << " " << Units.at(0) << ")";
+    return ss.str();
+  };
+
   if (ImGui::BeginTable("Table", 2,
                         ImGuiTableFlags_Borders |
                             ImGuiTableColumnFlags_WidthStretch |
                             ImGuiTableFlags_RowBg)) {
 
+    // Buffers
     renderTableRow(
         "Number of buffers",
         std::to_string(mDeviceStats.getResourceMetrics()->getBuffersCount()));
 
     renderTableRow(
         "Total size of allocated buffers",
-        std::to_string(
-            mDeviceStats.getResourceMetrics()->getTotalBufferSize()));
+        getSizeString(mDeviceStats.getResourceMetrics()->getTotalBufferSize()));
 
     // Textures
-
     renderTableRow(
         "Number of textures",
         std::to_string(mDeviceStats.getResourceMetrics()->getTexturesCount()));
     renderTableRow(
         "Total size of allocated textures",
-        std::to_string(
+        getSizeString(
             mDeviceStats.getResourceMetrics()->getTotalTextureSize()));
 
     // Draw calls

--- a/engine/src/liquid/renderer/SceneRendererFrameData.cpp
+++ b/engine/src/liquid/renderer/SceneRendererFrameData.cpp
@@ -21,30 +21,46 @@ SceneRendererFrameData::SceneRendererFrameData(rhi::RenderDevice *device,
   mMeshEntities.reserve(mReservedSpace);
   mSkinnedMeshEntities.reserve(mReservedSpace);
 
-  mMeshTransformsBuffer = mDevice->createBuffer(
-      {rhi::BufferType::Storage, mReservedSpace * sizeof(glm::mat4)});
+  rhi::BufferDescription defaultDesc{};
+  defaultDesc.type = rhi::BufferType::Storage;
+  defaultDesc.size = mReservedSpace * sizeof(glm::mat4);
+  defaultDesc.mapped = true;
 
-  mSkinnedMeshTransformsBuffer = mDevice->createBuffer(
-      {rhi::BufferType::Storage, mReservedSpace * sizeof(glm::mat4)});
+  mMeshTransformsBuffer = mDevice->createBuffer(defaultDesc);
+  mSkinnedMeshTransformsBuffer = mDevice->createBuffer(defaultDesc);
+  mTextTransformsBuffer = mDevice->createBuffer(defaultDesc);
 
-  mSkeletonsBuffer = mDevice->createBuffer(
-      {rhi::BufferType::Storage,
-       mReservedSpace * MaxNumJoints * sizeof(glm::mat4)});
+  {
+    auto desc = defaultDesc;
+    desc.size = mReservedSpace * MaxNumJoints * sizeof(glm::mat4);
+    mSkeletonsBuffer = mDevice->createBuffer(desc);
+  }
 
-  mTextTransformsBuffer = mDevice->createBuffer(
-      {rhi::BufferType::Storage, mReservedSpace * sizeof(glm::mat4)});
+  {
+    auto desc = defaultDesc;
+    desc.size = mReservedSpace * sizeof(GlyphData);
+    mTextGlyphsBuffer = mDevice->createBuffer(desc);
+  }
 
-  mTextGlyphsBuffer = mDevice->createBuffer(
-      {rhi::BufferType::Storage, mReservedSpace * sizeof(GlyphData)});
+  {
+    auto desc = defaultDesc;
+    desc.size = mLights.capacity() * sizeof(LightData);
+    mLightsBuffer = mDevice->createBuffer(desc);
+  }
 
-  mLightsBuffer = mDevice->createBuffer(
-      {rhi::BufferType::Storage, mLights.capacity() * sizeof(LightData)});
+  {
+    auto desc = defaultDesc;
+    desc.size = sizeof(CameraComponent);
+    desc.type = rhi::BufferType::Uniform;
+    mCameraBuffer = mDevice->createBuffer(desc);
+  }
 
-  mCameraBuffer = mDevice->createBuffer(
-      {rhi::BufferType::Uniform, sizeof(CameraComponent)});
-
-  mSceneBuffer =
-      mDevice->createBuffer({rhi::BufferType::Uniform, sizeof(SceneData)});
+  {
+    auto desc = defaultDesc;
+    desc.size = sizeof(SceneData);
+    desc.type = rhi::BufferType::Uniform;
+    mSceneBuffer = mDevice->createBuffer(desc);
+  }
 }
 
 void SceneRendererFrameData::updateBuffers() {


### PR DESCRIPTION
- Add new mapped property in buffer description
- Use mapped buffers for frame data in scene, editor, imgui renderers
- Show human readable sizes for allocated space in debug layer
- Remove renderer from editor camera
- Only load imgui renderer in project selector screen