### PR TITLE
Create descriptor layout cache

### DIFF
--- a/engine/assets/shaders/pbr.frag
+++ b/engine/assets/shaders/pbr.frag
@@ -44,9 +44,18 @@ layout(std140, set = 2, binding = 2) readonly buffer LightData {
 }
 uLightData;
 
+/**
+ * @brief Single shadow data
+ */
 struct ShadowMapItem {
+  /**
+   * Shadow matrix generated from light
+   */
   mat4 shadowMatrix;
 
+  /**
+   * Shadow data
+   */
   vec4 shadowData;
 };
 

--- a/engine/assets/shaders/shadowmap-skinned.vert
+++ b/engine/assets/shaders/shadowmap-skinned.vert
@@ -46,7 +46,7 @@ struct ShadowMapItem {
 layout(std140, set = 0, binding = 0) readonly buffer ShadowMapData {
   ShadowMapItem items[];
 }
-uShadowMaps;
+uShadowMapData;
 
 /**
  * @brief Single object transforms
@@ -90,7 +90,7 @@ void main() {
                     inWeights.z * item.joints[inJoints.z] +
                     inWeights.w * item.joints[inJoints.w];
 
-  gl_Position = uShadowMaps.items[pcShadowRef.index.x].shadowMatrix *
+  gl_Position = uShadowMapData.items[pcShadowRef.index.x].shadowMatrix *
                 modelMatrix * skinMatrix * vec4(inPosition, 1.0);
   gl_Layer = pcShadowRef.index.x;
 }

--- a/engine/assets/shaders/shadowmap.vert
+++ b/engine/assets/shaders/shadowmap.vert
@@ -22,7 +22,7 @@ struct ShadowMapItem {
 layout(std140, set = 0, binding = 0) readonly buffer ShadowMapData {
   ShadowMapItem items[];
 }
-uShadowMaps;
+uShadowMapData;
 
 /**
  * @brief Single object transforms
@@ -45,7 +45,7 @@ pcShadowRef;
 void main() {
   mat4 modelMatrix = uObjectData.items[gl_InstanceIndex].modelMatrix;
 
-  gl_Position = uShadowMaps.items[pcShadowRef.index.x].shadowMatrix *
+  gl_Position = uShadowMapData.items[pcShadowRef.index.x].shadowMatrix *
                 modelMatrix * vec4(inPosition, 1.0);
   gl_Layer = pcShadowRef.index.x;
 }

--- a/engine/rhi/core/include/liquid/rhi/NativeResourceMetrics.h
+++ b/engine/rhi/core/include/liquid/rhi/NativeResourceMetrics.h
@@ -34,6 +34,13 @@ public:
    * @return Number of textures
    */
   virtual size_t getTexturesCount() const = 0;
+
+  /**
+   * @brief Get number of descriptors
+   *
+   * @return Number of descriptors
+   */
+  virtual size_t getDescriptorsCount() const = 0;
 };
 
 } // namespace liquid::rhi

--- a/engine/rhi/vulkan/include/liquid/rhi-vulkan/VulkanDescriptorManager.h
+++ b/engine/rhi/vulkan/include/liquid/rhi-vulkan/VulkanDescriptorManager.h
@@ -32,7 +32,7 @@ public:
   VulkanDescriptorManager &operator=(VulkanDescriptorManager &&) = delete;
 
   /**
-   * @brief Destroy desceriptor manager
+   * @brief Destroy descriptor manager
    */
   ~VulkanDescriptorManager();
 
@@ -48,6 +48,18 @@ public:
    */
   VkDescriptorSet getOrCreateDescriptor(const Descriptor &descriptor,
                                         VkDescriptorSetLayout layout);
