### PR TITLE
Add cascaded shadow maps for directional lights

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -12,6 +12,7 @@ Framebuffer coordinate: +Y is down. Origin(0, 0) is at the top left corner
 Texture coordinate: +Y is down. Origin(0, 0) is at the top left corner.
 
 > **Note:**
+>
 > This coordinate system is based on modern APIs such as DX12, Metal, and WebGPU.
 > In Vulkan coordinate system, NDC +Y is down; so, the engine will invert this
 > automatically when Vulkan is used as a rendering backend.

--- a/editor/src/liquidator/editor-scene/EditorCamera.h
+++ b/editor/src/liquidator/editor-scene/EditorCamera.h
@@ -34,7 +34,7 @@ public:
   /**
    * Default near perspective plane
    */
-  static constexpr float DefaultNear = 0.001f;
+  static constexpr float DefaultNear = 0.1f;
 
   /**
    * Default far perspective plane
@@ -84,49 +84,51 @@ public:
    *
    * @param fov Field of view
    */
-  inline void setFOV(float fov) { mFov = fov; }
+  void setFOV(float fov) { getPerspectiveLens().fovY = fov; }
 
   /**
    * @brief Set near plane
    *
    * @param near Near plane
    */
-  inline void setNear(float near) { mNear = near; }
+  void setNear(float near) { getPerspectiveLens().near = near; }
 
   /**
    * @brief Set far plane
    *
    * @param far Far plane
    */
-  inline void setFar(float far) { mFar = far; }
+  void setFar(float far) { getPerspectiveLens().far = far; }
 
   /**
    * @brief Get field of view
    *
    * @return Field of view
    */
-  inline float getFOV() const { return mFov; }
+  inline float getFOV() const { return getPerspectiveLens().fovY; }
 
   /**
    * @brief Get near place
    *
    * @return Near plane
    */
-  inline float getNear() const { return mNear; }
+  inline float getNear() const { return getPerspectiveLens().near; }
 
   /**
    * @brief Get far plane
    *
    * @return Far plane
    */
-  inline float getFar() const { return mFar; }
+  inline float getFar() const { return getPerspectiveLens().far; }
 
   /**
    * @brief Get aspect ratio
    *
    * @return Aspect ratio
    */
-  inline float getAspectRatio() const { return mWidth / mHeight; }
+  inline float getAspectRatio() const {
+    return getPerspectiveLens().aspectRatio;
+  }
 
   /**
    * @brief Get position
@@ -228,6 +230,24 @@ public:
 
 private:
   /**
+   * @brief Get perspective lens
+   *
+   * @return Perspective lens
+   */
+  inline liquid::PerspectiveLens &getPerspectiveLens() {
+    return mEntityDatabase.get<liquid::PerspectiveLens>(mCameraEntity);
+  }
+
+  /**
+   * @brief Get perspective lens
+   *
+   * @return Perspective lens
+   */
+  inline const liquid::PerspectiveLens &getPerspectiveLens() const {
+    return mEntityDatabase.get<liquid::PerspectiveLens>(mCameraEntity);
+  }
+
+  /**
    * @brief Pan camera using mouse movement
    */
   void pan();
@@ -243,10 +263,6 @@ private:
   void zoom();
 
 private:
-  float mFov = DefaultFOV;
-  float mNear = DefaultNear;
-  float mFar = DefaultFar;
-
   float mX = 0.0f;
   float mY = 0.0f;
   float mWidth = 0.0f;

--- a/editor/src/liquidator/editor-scene/EntityManager.cpp
+++ b/editor/src/liquidator/editor-scene/EntityManager.cpp
@@ -113,6 +113,15 @@ void EntityManager::toggleSkeletonDebugForEntity(liquid::Entity entity) {
   entityDatabase.set(entity, skeletonDebug);
 }
 
