### PR TITLE
Move render graph and render graph evaluator to renderer

### DIFF
--- a/editor/src/liquidator/core/EditorRenderer.cpp
+++ b/editor/src/liquidator/core/EditorRenderer.cpp
@@ -46,8 +46,7 @@ EditorRenderer::EditorRenderer(liquid::ShaderLibrary &shaderLibrary,
       mDevice->createShader({shadersPath / "collidable-shape.frag.spv"}));
 }
 
-liquid::rhi::RenderGraphPass &
-EditorRenderer::attach(liquid::rhi::RenderGraph &graph) {
+liquid::RenderGraphPass &EditorRenderer::attach(liquid::RenderGraph &graph) {
   auto &pass = graph.addPass("editor-debug");
 
   auto vEditorGridPipeline = pass.addPipeline(
@@ -122,7 +121,7 @@ EditorRenderer::attach(liquid::rhi::RenderGraph &graph) {
   pass.setExecutor([vEditorGridPipeline, vSkeletonLinesPipeline,
                     vObjectIconsPipeline, vCollidableShapePipeline,
                     this](liquid::rhi::RenderCommandList &commandList,
-                          const liquid::rhi::RenderGraphRegistry &registry,
+                          const liquid::RenderGraphRegistry &registry,
                           uint32_t frameIndex) {
     auto &frameData = mFrameData.at(frameIndex);
     auto collidableShapePipeline = registry.get(vCollidableShapePipeline);

--- a/editor/src/liquidator/core/EditorRenderer.h
+++ b/editor/src/liquidator/core/EditorRenderer.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "liquid/rhi/RenderGraph.h"
+#include "liquid/renderer/RenderGraph.h"
 #include "liquid/entity/EntityDatabase.h"
 #include "liquid/renderer/ShaderLibrary.h"
 #include "liquidator/editor-scene/EditorGrid.h"
@@ -50,7 +50,7 @@ public:
    * @param graph Render graph
    * @return Newly created render pass
    */
-  liquid::rhi::RenderGraphPass &attach(liquid::rhi::RenderGraph &graph);
+  liquid::RenderGraphPass &attach(liquid::RenderGraph &graph);
 
   /**
    * @brief Update frame data

--- a/editor/src/liquidator/core/MousePickingGraph.cpp
+++ b/editor/src/liquidator/core/MousePickingGraph.cpp
@@ -74,7 +74,7 @@ MousePickingGraph::MousePickingGraph(
 
   pass.setExecutor([this, vPipeline, vSkinnedPipeline](
                        liquid::rhi::RenderCommandList &commandList,
-                       const liquid::rhi::RenderGraphRegistry &registry,
+                       const liquid::RenderGraphRegistry &registry,
                        uint32_t frameIndex) {
     auto &frameData = mFrameData.at(frameIndex);
 

--- a/editor/src/liquidator/core/MousePickingGraph.h
+++ b/editor/src/liquidator/core/MousePickingGraph.h
@@ -1,8 +1,8 @@
 #pragma once
 
-#include "liquid/rhi/RenderGraph.h"
 #include "liquid/rhi/RenderDevice.h"
-#include "liquid/rhi/RenderGraphEvaluator.h"
+#include "liquid/renderer/RenderGraphEvaluator.h"
+#include "liquid/renderer/RenderGraph.h"
 #include "liquid/renderer/ShaderLibrary.h"
 #include "liquid/renderer/SceneRendererFrameData.h"
 #include "liquid/asset/AssetRegistry.h"
@@ -86,8 +86,8 @@ public:
 private:
   liquid::rhi::RenderDevice *mDevice = nullptr;
 
-  liquid::rhi::RenderGraph mRenderGraph;
-  liquid::rhi::RenderGraphEvaluator mGraphEvaluator;
+  liquid::RenderGraph mRenderGraph;
+  liquid::RenderGraphEvaluator mGraphEvaluator;
   const std::array<liquid::SceneRendererFrameData,
                    liquid::rhi::RenderDevice::NumFrames> &mFrameData;
   liquid::AssetRegistry &mAssetRegistry;

--- a/editor/src/liquidator/screens/EditorScreen.cpp
+++ b/editor/src/liquidator/screens/EditorScreen.cpp
@@ -129,7 +129,7 @@ void EditorScreen::start(const Project &project) {
   liquidator::EditorRenderer editorRenderer(renderer.getShaderLibrary(),
                                             ui.getIconRegistry(), mDevice);
 
-  liquid::rhi::RenderGraph graph("Main");
+  liquid::RenderGraph graph("Main");
 
   auto scenePassGroup = renderer.getSceneRenderer().attach(graph);
   auto imguiPassGroup = renderer.getImguiRenderer().attach(graph);

--- a/editor/src/liquidator/screens/ProjectSelectorScreen.cpp
+++ b/editor/src/liquidator/screens/ProjectSelectorScreen.cpp
@@ -24,7 +24,7 @@ std::optional<Project> ProjectSelectorScreen::start() {
   liquid::EntityDatabase entityDatabase;
   liquid::AssetRegistry assetRegistry;
   liquid::ShaderLibrary shaderLibrary;
-  liquid::rhi::RenderGraphEvaluator graphEvaluator(mDevice);
+  liquid::RenderGraphEvaluator graphEvaluator(mDevice);
 
   liquid::ImguiRenderer imguiRenderer(mWindow, shaderLibrary, mDevice);
   liquid::Presenter presenter(shaderLibrary, mDevice);
@@ -48,7 +48,7 @@ std::optional<Project> ProjectSelectorScreen::start() {
   imguiRenderer.setClearColor(Theme::getColor(ThemeColor::BackgroundColor));
   imguiRenderer.buildFonts();
 
-  liquid::rhi::RenderGraph graph("Main");
+  liquid::RenderGraph graph("Main");
   auto imguiPassData = imguiRenderer.attach(graph);
 
   graph.setFramebufferExtent(mWindow.getFramebufferSize());

--- a/engine/src/liquid/imgui/ImguiRenderer.cpp
+++ b/engine/src/liquid/imgui/ImguiRenderer.cpp
@@ -66,7 +66,7 @@ ImguiRenderer::~ImguiRenderer() {
   ImGui::DestroyContext();
 }
 
-ImguiRenderPassData ImguiRenderer::attach(rhi::RenderGraph &graph) {
+ImguiRenderPassData ImguiRenderer::attach(RenderGraph &graph) {
   LIQUID_ASSERT(mReady, "Fonts are not built. Call ImguiRenderer::loadFonts "
                         "before starting rendering");
 
@@ -107,7 +107,7 @@ ImguiRenderPassData ImguiRenderer::attach(rhi::RenderGraph &graph) {
           rhi::BlendFactor::OneMinusSrcAlpha, rhi::BlendOp::Add}}}});
 
   pass.setExecutor([this, pipeline](rhi::RenderCommandList &commandList,
-                                    const rhi::RenderGraphRegistry &registry,
+                                    const RenderGraphRegistry &registry,
                                     uint32_t frameIndex) {
     draw(commandList, registry.get(pipeline), frameIndex);
   });

--- a/engine/src/liquid/imgui/ImguiRenderer.h
+++ b/engine/src/liquid/imgui/ImguiRenderer.h
@@ -3,7 +3,7 @@
 #include "liquid/window/Window.h"
 
 #include "liquid/rhi/RenderCommandList.h"
-#include "liquid/rhi/RenderGraph.h"
+#include "liquid/renderer/RenderGraph.h"
 #include "liquid/rhi/RenderDevice.h"
 #include "liquid/renderer/ShaderLibrary.h"
 
@@ -18,7 +18,7 @@ struct ImguiRenderPassData {
   /**
    * Imgui pass
    */
-  rhi::RenderGraphPass &pass;
+  RenderGraphPass &pass;
 
   /**
    * Imgui texture
@@ -94,7 +94,7 @@ public:
    * @param graph Render graph
    * @return Imgui render pass data
    */
-  ImguiRenderPassData attach(rhi::RenderGraph &graph);
+  ImguiRenderPassData attach(RenderGraph &graph);
 
   /**
    * @brief Set clear color

--- a/engine/src/liquid/renderer/RenderGraph.h
+++ b/engine/src/liquid/renderer/RenderGraph.h
@@ -1,9 +1,10 @@
 #pragma once
 
-#include "RenderGraphPass.h"
-#include "RenderDevice.h"
+#include "liquid/rhi/RenderDevice.h"
 
-namespace liquid::rhi {
+#include "RenderGraphPass.h"
+
+namespace liquid {
 
 /**
  * @brief Render graph
@@ -33,7 +34,7 @@ public:
    *
    * @param device Render device
    */
-  void compile(RenderDevice *device);
+  void compile(rhi::RenderDevice *device);
 
   /**
    * @brief Get passes
@@ -97,4 +98,4 @@ private:
   String mName;
 };
 
-} // namespace liquid::rhi
+} // namespace liquid

--- a/engine/src/liquid/renderer/RenderGraphEvaluator.cpp
+++ b/engine/src/liquid/renderer/RenderGraphEvaluator.cpp
@@ -4,11 +4,10 @@
 #include "liquid/rhi/FramebufferDescription.h"
 
 #include "RenderGraphEvaluator.h"
-#include "RenderDevice.h"
 
-namespace liquid::rhi {
+namespace liquid {
 
-RenderGraphEvaluator::RenderGraphEvaluator(RenderDevice *device)
+RenderGraphEvaluator::RenderGraphEvaluator(rhi::RenderDevice *device)
     : mDevice(device) {}
 
 void RenderGraphEvaluator::build(RenderGraph &graph) {
@@ -23,7 +22,7 @@ void RenderGraphEvaluator::build(RenderGraph &graph) {
   graph.updateDirtyFlag();
 }
 
-void RenderGraphEvaluator::execute(RenderCommandList &commandList,
+void RenderGraphEvaluator::execute(rhi::RenderCommandList &commandList,
                                    RenderGraph &graph, uint32_t frameIndex) {
   LIQUID_PROFILE_EVENT("RenderGraphEvaluator::execute");
 
@@ -63,9 +62,9 @@ void RenderGraphEvaluator::buildPass(size_t index, RenderGraph &graph,
   uint32_t height = 0;
   uint32_t layers = 0;
 
-  std::vector<TextureHandle> framebufferAttachments;
+  std::vector<rhi::TextureHandle> framebufferAttachments;
 
-  RenderPassDescription renderPassDesc{};
+  rhi::RenderPassDescription renderPassDesc{};
 
   for (size_t i = 0; i < pass.getOutputs().size(); ++i) {
     auto &output = pass.mOutputs.at(i);
@@ -85,27 +84,27 @@ void RenderGraphEvaluator::buildPass(size_t index, RenderGraph &graph,
   }
 
   if (!renderPassDesc.attachments.empty()) {
-    renderPassDesc.bindPoint = PipelineBindPoint::Graphics;
+    renderPassDesc.bindPoint = rhi::PipelineBindPoint::Graphics;
 
     bool renderPassExists = isHandleValid(pass.mRenderPass);
 
-    if (pass.mRenderPass != RenderPassHandle::Invalid) {
+    if (pass.mRenderPass != rhi::RenderPassHandle::Invalid) {
       mDevice->destroyRenderPass(pass.mRenderPass);
     }
 
     pass.mRenderPass = mDevice->createRenderPass(renderPassDesc);
 
-    std::vector<FramebufferHandle> framebuffers(framebufferAttachments.size(),
-                                                FramebufferHandle::Invalid);
+    std::vector<rhi::FramebufferHandle> framebuffers(
+        framebufferAttachments.size(), rhi::FramebufferHandle::Invalid);
 
-    FramebufferDescription framebufferDesc;
+    rhi::FramebufferDescription framebufferDesc;
     framebufferDesc.width = width;
     framebufferDesc.height = height;
     framebufferDesc.layers = layers;
     framebufferDesc.attachments = framebufferAttachments;
     framebufferDesc.renderPass = pass.mRenderPass;
 
-    if (pass.mFramebuffer != FramebufferHandle::Invalid) {
+    if (pass.mFramebuffer != rhi::FramebufferHandle::Invalid) {
       mDevice->destroyFramebuffer(pass.mFramebuffer);
     }
 
@@ -125,7 +124,7 @@ void RenderGraphEvaluator::buildPass(size_t index, RenderGraph &graph,
 
     auto handle = pass.mRegistry.mRealResources.at(i);
 
-    if (handle != PipelineHandle::Invalid) {
+    if (handle != rhi::PipelineHandle::Invalid) {
       mDevice->destroyPipeline(handle);
     }
 
@@ -151,7 +150,7 @@ RenderGraphEvaluator::createAttachment(const AttachmentData &attachment,
   info.attachment.layout = renderTarget.dstLayout;
 
   static constexpr uint32_t HundredPercent = 100;
-  if (desc.sizeMethod == TextureSizeMethod::FramebufferRatio) {
+  if (desc.sizeMethod == rhi::TextureSizeMethod::FramebufferRatio) {
     info.width = desc.width * extent.x / HundredPercent;
     info.height = desc.height * extent.y / HundredPercent;
   } else {
@@ -168,9 +167,9 @@ bool RenderGraphEvaluator::hasSwapchainRelativeResources(
     RenderGraphPass &pass) {
   for (auto rt : pass.getOutputs()) {
     auto handle = rt.texture;
-    if (handle == TextureHandle(1) ||
+    if (handle == rhi::TextureHandle(1) ||
         mDevice->getTextureDescription(handle).sizeMethod ==
-            TextureSizeMethod::FramebufferRatio) {
+            rhi::TextureSizeMethod::FramebufferRatio) {
       return true;
     }
   }
@@ -178,4 +177,4 @@ bool RenderGraphEvaluator::hasSwapchainRelativeResources(
   return false;
 }
 
-} // namespace liquid::rhi
+} // namespace liquid

--- a/engine/src/liquid/renderer/RenderGraphEvaluator.h
+++ b/engine/src/liquid/renderer/RenderGraphEvaluator.h
@@ -1,23 +1,24 @@
 #pragma once
 
-#include "PipelineDescription.h"
-#include "RenderPassDescription.h"
-#include "RenderGraph.h"
-#include "RenderCommandList.h"
-#include "RenderDevice.h"
+#include "liquid/rhi/PipelineDescription.h"
+#include "liquid/rhi/RenderPassDescription.h"
+#include "liquid/rhi/RenderCommandList.h"
+#include "liquid/rhi/RenderDevice.h"
 
-namespace liquid::rhi {
+#include "RenderGraph.h"
+
+namespace liquid {
 
 /**
  * @brief Render graph evaluator
  */
 class RenderGraphEvaluator {
   struct RenderPassAttachmentInfo {
-    std::vector<TextureHandle> framebufferAttachments;
+    std::vector<rhi::TextureHandle> framebufferAttachments;
     uint32_t width = 0;
     uint32_t height = 0;
     uint32_t layers = 0;
-    RenderPassAttachmentDescription attachment;
+    rhi::RenderPassAttachmentDescription attachment;
   };
 
 public:
@@ -26,7 +27,7 @@ public:
    *
    * @param device Render device
    */
-  RenderGraphEvaluator(RenderDevice *device);
+  RenderGraphEvaluator(rhi::RenderDevice *device);
 
   /**
    * @brief Build render graph
@@ -42,7 +43,7 @@ public:
    * @param graph Render graph
    * @param frameIndex Frame index
    */
-  void execute(RenderCommandList &commandList, RenderGraph &graph,
+  void execute(rhi::RenderCommandList &commandList, RenderGraph &graph,
                uint32_t frameIndex);
 
 private:
@@ -77,7 +78,7 @@ private:
   bool hasSwapchainRelativeResources(RenderGraphPass &pass);
 
 private:
-  RenderDevice *mDevice = nullptr;
+  rhi::RenderDevice *mDevice = nullptr;
 };
 
-} // namespace liquid::rhi
+} // namespace liquid

--- a/engine/src/liquid/renderer/RenderGraphPass.cpp
+++ b/engine/src/liquid/renderer/RenderGraphPass.cpp
@@ -1,17 +1,17 @@
 #include "liquid/core/Base.h"
 #include "RenderGraphPass.h"
 
-namespace liquid::rhi {
+namespace liquid {
 
 RenderGraphPass::RenderGraphPass(StringView name) : mName(name) {}
 
-void RenderGraphPass::write(TextureHandle handle,
-                            const AttachmentClearValue &clearValue) {
+void RenderGraphPass::write(rhi::TextureHandle handle,
+                            const rhi::AttachmentClearValue &clearValue) {
   mOutputs.push_back({handle});
   mAttachments.push_back({clearValue});
 }
 
-void RenderGraphPass::read(TextureHandle handle) {
+void RenderGraphPass::read(rhi::TextureHandle handle) {
   mInputs.push_back({handle});
 }
 
@@ -20,13 +20,13 @@ void RenderGraphPass::setExecutor(const ExecutorFn &executor) {
 }
 
 VirtualPipelineHandle
-RenderGraphPass::addPipeline(const PipelineDescription &description) {
+RenderGraphPass::addPipeline(const rhi::PipelineDescription &description) {
   return mRegistry.set(description);
 }
 
-void RenderGraphPass::execute(RenderCommandList &commandList,
+void RenderGraphPass::execute(rhi::RenderCommandList &commandList,
                               uint32_t frameIndex) {
   mExecutor(commandList, mRegistry, frameIndex);
 }
 
-} // namespace liquid::rhi
+} // namespace liquid

--- a/engine/src/liquid/renderer/RenderGraphPass.h
+++ b/engine/src/liquid/renderer/RenderGraphPass.h
@@ -7,10 +7,10 @@
 
 #include "RenderGraphRegistry.h"
 
-namespace liquid::rhi {
+namespace liquid {
 
-class RenderGraphEvaluator;
 class RenderGraph;
+class RenderGraphEvaluator;
 
 /**
  * @brief Render graph attachment data
@@ -19,17 +19,17 @@ struct AttachmentData {
   /**
    * Clear value
    */
-  AttachmentClearValue clearValue;
+  rhi::AttachmentClearValue clearValue;
 
   /**
    * Load operation
    */
-  AttachmentLoadOp loadOp = AttachmentLoadOp::DontCare;
+  rhi::AttachmentLoadOp loadOp = rhi::AttachmentLoadOp::DontCare;
 
   /**
    * Store operation
    */
-  AttachmentStoreOp storeOp = AttachmentStoreOp::DontCare;
+  rhi::AttachmentStoreOp storeOp = rhi::AttachmentStoreOp::DontCare;
 };
 
 /**
@@ -39,17 +39,17 @@ struct RenderTargetData {
   /**
    * Texture
    */
-  TextureHandle texture = TextureHandle::Invalid;
+  rhi::TextureHandle texture = rhi::TextureHandle::Invalid;
 
   /**
    * Source image layout
    */
-  ImageLayout srcLayout{ImageLayout::Undefined};
+  rhi::ImageLayout srcLayout{rhi::ImageLayout::Undefined};
 
   /**
    * Destination image layout
    */
-  ImageLayout dstLayout{ImageLayout::Undefined};
+  rhi::ImageLayout dstLayout{rhi::ImageLayout::Undefined};
 };
 
 /**
@@ -64,29 +64,29 @@ struct RenderGraphPassBarrier {
   /**
    * Source pipeline stage
    */
-  PipelineStage srcStage{PipelineStage::None};
+  rhi::PipelineStage srcStage{rhi::PipelineStage::None};
 
   /**
    * Destination pipeline stage
    */
-  PipelineStage dstStage{PipelineStage::None};
+  rhi::PipelineStage dstStage{rhi::PipelineStage::None};
 
   /**
    * Memory barriers
    */
-  std::vector<MemoryBarrier> memoryBarriers;
+  std::vector<rhi::MemoryBarrier> memoryBarriers;
 
   /**
    * Image barriers
    */
-  std::vector<ImageBarrier> imageBarriers;
+  std::vector<rhi::ImageBarrier> imageBarriers;
 };
 
 /**
  * @brief Render graph pass
  */
 class RenderGraphPass {
-  using ExecutorFn = std::function<void(RenderCommandList &,
+  using ExecutorFn = std::function<void(rhi::RenderCommandList &,
                                         const RenderGraphRegistry &, uint32_t)>;
   friend RenderGraph;
   friend RenderGraphEvaluator;
@@ -140,7 +140,7 @@ public:
    * @param commandList Command list
    * @param frameIndex Frame index
    */
-  void execute(RenderCommandList &commandList, uint32_t frameIndex);
+  void execute(rhi::RenderCommandList &commandList, uint32_t frameIndex);
 
   /**
    * @brief Set output texture
@@ -148,14 +148,15 @@ public:
    * @param handle Texture handle
    * @param clearValue Clear value
    */
-  void write(TextureHandle handle, const AttachmentClearValue &clearValue);
+  void write(rhi::TextureHandle handle,
+             const rhi::AttachmentClearValue &clearValue);
 
   /**
    * @brief Set input texture
    *
    * @param handle Texture handle
    */
-  void read(TextureHandle handle);
+  void read(rhi::TextureHandle handle);
 
   /**
    * @brief Set executor function
@@ -170,7 +171,8 @@ public:
    * @param description Pipeline description
    * @return Virtual pipeline handle
    */
-  VirtualPipelineHandle addPipeline(const PipelineDescription &description);
+  VirtualPipelineHandle
+  addPipeline(const rhi::PipelineDescription &description);
 
   /**
    * @brief Get pass name
@@ -211,7 +213,7 @@ public:
    *
    * @return Pipelines
    */
-  inline const std::vector<PipelineHandle> &getPipelines() const {
+  inline const std::vector<rhi::PipelineHandle> &getPipelines() const {
     return mPipelines;
   }
 
@@ -220,7 +222,7 @@ public:
    *
    * @return Framebuffer
    */
-  inline FramebufferHandle getFramebuffer() const { return mFramebuffer; }
+  inline rhi::FramebufferHandle getFramebuffer() const { return mFramebuffer; }
 
   /**
    * @brief Get dimensions
@@ -251,7 +253,7 @@ private:
   std::vector<AttachmentData> mAttachments;
   std::vector<RenderTargetData> mOutputs;
   std::vector<RenderTargetData> mInputs;
-  std::vector<PipelineHandle> mPipelines;
+  std::vector<rhi::PipelineHandle> mPipelines;
 
   RenderGraphPassBarrier mPreBarrier;
   RenderGraphPassBarrier mPostBarrier;
@@ -259,7 +261,7 @@ private:
   ExecutorFn mExecutor;
 
   rhi::RenderPassHandle mRenderPass = rhi::RenderPassHandle::Invalid;
-  FramebufferHandle mFramebuffer = rhi::FramebufferHandle::Invalid;
+  rhi::FramebufferHandle mFramebuffer = rhi::FramebufferHandle::Invalid;
   glm::uvec3 mDimensions{};
 
   RenderGraphRegistry mRegistry;
@@ -267,4 +269,4 @@ private:
   String mName;
 };
 
-} // namespace liquid::rhi
+} // namespace liquid

--- a/engine/src/liquid/renderer/RenderGraphRegistry.cpp
+++ b/engine/src/liquid/renderer/RenderGraphRegistry.cpp
@@ -1,14 +1,14 @@
 #include "liquid/core/Base.h"
 #include "RenderGraphRegistry.h"
 
-namespace liquid::rhi {
+namespace liquid {
 
 VirtualPipelineHandle
-RenderGraphRegistry::set(const PipelineDescription &description) {
+RenderGraphRegistry::set(const rhi::PipelineDescription &description) {
   mDescriptions.push_back(description);
-  mRealResources.push_back(PipelineHandle::Invalid);
+  mRealResources.push_back(rhi::PipelineHandle::Invalid);
 
   return static_cast<VirtualPipelineHandle>(mDescriptions.size() - 1);
 }
 
-} // namespace liquid::rhi
+} // namespace liquid

--- a/engine/src/liquid/renderer/RenderGraphRegistry.h
+++ b/engine/src/liquid/renderer/RenderGraphRegistry.h
@@ -1,9 +1,9 @@
 #pragma once
 
-#include "RenderHandle.h"
-#include "PipelineDescription.h"
+#include "liquid/rhi/RenderHandle.h"
+#include "liquid/rhi/PipelineDescription.h"
 
-namespace liquid::rhi {
+namespace liquid {
 
 enum class VirtualPipelineHandle : size_t {};
 
@@ -23,7 +23,7 @@ public:
    * @param handle Virtual pipeline handle
    * @return Pipeline
    */
-  inline PipelineHandle get(VirtualPipelineHandle handle) const {
+  inline rhi::PipelineHandle get(VirtualPipelineHandle handle) const {
     return mRealResources.at(static_cast<size_t>(handle));
   }
 
@@ -33,11 +33,11 @@ public:
    * @param description Pipeline description
    * @return Virtual pipeline handle
    */
-  VirtualPipelineHandle set(const PipelineDescription &description);
+  VirtualPipelineHandle set(const rhi::PipelineDescription &description);
 
 private:
-  std::vector<PipelineDescription> mDescriptions;
-  std::vector<PipelineHandle> mRealResources;
+  std::vector<rhi::PipelineDescription> mDescriptions;
+  std::vector<rhi::PipelineHandle> mRealResources;
 };
 
-} // namespace liquid::rhi
+} // namespace liquid

--- a/engine/src/liquid/renderer/Renderer.cpp
+++ b/engine/src/liquid/renderer/Renderer.cpp
@@ -7,7 +7,7 @@
 
 #include "liquid/renderer/SceneRenderer.h"
 
-#include "liquid/rhi/RenderGraph.h"
+#include "liquid/renderer/RenderGraph.h"
 
 namespace liquid {
 
@@ -18,8 +18,7 @@ Renderer::Renderer(AssetRegistry &assetRegistry, Window &window,
       mAssetRegistry(assetRegistry),
       mSceneRenderer(mShaderLibrary, mAssetRegistry, device) {}
 
-void Renderer::render(rhi::RenderGraph &graph,
-                      rhi::RenderCommandList &commandList,
+void Renderer::render(RenderGraph &graph, rhi::RenderCommandList &commandList,
                       uint32_t frameIndex) {
   graph.compile(mDevice);
 

--- a/engine/src/liquid/renderer/Renderer.h
+++ b/engine/src/liquid/renderer/Renderer.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include "liquid/rhi/RenderDevice.h"
-#include "liquid/rhi/RenderGraphEvaluator.h"
+#include "liquid/renderer/RenderGraphEvaluator.h"
 #include "ShaderLibrary.h"
 #include "MaterialPBR.h"
 #include "SceneRenderer.h"
@@ -96,7 +96,7 @@ public:
    * @param commandList Render command list
    * @param frameIndex Frame index
    */
-  void render(rhi::RenderGraph &graph, rhi::RenderCommandList &commandList,
+  void render(RenderGraph &graph, rhi::RenderCommandList &commandList,
               uint32_t frameIndex);
 
   /**
@@ -105,7 +105,7 @@ public:
   inline void wait() { mDevice->waitForIdle(); }
 
 private:
-  rhi::RenderGraphEvaluator mGraphEvaluator;
+  RenderGraphEvaluator mGraphEvaluator;
   rhi::RenderDevice *mDevice;
   ShaderLibrary mShaderLibrary;
   AssetRegistry &mAssetRegistry;

--- a/engine/src/liquid/renderer/SceneRenderer.cpp
+++ b/engine/src/liquid/renderer/SceneRenderer.cpp
@@ -54,7 +54,7 @@ void SceneRenderer::setClearColor(const glm::vec4 &clearColor) {
   mClearColor = clearColor;
 }
 
-SceneRenderPassData SceneRenderer::attach(rhi::RenderGraph &graph) {
+SceneRenderPassData SceneRenderer::attach(RenderGraph &graph) {
   static constexpr uint32_t ShadowMapDimensions = 4096;
   static constexpr uint32_t SwapchainSizePercentage = 100;
 
@@ -107,7 +107,7 @@ SceneRenderPassData SceneRenderer::attach(rhi::RenderGraph &graph) {
 
     pass.setExecutor([vPipeline, vSkinnedPipeline, shadowmap,
                       this](rhi::RenderCommandList &commandList,
-                            const rhi::RenderGraphRegistry &registry,
+                            const RenderGraphRegistry &registry,
                             uint32_t frameIndex) {
       auto &frameData = mFrameData.at(frameIndex);
       rhi::Descriptor descriptor;
@@ -178,7 +178,7 @@ SceneRenderPassData SceneRenderer::attach(rhi::RenderGraph &graph) {
 
     pass.setExecutor([this, vPipeline, vSkinnedPipeline,
                       shadowmap](rhi::RenderCommandList &commandList,
-                                 const rhi::RenderGraphRegistry &registry,
+                                 const RenderGraphRegistry &registry,
                                  uint32_t frameIndex) {
       auto &frameData = mFrameData.at(frameIndex);
       auto pipeline = registry.get(vPipeline);
@@ -244,7 +244,7 @@ SceneRenderPassData SceneRenderer::attach(rhi::RenderGraph &graph) {
                                  rhi::FrontFace::Clockwise},
          rhi::PipelineColorBlend{{rhi::PipelineColorBlendAttachment{}}}});
     pass.setExecutor([vPipeline, this](rhi::RenderCommandList &commandList,
-                                       const rhi::RenderGraphRegistry &registry,
+                                       const RenderGraphRegistry &registry,
                                        uint32_t frameIndex) {
       auto &frameData = mFrameData.at(frameIndex);
       if (!rhi::isHandleValid(frameData.getIrradianceMap()))
@@ -282,7 +282,7 @@ SceneRenderPassData SceneRenderer::attach(rhi::RenderGraph &graph) {
   return SceneRenderPassData{sceneColor, depthBuffer};
 }
 
-void SceneRenderer::attachText(rhi::RenderGraph &graph,
+void SceneRenderer::attachText(RenderGraph &graph,
                                const SceneRenderPassData &passData) {
   auto &pass = graph.addPass("textPass");
   pass.write(passData.sceneColor, mClearColor);
@@ -300,21 +300,20 @@ void SceneRenderer::attachText(rhi::RenderGraph &graph,
           rhi::BlendOp::Add, rhi::BlendFactor::One,
           rhi::BlendFactor::OneMinusSrcAlpha, rhi::BlendOp::Add}}}});
 
-  pass.setExecutor(
-      [vTextPipeline, this](rhi::RenderCommandList &commandList,
-                            const rhi::RenderGraphRegistry &registry,
-                            uint32_t frameIndex) {
-        auto &frameData = mFrameData.at(frameIndex);
+  pass.setExecutor([vTextPipeline, this](rhi::RenderCommandList &commandList,
+                                         const RenderGraphRegistry &registry,
+                                         uint32_t frameIndex) {
+    auto &frameData = mFrameData.at(frameIndex);
 
-        auto textPipeline = registry.get(vTextPipeline);
+    auto textPipeline = registry.get(vTextPipeline);
 
-        commandList.bindPipeline(textPipeline);
-        rhi::Descriptor sceneDescriptor;
-        sceneDescriptor.bind(0, frameData.getActiveCameraBuffer(),
-                             rhi::DescriptorType::UniformBuffer);
-        commandList.bindDescriptor(textPipeline, 0, sceneDescriptor);
-        renderText(commandList, textPipeline, frameIndex);
-      });
+    commandList.bindPipeline(textPipeline);
+    rhi::Descriptor sceneDescriptor;
+    sceneDescriptor.bind(0, frameData.getActiveCameraBuffer(),
+                         rhi::DescriptorType::UniformBuffer);
+    commandList.bindDescriptor(textPipeline, 0, sceneDescriptor);
+    renderText(commandList, textPipeline, frameIndex);
+  });
 }
 
 void SceneRenderer::updateFrameData(EntityDatabase &entityDatabase,

--- a/engine/src/liquid/renderer/SceneRenderer.h
+++ b/engine/src/liquid/renderer/SceneRenderer.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include "liquid/rhi/RenderCommandList.h"
-#include "liquid/rhi/RenderGraph.h"
+#include "liquid/renderer/RenderGraph.h"
 #include "liquid/asset/AssetRegistry.h"
 #include "SceneRendererFrameData.h"
 #include "ShaderLibrary.h"
@@ -53,7 +53,7 @@ public:
    * @param graph Render graph
    * @return Scene render pass data
    */
-  SceneRenderPassData attach(rhi::RenderGraph &graph);
+  SceneRenderPassData attach(RenderGraph &graph);
 
   /**
    * @brief Attach text pass to render graph
@@ -61,7 +61,7 @@ public:
    * @param graph Render graph
    * @param passData Scene render pass data
    */
-  void attachText(rhi::RenderGraph &graph, const SceneRenderPassData &passData);
+  void attachText(RenderGraph &graph, const SceneRenderPassData &passData);
 
   /**
    * @brief Update frame data

--- a/engine/tests/liquid-tests/renderer/RenderGraph.test.cpp
+++ b/engine/tests/liquid-tests/renderer/RenderGraph.test.cpp
@@ -1,5 +1,5 @@
 #include "liquid/core/Base.h"
-#include "liquid/rhi/RenderGraph.h"
+#include "liquid/renderer/RenderGraph.h"
 
 #include "liquid-tests/mocks/MockRenderDevice.h"
 #include "liquid-tests/Testing.h"
@@ -11,7 +11,7 @@ public:
   RenderGraphTest() : graph("TestGraph") {}
 
   MockRenderDevice device;
-  liquid::rhi::RenderGraph graph;
+  liquid::RenderGraph graph;
 };
 
 class RenderGraphDeathTest : public RenderGraphTest {};

--- a/engine/tests/liquid-tests/renderer/RenderGraphPass.test.cpp
+++ b/engine/tests/liquid-tests/renderer/RenderGraphPass.test.cpp
@@ -1,19 +1,20 @@
 #include "liquid/core/Base.h"
-#include "liquid/rhi/RenderGraphPass.h"
+#include "liquid/renderer/RenderGraphPass.h"
 
 #include "liquid-tests/Testing.h"
 
 class RenderGraphPassTest : public ::testing::Test {
 public:
+  RenderGraphPassTest() : pass("Test") {}
+
+  liquid::RenderGraphPass pass;
 };
 
 TEST_F(RenderGraphPassTest, SetsNameOnConstruct) {
-  liquid::rhi::RenderGraphPass pass("Test");
   EXPECT_EQ(pass.getName(), "Test");
 }
 
 TEST_F(RenderGraphPassTest, AddsHandleToOutputOnWrite) {
-  liquid::rhi::RenderGraphPass pass("Test");
   liquid::rhi::TextureHandle handle{2};
 
   pass.write(handle, glm::vec4());
@@ -22,7 +23,6 @@ TEST_F(RenderGraphPassTest, AddsHandleToOutputOnWrite) {
 }
 
 TEST_F(RenderGraphPassTest, AddsClearValueToAttachmentDataOnWrite) {
-  liquid::rhi::RenderGraphPass pass("Test");
   liquid::rhi::TextureHandle handle{2};
 
   pass.write(handle, glm::vec4(2.0f));
@@ -38,7 +38,6 @@ TEST_F(RenderGraphPassTest, AddsClearValueToAttachmentDataOnWrite) {
 }
 
 TEST_F(RenderGraphPassTest, AddsHandleToInputOnRead) {
-  liquid::rhi::RenderGraphPass pass("Test");
   liquid::rhi::TextureHandle handle{2};
 
   pass.read(handle);

--- a/runtime/src/runtime/Runtime.cpp
+++ b/runtime/src/runtime/Runtime.cpp
@@ -45,7 +45,7 @@ void Runtime::start() {
   liquid::FPSCounter fpsCounter;
   liquid::MainLoop mainLoop(window, fpsCounter);
 
-  liquid::rhi::RenderGraph graph("Main");
+  liquid::RenderGraph graph("Main");
   liquid::Renderer renderer(assetCache.getRegistry(), window, device);
 
   static constexpr glm::vec4 BlueishClearValue{0.52f, 0.54f, 0.89f, 1.0f};


### PR DESCRIPTION
- Remove them from RHI namespace
- Update all uses of render graph in engine, editor, runtime, and tests