+
+  /**
+   * @brief Get descriptor cache size
+   *
+   * @return Descriptor cache size
+   */
+  inline size_t getCacheSize() { return mDescriptorCache.size(); }
+
+  /**
+   * @brief Clear cache
+   */
+  void clear();
 
 private:
   /**

--- a/engine/rhi/vulkan/include/liquid/rhi-vulkan/VulkanPipeline.h
+++ b/engine/rhi/vulkan/include/liquid/rhi-vulkan/VulkanPipeline.h
@@ -2,6 +2,7 @@
 
 #include "liquid/rhi-vulkan/VulkanDeviceObject.h"
 #include "liquid/rhi-vulkan/VulkanResourceRegistry.h"
+#include "liquid/rhi-vulkan/VulkanPipelineLayoutCache.h"
 
 #include "liquid/rhi/PipelineDescription.h"
 
@@ -20,10 +21,12 @@ public:
    * @param description Pipeline description
    * @param device Vulkan device
    * @param registry Resource registry
+   * @param pipelineLayoutCache Pipeline layout cache
    */
   VulkanPipeline(const PipelineDescription &description,
                  VulkanDeviceObject &device,
-                 const VulkanResourceRegistry &registry);
+                 const VulkanResourceRegistry &registry,
+                 VulkanPipelineLayoutCache &pipelineLayoutCache);
 
   /**
    * @brief Destructor

--- a/engine/rhi/vulkan/include/liquid/rhi-vulkan/VulkanPipelineLayoutCache.h
+++ b/engine/rhi/vulkan/include/liquid/rhi-vulkan/VulkanPipelineLayoutCache.h
@@ -1,0 +1,70 @@
+#pragma once
+
+#include "VulkanDeviceObject.h"
+#include "VulkanShader.h"
+
+namespace liquid::rhi {
+
+/**
+ * @brief Vulkan pipeline layout cache
+ *
+ * Stores references to descriptor and
+ * pipeline layouts and reuses descriptor
+ * or pipeline layouts if the provided
+ * create information matches what's
+ * already in the cache
+ */
+class VulkanPipelineLayoutCache {
+public:
+  /**
+   * @brief Create Vulkan pipeline layout cache
+   *
+   * @param device Vulkan device
+   */
+  VulkanPipelineLayoutCache(VulkanDeviceObject &device);
+
+  VulkanPipelineLayoutCache(const VulkanPipelineLayoutCache &) = delete;
+  VulkanPipelineLayoutCache(VulkanPipelineLayoutCache &&) = delete;
+  VulkanPipelineLayoutCache &
+  operator=(const VulkanPipelineLayoutCache &) = delete;
+  VulkanPipelineLayoutCache &operator=(VulkanPipelineLayoutCache &&) = delete;
+
+  /**
+   * @brief Destroy pipeline layout cache
+   */
+  ~VulkanPipelineLayoutCache();
+
+  /**
+   * @brief Get or create descriptor layout
+   *
+   * @param info Descriptor set layout create info
+   * @return Vulkan descriptor set layout
+   */
+  VkDescriptorSetLayout getOrCreateDescriptorLayout(
+      const VulkanShader::ReflectionDescriptorSetLayout &info);
+
+  /**
+   * @brief Clear pipeline layout cache
+   */
+  void clear();
+
+private:
+  /**
+   * @brief Create desctiptor set layout
+   *
+   * @param info Descriptor set layout create info
+   * @return Vulkan descriptor set layout
+   */
+  VkDescriptorSetLayout createDescriptorLayout(
+      const VulkanShader::ReflectionDescriptorSetLayout &info);
+
+private:
+  VulkanDeviceObject &mDevice;
+
+  std::vector<VulkanShader::ReflectionDescriptorSetLayout>
+      mDescriptorSetLayoutData;
+
+  std::vector<VkDescriptorSetLayout> mDescriptorSetLayouts;
+};
+
+} // namespace liquid::rhi

--- a/engine/rhi/vulkan/include/liquid/rhi-vulkan/VulkanRenderDevice.h
+++ b/engine/rhi/vulkan/include/liquid/rhi-vulkan/VulkanRenderDevice.h
@@ -12,6 +12,7 @@
 #include "VulkanResourceAllocator.h"
 #include "VulkanResourceRegistry.h"
 #include "VulkanCommandPool.h"