+void EntityManager::toggleShadowsForLightEntity(liquid::Entity entity) {
+  auto &entityDatabase = getActiveEntityDatabase();
+  if (entityDatabase.has<liquid::CascadedShadowMap>(entity)) {
+    entityDatabase.remove<liquid::CascadedShadowMap>(entity);
+  } else {
+    entityDatabase.set<liquid::CascadedShadowMap>(entity, {});
+  }
+}
+
 void EntityManager::setMesh(liquid::Entity entity,
                             liquid::MeshAssetHandle handle) {
   if (getActiveEntityDatabase().has<liquid::SkinnedMesh>(entity)) {

--- a/editor/src/liquidator/editor-scene/EntityManager.h
+++ b/editor/src/liquidator/editor-scene/EntityManager.h
@@ -85,6 +85,13 @@ public:
   void toggleSkeletonDebugForEntity(liquid::Entity entity);
 
   /**
+   * @brief Toggle shadows for light entity
+   *
+   * @param entity Entity
+   */
+  void toggleShadowsForLightEntity(liquid::Entity entity);
+
+  /**
    * @brief Set mesh for entiy
    *
    * @param entity Entity

--- a/editor/src/liquidator/ui/EntityPanel.cpp
+++ b/editor/src/liquidator/ui/EntityPanel.cpp
@@ -141,6 +141,34 @@ void EntityPanel::renderLight() {
     if (widgets::Input("Intensity", component.intensity)) {
       mEntityManager.save(mSelectedEntity);
     }
+
+    bool castShadows =
+        mEntityManager.getActiveEntityDatabase().has<liquid::CascadedShadowMap>(
+            mSelectedEntity);
+    if (ImGui::Checkbox("Cast shadows", &castShadows)) {
+      mEntityManager.toggleShadowsForLightEntity(mSelectedEntity);
+      mEntityManager.save(mSelectedEntity);
+    }
+
+    if (castShadows) {
+      auto &component = mEntityManager.getActiveEntityDatabase()
+                            .get<liquid::CascadedShadowMap>(mSelectedEntity);
+
+      if (ImGui::Checkbox("Soft shadows", &component.softShadows)) {
+        mEntityManager.save(mSelectedEntity);
+      }
+
+      if (widgets::Input("Split lambda", component.splitLambda)) {
+        component.splitLambda = glm::clamp(component.splitLambda, 0.0f, 1.0f);
+        mEntityManager.save(mSelectedEntity);
+      }
+
+      if (widgets::Input("Number of cascades", component.numCascades)) {
+        component.numCascades =
+            glm::clamp(component.numCascades, 1u, component.MaxCascades);
+        mEntityManager.save(mSelectedEntity);
+      }
+    }
   }
 }
 

--- a/editor/src/liquidator/ui/Widgets.cpp
+++ b/editor/src/liquidator/ui/Widgets.cpp
@@ -196,7 +196,8 @@ void Table::column(liquid::rhi::TextureHandle handle, const glm::vec2 &size) {
 Input::Input(liquid::String label, glm::vec3 &value) {
   glm::vec3 temp = value;
 
-  renderScalarInput(label, glm::value_ptr(temp), glm::vec3::length());
+  renderScalarInput(label, glm::value_ptr(temp), glm::vec3::length(),
+                    ImGuiDataType_Float);
 
   if (mChanged) {
     value = temp;
@@ -206,7 +207,17 @@ Input::Input(liquid::String label, glm::vec3 &value) {
 Input::Input(liquid::String label, float &value) {
   float temp = value;
 
-  renderScalarInput(label, &temp, 1);
+  renderScalarInput(label, &temp, 1, ImGuiDataType_Float);
+
+  if (mChanged) {
+    value = temp;
+  }
+}
+
+Input::Input(liquid::String label, uint32_t &value) {
+  uint32_t temp = value;
+
+  renderScalarInput(label, &temp, 1, ImGuiDataType_U32);
 
   if (mChanged) {
     value = temp;
@@ -222,14 +233,16 @@ Input::Input(liquid::String label, liquid::String &value) {
   }
 }
 
-void Input::renderScalarInput(liquid::String label, void *data, size_t size) {
+void Input::renderScalarInput(liquid::String label, void *data, size_t size,
+                              ImGuiDataType dataType) {
   if (!label.empty()) {
     ImGui::Text("%s", label.c_str());
   }
   const auto id = "###Input" + label;
 
-  ImGui::InputScalarN(id.c_str(), ImGuiDataType_Float, data,
-                      static_cast<int>(size), nullptr, nullptr, "%.3f");
+  ImGui::InputScalarN(id.c_str(), dataType, data, static_cast<int>(size),
+                      nullptr, nullptr,
+                      dataType == ImGuiDataType_Float ? "%.3f" : 0);
   mChanged = ImGui::IsItemDeactivatedAfterEdit();
 }
 

--- a/editor/src/liquidator/ui/Widgets.h
+++ b/editor/src/liquidator/ui/Widgets.h
@@ -300,12 +300,20 @@ public:
   Input(liquid::String label, glm::vec3 &value);
 
   /**
-   * @brief Render scalar input
+   * @brief Render decimal scalar input
    *
    * @param label Input label
    * @param value Input value
    */
   Input(liquid::String label, float &value);
+
+  /**
+   * @brief Render uint scalar input
+   *
+   * @param label Input label
+   * @param value Input value
+   */
+  Input(liquid::String label, uint32_t &value);
 
   /**
    * @brief Render text input
@@ -330,8 +338,10 @@ private:
    * @param label Input label
    * @param data Scalar data
    * @param size Number of data items
+   * @param dataType Input data type
    */
-  void renderScalarInput(liquid::String label, void *data, size_t size);
+  void renderScalarInput(liquid::String label, void *data, size_t size,
+                         ImGuiDataType dataType);
 
   /**
    * @brief Render text input

--- a/engine/assets/shaders/geometry-skinned.vert
+++ b/engine/assets/shaders/geometry-skinned.vert
@@ -9,13 +9,11 @@ layout(location = 5) in vec2 inTextureCoord1;
 layout(location = 6) in uvec4 inJoints;
 layout(location = 7) in vec4 inWeights;
 
-layout(location = 0) out vec4 outModelPosition;
-layout(location = 1) out vec3 outWorldPosition;
-layout(location = 2) out vec2 outTextureCoord[2];
-layout(location = 4) out vec3 outNormal;
-layout(location = 5) out float outTangentHand;
-layout(location = 6) out mat3 outTBN;
-layout(location = 9) out mat4 outModelMatrix;
+layout(location = 0) out vec3 outWorldPosition;
+layout(location = 1) out vec2 outTextureCoord[2];
+layout(location = 3) out vec3 outNormal;
+layout(location = 4) out float outTangentHand;
+layout(location = 5) out mat3 outTBN;
 
 layout(set = 0, binding = 0) uniform CameraData {
   mat4 proj;
@@ -54,8 +52,7 @@ void main() {
                     inWeights.z * item.joints[inJoints.z] +
                     inWeights.w * item.joints[inJoints.w];
 
-  vec4 worldPosition =
-      uCameraData.viewProj * modelMatrix * skinMatrix * vec4(inPosition, 1.0f);
+  vec4 worldPosition = modelMatrix * skinMatrix * vec4(inPosition, 1.0f);
 
   mat3 m3ModelMatrix = mat3(modelMatrix);
   mat3 normalMatrix = transpose(inverse(m3ModelMatrix));
@@ -64,13 +61,11 @@ void main() {
   vec3 tangent = normalize(m3ModelMatrix * inTangent.xyz);
   vec3 bitangent = cross(normal, tangent) * inTangent.w;
 
-  outModelMatrix = modelMatrix;
-  outModelPosition = vec4(inPosition, 1.0f);
   outWorldPosition = worldPosition.xyz;
   outNormal = normal;
   outTangentHand = inTangent.w;
   outTBN = mat3(tangent, bitangent, normal);
   outTextureCoord[0] = inTextureCoord0;
   outTextureCoord[1] = inTextureCoord1;
-  gl_Position = worldPosition;
+  gl_Position = uCameraData.viewProj * worldPosition;
 }

--- a/engine/assets/shaders/geometry.vert
+++ b/engine/assets/shaders/geometry.vert
@@ -7,13 +7,11 @@ layout(location = 3) in vec3 inColor;
 layout(location = 4) in vec2 inTextureCoord0;
 layout(location = 5) in vec2 inTextureCoord1;
 
-layout(location = 0) out vec4 outModelPosition;
-layout(location = 1) out vec3 outWorldPosition;
-layout(location = 2) out vec2 outTextureCoord[2];
-layout(location = 4) out vec3 outNormal;
-layout(location = 5) out float outTangentHand;
-layout(location = 6) out mat3 outTBN;
-layout(location = 9) out mat4 outModelMatrix;
+layout(location = 0) out vec3 outWorldPosition;
+layout(location = 1) out vec2 outTextureCoord[2];
+layout(location = 3) out vec3 outNormal;
+layout(location = 4) out float outTangentHand;
+layout(location = 5) out mat3 outTBN;
 
 layout(set = 0, binding = 0) uniform CameraData {
   mat4 proj;
@@ -40,8 +38,7 @@ uObjectData;
 void main() {
   mat4 modelMatrix = uObjectData.items[gl_InstanceIndex].modelMatrix;
 
-  vec4 worldPosition =
-      uCameraData.viewProj * modelMatrix * vec4(inPosition, 1.0f);
+  vec4 worldPosition = modelMatrix * vec4(inPosition, 1.0f);
 
   mat3 m3ModelMatrix = mat3(modelMatrix);
   mat3 normalMatrix = transpose(inverse(m3ModelMatrix));
@@ -50,13 +47,11 @@ void main() {
   vec3 tangent = normalize(m3ModelMatrix * inTangent.xyz);
   vec3 bitangent = cross(normal, tangent) * inTangent.w;
 
-  outModelMatrix = modelMatrix;
-  outModelPosition = vec4(inPosition, 1.0f);
   outWorldPosition = worldPosition.xyz;
   outNormal = normal;
   outTangentHand = inTangent.w;
   outTBN = mat3(tangent, bitangent, normal);
   outTextureCoord[0] = inTextureCoord0;
   outTextureCoord[1] = inTextureCoord1;
-  gl_Position = worldPosition;
+  gl_Position = uCameraData.viewProj * worldPosition;
 }

--- a/engine/assets/shaders/shadowmap.vert
+++ b/engine/assets/shaders/shadowmap.vert
@@ -5,29 +5,24 @@
 layout(location = 0) in vec3 inPosition;
 
 /**
- * @brief Single light data
+ * @brief Single shadow data
  */
-struct LightItem {
+struct ShadowMapItem {
   /**
-   * Light data
+   * Shadow matrix generated from light
    */
-  vec4 data;
+  mat4 shadowMatrix;
 
   /**
-   * Light color
+   * Shadow data
    */
-  vec4 color;
-
-  /**
-   * Light space matrix
-   */
-  mat4 lightMatrix;
+  vec4 shadowData;
 };
 
-layout(std140, set = 0, binding = 0) readonly buffer LightData {
-  LightItem items[];
+layout(std140, set = 0, binding = 0) readonly buffer ShadowMapData {
+  ShadowMapItem items[];
 }
-uLightData;
+uShadowMaps;
 
 /**
  * @brief Single object transforms
@@ -45,12 +40,12 @@ layout(std140, set = 1, binding = 0) readonly buffer ObjectData {
 uObjectData;
 
 layout(push_constant) uniform PushConstants { ivec4 index; }
-pcLightRef;
+pcShadowRef;
 
 void main() {
-  mat4 modelMatrix = uObjectData.items[gl_BaseInstance].modelMatrix;
+  mat4 modelMatrix = uObjectData.items[gl_InstanceIndex].modelMatrix;
 
-  gl_Position = uLightData.items[pcLightRef.index.x].lightMatrix * modelMatrix *
-                vec4(inPosition, 1.0);
-  gl_Layer = pcLightRef.index.x;
+  gl_Position = uShadowMaps.items[pcShadowRef.index.x].shadowMatrix *
+                modelMatrix * vec4(inPosition, 1.0);
+  gl_Layer = pcShadowRef.index.x;
 }

--- a/engine/src/liquid/entity/EntityDatabase.cpp
+++ b/engine/src/liquid/entity/EntityDatabase.cpp
@@ -9,6 +9,7 @@ EntityDatabase::EntityDatabase() {
   reg<Delete>();
   reg<Mesh>();
   reg<DirectionalLight>();
+  reg<CascadedShadowMap>();
   reg<Camera>();
   reg<AutoAspectRatio>();
   reg<PerspectiveLens>();

--- a/engine/src/liquid/entity/EntityDatabase.h
+++ b/engine/src/liquid/entity/EntityDatabase.h
@@ -9,6 +9,7 @@
 #include "liquid/scene/Mesh.h"
 #include "liquid/scene/SkinnedMesh.h"
 #include "liquid/scene/DirectionalLight.h"
+#include "liquid/scene/CascadedShadowMap.h"
 #include "liquid/scene/PerspectiveLens.h"
 #include "liquid/scene/AutoAspectRatio.h"
 #include "liquid/scene/Skeleton.h"

--- a/engine/src/liquid/scene/CascadedShadowMap.h
+++ b/engine/src/liquid/scene/CascadedShadowMap.h
@@ -1,0 +1,37 @@
+#pragma once
+
+namespace liquid {
+
+/**
+ * @brief Cascaded shadow map component
+ */
+struct CascadedShadowMap {
+  /**
+   * @brief Maximum number of shadow cascades
+   */
+  static constexpr uint32_t MaxCascades = 6;
+
+  /**
+   * Split lambda for calculating splits
+   *
+   * Used to calculate split distances by combining
+   * logarithmic and uniform splitting
+   *
+   * log_i = near * (far/near)^(i / size)
+   * uniform_i = near + (far - near) * (1 / size)
+   * distance_i = lambda * log_i + (1 - lambda) * uniform_i
+   */
+  float splitLambda = 0.8f;
+
+  /**
+   * Use soft shadows
+   */
+  bool softShadows = true;
+
+  /**
+   * Number of cascades
+   */
+  uint32_t numCascades = 4;
+};
+
+} // namespace liquid

--- a/engine/src/liquid/scene/PerspectiveLens.h
+++ b/engine/src/liquid/scene/PerspectiveLens.h
@@ -14,7 +14,7 @@ struct PerspectiveLens {
   /**
    * Near plane
    */
-  float near = 0.001f;
+  float near = 0.1f;
 
   /**
    * Far plane

--- a/engine/src/liquid/scene/private/EntitySerializer.cpp
+++ b/engine/src/liquid/scene/private/EntitySerializer.cpp
@@ -60,6 +60,13 @@ YAML::Node EntitySerializer::createComponentsNode(Entity entity) {
     components["light"]["type"] = 0;
     components["light"]["color"] = light.color;
     components["light"]["intensity"] = light.intensity;
+
+    if (mEntityDatabase.has<CascadedShadowMap>(entity)) {
+      const auto &shadow = mEntityDatabase.get<CascadedShadowMap>(entity);
+      components["light"]["shadow"]["softShadows"] = shadow.softShadows;
+      components["light"]["shadow"]["splitLambda"] = shadow.splitLambda;
+      components["light"]["shadow"]["numCascades"] = shadow.numCascades;
+    }
   }
 
   if (mEntityDatabase.has<PerspectiveLens>(entity)) {

--- a/engine/src/liquid/scene/private/SceneLoader.cpp
+++ b/engine/src/liquid/scene/private/SceneLoader.cpp
@@ -220,17 +220,35 @@ Result<bool> SceneLoader::loadComponents(const YAML::Node &node, Entity entity,
   }
 
   if (node["components"]["light"] && node["components"]["light"].IsMap()) {
-    auto type = node["components"]["light"]["type"].as<uint32_t>(
-        std::numeric_limits<uint32_t>::max());
+    auto light = node["components"]["light"];
+    auto type =
+        light["type"].as<uint32_t>(std::numeric_limits<uint32_t>::max());
 
     if (type == 0) {
       DirectionalLight component{};
-      component.intensity = node["components"]["light"]["intensity"].as<float>(
-          component.intensity);
-      component.color =
-          node["components"]["light"]["color"].as<glm::vec4>(component.color);
+      component.intensity = light["intensity"].as<float>(component.intensity);
+      component.color = light["color"].as<glm::vec4>(component.color);
 
       mEntityDatabase.set(entity, component);
+
+      if (light["shadow"] && light["shadow"].IsMap()) {
+        CascadedShadowMap shadowComponent{};
+        shadowComponent.softShadows = light["shadow"]["softShadows"].as<bool>(
+            shadowComponent.softShadows);
+        shadowComponent.splitLambda = light["shadow"]["splitLambda"].as<float>(
+            shadowComponent.splitLambda);
+        shadowComponent.numCascades =
+            light["shadow"]["numCascades"].as<uint32_t>(
+                shadowComponent.numCascades);
+
+        shadowComponent.numCascades = glm::clamp(
+            shadowComponent.numCascades, 1u, shadowComponent.MaxCascades);
+
+        shadowComponent.splitLambda =
+            glm::clamp(shadowComponent.splitLambda, 0.0f, 1.0f);
+
+        mEntityDatabase.set(entity, shadowComponent);
+      }
     }
   }
 


### PR DESCRIPTION
- Read shadow coordinates from shadow map correctly when using negative viewport
- Calculate object data properly for instanced rendering when using shadows
- Calculate light projection matrices from camera
- Split the camera frustum into cascades
- Use cascades to render shadows
- Add cascaded shadow map component
- Cast shadows if cascaded shadow map exists for entity
- Save and load shadow data from scene files
- Add UI for casting and disabling shadows
- Create perspective lens component for editor camera