+#include "VulkanPipelineLayoutCache.h"
 #include "VulkanDescriptorManager.h"
 #include "VulkanSwapchain.h"
 
@@ -189,6 +190,7 @@ private:
   VulkanFrameManager mFrameManager;
   VulkanResourceAllocator mAllocator;
   VulkanResourceRegistry mRegistry;
+  VulkanPipelineLayoutCache mPipelineLayoutCache;
   VulkanDescriptorManager mDescriptorManager;
   VulkanCommandPool mCommandPool;
   VulkanRenderContext mRenderContext;

--- a/engine/rhi/vulkan/include/liquid/rhi-vulkan/VulkanResourceMetrics.h
+++ b/engine/rhi/vulkan/include/liquid/rhi-vulkan/VulkanResourceMetrics.h
@@ -2,6 +2,7 @@
 
 #include "liquid/rhi/NativeResourceMetrics.h"
 #include "VulkanResourceRegistry.h"
+#include "VulkanDescriptorManager.h"
 
 namespace liquid::rhi {
 
@@ -14,39 +15,49 @@ public:
    * @brief Create Vulkan resource metrics
    *
    * @param registry Vulkan resource registry
+   * @param descriptorManager Descriptor manager
    */
-  VulkanResourceMetrics(VulkanResourceRegistry &registry);
+  VulkanResourceMetrics(VulkanResourceRegistry &registry,
+                        VulkanDescriptorManager &descriptorManager);
 
   /**
    * @brief Get size of all the buffers
    *
    * @return Total buffer size
    */
-  size_t getTotalBufferSize() const;
+  size_t getTotalBufferSize() const override;
 
   /**
    * @brief Get number of buffers
    *
    * @return Number of buffers
    */
-  size_t getBuffersCount() const;
+  size_t getBuffersCount() const override;
 
   /**
    * @brief Get size of all the textures
    *
    * @return Total texture size
    */
-  size_t getTotalTextureSize() const;
+  size_t getTotalTextureSize() const override;
 
   /**
    * @brief Get number of textures
    *
    * @return Number of textures
    */
-  size_t getTexturesCount() const;
+  size_t getTexturesCount() const override;
+
+  /**
+   * @brief Get number of descriptors
+   *
+   * @return Descriptors
+   */
+  size_t getDescriptorsCount() const override;
 
 private:
   VulkanResourceRegistry &mRegistry;
+  VulkanDescriptorManager &mDescriptorManager;
 };
 
 } // namespace liquid::rhi

--- a/engine/rhi/vulkan/include/liquid/rhi-vulkan/VulkanShader.h
+++ b/engine/rhi/vulkan/include/liquid/rhi-vulkan/VulkanShader.h
@@ -11,6 +11,22 @@ namespace liquid::rhi {
  * @brief Vulkan shader
  */
 class VulkanShader {
+public:
+  /**
+   * @brief Shader reflection descriptor set layout data
+   */
+  struct ReflectionDescriptorSetLayout {
+    /**
+     * Binding names
+     */
+    std::vector<String> names;
+
+    /**
+     * Bindings
+     */
+    std::vector<VkDescriptorSetLayoutBinding> bindings;
+  };
+
   /**
    * @brief Shader reflection data
    */
@@ -23,8 +39,7 @@ class VulkanShader {
     /**
      * Descriptor set layouts
      */
-    std::map<uint32_t, std::vector<VkDescriptorSetLayoutBinding>>
-        descriptorSetLayouts;
+    std::map<uint32_t, ReflectionDescriptorSetLayout> descriptorSetLayouts;
   };
 
 public:

--- a/engine/rhi/vulkan/src/VulkanDescriptorManager.cpp
+++ b/engine/rhi/vulkan/src/VulkanDescriptorManager.cpp
@@ -43,6 +43,12 @@ VulkanDescriptorManager::getOrCreateDescriptor(const Descriptor &descriptor,
   return (*found).second;
 }
 
+void VulkanDescriptorManager::clear() {
+  vkResetDescriptorPool(mDevice, mDescriptorPool, 0);
+
+  mDescriptorCache.clear();
+}
+
 VkDescriptorSet
 VulkanDescriptorManager::createDescriptorSet(const Descriptor &descriptor,
                                              VkDescriptorSetLayout layout) {

--- a/engine/rhi/vulkan/src/VulkanPipelineLayoutCache.cpp
+++ b/engine/rhi/vulkan/src/VulkanPipelineLayoutCache.cpp
@@ -1,0 +1,94 @@
+#include "liquid/core/Base.h"
+
+#include <vulkan/vulkan.hpp>
+
+#include "VulkanPipelineLayoutCache.h"
+#include "VulkanError.h"
+
+namespace liquid::rhi {
+
+/**
+ * @brief Check if two descriptor set bindings match
+ *
+ * @param a First binding
+ * @param b Second binding
+ * @retval true Bindings match
+ * @retval false Bindings do not match
+ */
+static bool bindingsMatch(const VkDescriptorSetLayoutBinding &a,
+                          const VkDescriptorSetLayoutBinding &b) {
+  return (a.binding == b.binding) && (a.descriptorCount == b.descriptorCount) &&
+         (a.descriptorType == b.descriptorType) &&
+         (a.stageFlags == b.stageFlags);
+}
+
+VulkanPipelineLayoutCache::VulkanPipelineLayoutCache(VulkanDeviceObject &device)
+    : mDevice(device) {}
+
+VkDescriptorSetLayout VulkanPipelineLayoutCache::getOrCreateDescriptorLayout(
+    const VulkanShader::ReflectionDescriptorSetLayout &info) {
+
+  for (size_t i = 0; i < mDescriptorSetLayoutData.size(); ++i) {
+    const auto &existingInfo = mDescriptorSetLayoutData.at(i);
+    if (existingInfo.bindings.size() != info.bindings.size()) {
+      continue;
+    }
+
+    bool matches = true;
+    for (size_t li = 0; li < info.bindings.size() && matches; ++li) {
+      matches =
+          bindingsMatch(info.bindings.at(li), existingInfo.bindings.at(li));
+    }
+
+    if (matches) {
+      return mDescriptorSetLayouts.at(i);
+    }
+  }
+
+  VkDescriptorSetLayout layout = createDescriptorLayout(info);
+  mDescriptorSetLayoutData.push_back(info);
+  mDescriptorSetLayouts.push_back(layout);
+
+  return layout;
+}
+
+VulkanPipelineLayoutCache::~VulkanPipelineLayoutCache() { clear(); }
+
+void VulkanPipelineLayoutCache::clear() {
+  for (VkDescriptorSetLayout layout : mDescriptorSetLayouts) {
+    vkDestroyDescriptorSetLayout(mDevice, layout, nullptr);
+  }
+
+  mDescriptorSetLayouts.clear();
+  mDescriptorSetLayoutData.clear();
+}
+
+VkDescriptorSetLayout VulkanPipelineLayoutCache::createDescriptorLayout(
+    const VulkanShader::ReflectionDescriptorSetLayout &info) {
+  std::vector<VkDescriptorBindingFlags> bindingFlags(
+      info.bindings.size(), VK_DESCRIPTOR_BINDING_PARTIALLY_BOUND_BIT);
+
+  VkDescriptorSetLayoutBindingFlagsCreateInfoEXT bindingFlagsCreateInfo{};
+  bindingFlagsCreateInfo.sType =
+      VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_BINDING_FLAGS_CREATE_INFO_EXT;
+  bindingFlagsCreateInfo.pNext = nullptr;
+  bindingFlagsCreateInfo.pBindingFlags = bindingFlags.data();
+  bindingFlagsCreateInfo.bindingCount =
+      static_cast<uint32_t>(bindingFlags.size());
+
+  VkDescriptorSetLayout layout = VK_NULL_HANDLE;
+  VkDescriptorSetLayoutCreateInfo createInfo{};
+  createInfo.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO;
+  createInfo.flags = 0;
+  createInfo.pNext = &bindingFlagsCreateInfo;
+  createInfo.bindingCount = static_cast<uint32_t>(info.bindings.size());
+  createInfo.pBindings = info.bindings.data();
+
+  checkForVulkanError(
+      vkCreateDescriptorSetLayout(mDevice, &createInfo, nullptr, &layout),
+      "Failed to create descriptor set layout");
+
+  return layout;
+}
+
+} // namespace liquid::rhi

--- a/engine/rhi/vulkan/src/VulkanResourceMetrics.cpp
+++ b/engine/rhi/vulkan/src/VulkanResourceMetrics.cpp
@@ -5,8 +5,10 @@
 
 namespace liquid::rhi {
 
-VulkanResourceMetrics::VulkanResourceMetrics(VulkanResourceRegistry &registry)
-    : mRegistry(registry) {}
+VulkanResourceMetrics::VulkanResourceMetrics(
+    VulkanResourceRegistry &registry,
+    VulkanDescriptorManager &descriptorManager)
+    : mRegistry(registry), mDescriptorManager(descriptorManager) {}
 
 size_t VulkanResourceMetrics::getTotalBufferSize() const {
   size_t size = 0;
@@ -34,6 +36,10 @@ size_t VulkanResourceMetrics::getTotalTextureSize() const {
 
 size_t VulkanResourceMetrics::getTexturesCount() const {
   return mRegistry.getTextures().size();
+}
+
+size_t VulkanResourceMetrics::getDescriptorsCount() const {
+  return mDescriptorManager.getCacheSize();
 }
 
 } // namespace liquid::rhi

--- a/engine/rhi/vulkan/src/VulkanShader.cpp
+++ b/engine/rhi/vulkan/src/VulkanShader.cpp
@@ -115,6 +115,7 @@ void VulkanShader::createReflectionInfo(const std::vector<char> &bytes) {
 
         std::vector<VkDescriptorSetLayoutBinding> bindings(
             reflectDescriptorSet.binding_count);
+        std::vector<String> names(bindings.size());
 
         for (uint32_t i = 0; i < reflectDescriptorSet.binding_count; ++i) {
           // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-constant-array-index)
@@ -130,8 +131,18 @@ void VulkanShader::createReflectionInfo(const std::vector<char> &bytes) {
             // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-constant-array-index)
             bindings.at(i).descriptorCount *= reflectBinding->array.dims[j];
           }
+
+          names.at(i) = reflectBinding->name;
         }
-        mReflectionData.descriptorSetLayouts.insert({ds->set, bindings});
+
+        std::sort(bindings.begin(), bindings.end(),
+                  [](const VkDescriptorSetLayoutBinding &a,
+                     const VkDescriptorSetLayoutBinding &b) {
+                    return a.binding < b.binding;
+                  });
+
+        mReflectionData.descriptorSetLayouts.insert(
+            {ds->set, {names, bindings}});
       }
     }
   }

--- a/engine/src/liquid/profiler/ImguiDebugLayer.cpp
+++ b/engine/src/liquid/profiler/ImguiDebugLayer.cpp
@@ -108,6 +108,10 @@ void ImguiDebugLayer::renderUsageMetrics() {
                    std::to_string(mDeviceStats.getDrawnPrimitivesCount()));
     renderTableRow("Number of command calls",
                    std::to_string(mDeviceStats.getCommandCallsCount()));
+    renderTableRow(
+        "Number of descriptors",
+        std::to_string(
+            mDeviceStats.getResourceMetrics()->getDescriptorsCount()));
 
     ImGui::EndTable();
   }


### PR DESCRIPTION
- Create pipeline layout class that currently stores descriptor layouts
- Cache and retrieve descriptor layouts if they are already created
- Show number of descriptors in usage metrics
- Update shader variable names