### PR TITLE
Create bindless textures descriptor

### DIFF
--- a/engine/assets/shaders/imgui.frag
+++ b/engine/assets/shaders/imgui.frag
@@ -1,10 +1,17 @@
 #version 450 core
+#extension GL_EXT_nonuniform_qualifier : enable
 
 layout(location = 0) in vec4 inColor;
 layout(location = 1) in vec2 inTexCoord;
 
 layout(location = 0) out vec4 outColor;
 
-layout(set = 0, binding = 0) uniform sampler2D uTexture;
+layout(set = 0, binding = 0) uniform sampler2D uGlobalTextures[];
 
-void main() { outColor = inColor * texture(uTexture, inTexCoord); }
+layout(push_constant) uniform TextureData { layout(offset = 64) uint index; }
+pcTextureData;
+
+void main() {
+  outColor =
+      inColor * texture(uGlobalTextures[pcTextureData.index], inTexCoord);
+}

--- a/engine/assets/shaders/pbr.frag
+++ b/engine/assets/shaders/pbr.frag
@@ -1,5 +1,6 @@
 #version 450
 #extension GL_ARB_separate_shader_objects : enable
+#extension GL_EXT_nonuniform_qualifier : enable
 
 layout(location = 0) in vec3 inWorldPosition;
 layout(location = 1) in vec2 inTextureCoord[2];
@@ -214,7 +215,7 @@ MaterialData uMaterialData = MaterialData(
     uMaterialDataRaw.occlusionStrength[0], uMaterialDataRaw.emissiveTexture[0],
     uMaterialDataRaw.emissiveTextureCoord[0], uMaterialDataRaw.emissiveFactor);
 
-layout(set = 3, binding = 1) uniform sampler2D uTextures[8];
+layout(set = 4, binding = 0) uniform sampler2D uGlobalTextures[];
 
 const float PI = 3.141592653589793;
 const mat4 DepthBiasMatrix = mat4(0.5, 0.0, 0.0, 0.0, 0.0, 0.5, 0.0, 0.0, 0.0,
@@ -325,7 +326,7 @@ vec3 getNormal() {
   }
 
   if (uMaterialData.normalTexture >= 0) {
-    vec3 n = texture(uTextures[uMaterialData.normalTexture],
+    vec3 n = texture(uGlobalTextures[uMaterialData.normalTexture],
                      inTextureCoord[uMaterialData.normalTextureCoord])
                  .rgb *
              uMaterialData.normalScale;
@@ -453,7 +454,7 @@ void main() {
 
   if (uMaterialData.metallicRoughnessTexture >= 0) {
     vec3 mrSample =
-        texture(uTextures[uMaterialData.metallicRoughnessTexture],
+        texture(uGlobalTextures[uMaterialData.metallicRoughnessTexture],
                 inTextureCoord[uMaterialData.metallicRoughnessTextureCoord])
             .xyz;
     roughness *= mrSample.g;
@@ -467,7 +468,7 @@ void main() {
   if (uMaterialData.baseColorTexture >= 0) {
     baseColor =
         srgbToLinear(
-            texture(uTextures[uMaterialData.baseColorTexture],
+            texture(uGlobalTextures[uMaterialData.baseColorTexture],
                     inTextureCoord[uMaterialData.baseColorTextureCoord]))
             .xyzw *
         uMaterialData.baseColorFactor;
@@ -531,7 +532,7 @@ void main() {
   }
 
   if (uMaterialData.occlusionTexture >= 0) {
-    float ao = texture(uTextures[uMaterialData.occlusionTexture],
+    float ao = texture(uGlobalTextures[uMaterialData.occlusionTexture],
                        inTextureCoord[uMaterialData.occlusionTextureCoord])
                    .r;
     color = mix(color, color * ao, uMaterialData.occlusionStrength);
@@ -540,7 +541,7 @@ void main() {
   if (uMaterialData.emissiveTexture >= 0) {
     vec3 emissive =
         srgbToLinear(
-            texture(uTextures[uMaterialData.emissiveTexture],
+            texture(uGlobalTextures[uMaterialData.emissiveTexture],
                     inTextureCoord[uMaterialData.emissiveTextureCoord]))
             .rgb *
         uMaterialData.emissiveFactor;

--- a/engine/assets/shaders/text.frag
+++ b/engine/assets/shaders/text.frag
@@ -1,23 +1,28 @@
 #version 450
 #extension GL_ARB_separate_shader_objects : enable
+#extension GL_EXT_nonuniform_qualifier : enable
 
 layout(location = 0) in vec2 texCoord;
 layout(location = 0) out vec4 outColor;
 
-layout(set = 3, binding = 0) uniform sampler2D uFontAtlas;
+layout(set = 3, binding = 0) uniform sampler2D uGlobalTextures[];
+
+layout(push_constant) uniform TextureData { layout(offset = 16) uint index; }
+pcTextureData;
 
 float median(vec3 msd) {
   return max(min(msd.r, msd.g), min(max(msd.r, msd.g), msd.b));
 }
 
 float screenPxRange() {
-  vec2 unitRange = vec2(2.0) / vec2(textureSize(uFontAtlas, 0));
+  vec2 unitRange =
+      vec2(2.0) / vec2(textureSize(uGlobalTextures[pcTextureData.index], 0));
   vec2 screenTexSize = vec2(1.0) / fwidth(texCoord);
   return max(0.5 * dot(unitRange, screenTexSize), 1.0);
 }
 
 void main() {
-  vec3 msd = texture(uFontAtlas, texCoord).rgb;
+  vec3 msd = texture(uGlobalTextures[pcTextureData.index], texCoord).rgb;
   float sd = median(msd);
   float screenPxDistance = screenPxRange() * (sd - 0.5);
   float opacity = clamp(screenPxDistance + 0.5, 0.0, 1.0);

--- a/engine/rhi/core/include/liquid/rhi/Descriptor.h
+++ b/engine/rhi/core/include/liquid/rhi/Descriptor.h
@@ -8,6 +8,9 @@ enum class DescriptorType {
   UniformBuffer,
   StorageBuffer,
   CombinedImageSampler,
+
+  // Bindless textures
+  GlobalTextures
 };
 
 /**
@@ -55,6 +58,15 @@ public:
    * @return Current object
    */
   Descriptor &bind(uint32_t binding, BufferHandle buffer, DescriptorType type);
+
+  /**
+   * @brief Bind global textures
+   *
+   * Bindless textures
+   *
+   * @return Current object
+   */
+  Descriptor &bindGlobalTextures();
 
   /**
    * @brief Get bindings

--- a/engine/rhi/core/src/Descriptor.cpp
+++ b/engine/rhi/core/src/Descriptor.cpp
@@ -35,4 +35,9 @@ Descriptor &Descriptor::bind(uint32_t binding, BufferHandle buffer,
   return *this;
 }
 
+Descriptor &Descriptor::bindGlobalTextures() {
+  bindings.insert({0, DescriptorBinding{DescriptorType::GlobalTextures}});
+  return *this;
+}
+
 } // namespace liquid::rhi

--- a/engine/rhi/vulkan/include/liquid/rhi-vulkan/VulkanDescriptorManager.h
+++ b/engine/rhi/vulkan/include/liquid/rhi-vulkan/VulkanDescriptorManager.h
@@ -61,6 +61,22 @@ public:
    */
   void clear();
 
+  /**
+   * @brief Create global textures descriptor set
+   *
+   * Bindless textures
+   *
+   * @param layout Global texture descriptor set layout
+   */
+  void createGlobalTexturesDescriptorSet(VkDescriptorSetLayout layout);
+
+  /**
+   * @brief Add global texture to global textures descriptor
+   *
+   * @param handle Texture handle
+   */
+  void addGlobalTexture(rhi::TextureHandle handle);
+
 private:
   /**
    * @brief Create descriptor set
@@ -100,6 +116,8 @@ private:
   VkDevice mDevice;
 
   const rhi::VulkanResourceRegistry &mRegistry;
+
+  VkDescriptorSet mGlobalTexturesDescriptorSet = VK_NULL_HANDLE;
 };
 
 } // namespace liquid::rhi

--- a/engine/rhi/vulkan/include/liquid/rhi-vulkan/VulkanPipelineLayoutCache.h
+++ b/engine/rhi/vulkan/include/liquid/rhi-vulkan/VulkanPipelineLayoutCache.h
@@ -48,15 +48,40 @@ public:
    */
   void clear();
 
+  /**
+   * @brief Get global textures descriptor set layout
+   *
+   * Bindless textures
+   *
+   * @return Global textures descriptor set layout
+   **/
+  inline VkDescriptorSetLayout getGlobalTexturesDescriptorSetLayout() {
+    return mDescriptorSetLayouts.at(0);
+  }
+
 private:
   /**
    * @brief Create desctiptor set layout
    *
    * @param info Descriptor set layout create info
+   * @param flags Descriptor binding flags
    * @return Vulkan descriptor set layout
    */
   VkDescriptorSetLayout createDescriptorLayout(
-      const VulkanShader::ReflectionDescriptorSetLayout &info);
+      const VulkanShader::ReflectionDescriptorSetLayout &info,
+      VkDescriptorBindingFlags flags);
+
+  /**
+   * @brief Create global textures descriptor layout
+   *
+   * Bindless textures
+   */
+  void createGlobalTexturesDescriptorLayout();
+
+  /**
+   * @brief Destroy all decriptor layouts
+   */
+  void destroyAllDescriptorLayouts();
 
 private:
   VulkanDeviceObject &mDevice;

--- a/engine/rhi/vulkan/src/VulkanDescriptorManager.cpp
+++ b/engine/rhi/vulkan/src/VulkanDescriptorManager.cpp
@@ -29,6 +29,12 @@ VulkanDescriptorManager::~VulkanDescriptorManager() {
 VkDescriptorSet
 VulkanDescriptorManager::getOrCreateDescriptor(const Descriptor &descriptor,
                                                VkDescriptorSetLayout layout) {
+  // Bindless textures
+  if (descriptor.getBindings().size() == 1 &&
+      descriptor.getBindings().at(0).type == DescriptorType::GlobalTextures) {
+    return mGlobalTexturesDescriptorSet;
+  }
+
   const String &hash = createHash(descriptor, layout);
   const auto &found = mDescriptorCache.find(hash);
 
@@ -47,6 +53,62 @@ void VulkanDescriptorManager::clear() {
   vkResetDescriptorPool(mDevice, mDescriptorPool, 0);
 
   mDescriptorCache.clear();
+}
+
+void VulkanDescriptorManager::createGlobalTexturesDescriptorSet(
+    VkDescriptorSetLayout layout) {
+  static constexpr uint32_t NumSamplers = 1000;
+
+  std::array<uint32_t, 1> dynamicDescriptorSetCounts{NumSamplers};
+
+  VkDescriptorSetVariableDescriptorCountAllocateInfo countInfo{};
+  countInfo.sType =
+      VK_STRUCTURE_TYPE_DESCRIPTOR_SET_VARIABLE_DESCRIPTOR_COUNT_ALLOCATE_INFO;
+  countInfo.pNext = nullptr;
+  countInfo.descriptorSetCount =
+      static_cast<uint32_t>(dynamicDescriptorSetCounts.size());
+  countInfo.pDescriptorCounts = dynamicDescriptorSetCounts.data();
+
+  VkDescriptorSetAllocateInfo descriptorSetAllocateInfo{};
+  descriptorSetAllocateInfo.sType =
+      VK_STRUCTURE_TYPE_DESCRIPTOR_SET_ALLOCATE_INFO;
+  descriptorSetAllocateInfo.pNext = &countInfo;
+  descriptorSetAllocateInfo.descriptorPool = mDescriptorPool;
+  descriptorSetAllocateInfo.pSetLayouts = &layout;
+  descriptorSetAllocateInfo.descriptorSetCount = 1;
+
+  checkForVulkanError(vkAllocateDescriptorSets(mDevice,
+                                               &descriptorSetAllocateInfo,
+                                               &mGlobalTexturesDescriptorSet),
+                      "Failed to allocate global textures descriptor set");
+}
+
+void VulkanDescriptorManager::addGlobalTexture(rhi::TextureHandle handle) {
+  VkWriteDescriptorSet write{};
+  write.sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET;
+  write.pNext = nullptr;
+  write.dstBinding = 0;
+  write.dstSet = mGlobalTexturesDescriptorSet;
+  write.dstArrayElement = static_cast<uint32_t>(handle);
+  write.descriptorCount = 1;
+  write.pBufferInfo = nullptr;
+  write.pTexelBufferView = nullptr;
+  write.descriptorType =
+      VulkanMapping::getDescriptorType(DescriptorType::CombinedImageSampler);
+
+  const auto &texture = mRegistry.getTextures().at(handle);
+
+  std::array<VkDescriptorImageInfo, 1> imageInfo{};
+  imageInfo.at(0).sampler = texture->getSampler();
+  imageInfo.at(0).imageView = texture->getImageView();
+  imageInfo.at(0).imageLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
+
+  write.pImageInfo = imageInfo.data();
+
+  std::array<VkWriteDescriptorSet, 1> writes{write};
+
+  vkUpdateDescriptorSets(mDevice, static_cast<uint32_t>(writes.size()),
+                         writes.data(), 0, nullptr);
 }
 
 VkDescriptorSet
@@ -156,7 +218,7 @@ void VulkanDescriptorManager::createDescriptorPool() {
   VkDescriptorPoolCreateInfo descriptorPoolInfo{};
   descriptorPoolInfo.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_POOL_CREATE_INFO;
   descriptorPoolInfo.pNext = nullptr;
-  descriptorPoolInfo.flags = 0;
+  descriptorPoolInfo.flags = VK_DESCRIPTOR_POOL_CREATE_UPDATE_AFTER_BIND_BIT;
   descriptorPoolInfo.maxSets = NumDescriptors;
   descriptorPoolInfo.poolSizeCount = static_cast<uint32_t>(poolSizes.size());
   descriptorPoolInfo.pPoolSizes = poolSizes.data();

--- a/engine/rhi/vulkan/src/VulkanDeviceObject.cpp
+++ b/engine/rhi/vulkan/src/VulkanDeviceObject.cpp
@@ -46,19 +46,6 @@ VulkanDeviceObject::VulkanDeviceObject(
   Engine::getLogger().info()
       << "Vulkan extension enabled: " << VK_KHR_SWAPCHAIN_EXTENSION_NAME;
 
-  extensions.push_back(VK_EXT_DESCRIPTOR_INDEXING_EXTENSION_NAME);
-  Engine::getLogger().info() << "Vulkan extension enabled: "
-                             << VK_EXT_DESCRIPTOR_INDEXING_EXTENSION_NAME;
-
-  extensions.push_back(VK_EXT_SHADER_VIEWPORT_INDEX_LAYER_EXTENSION_NAME);
-  Engine::getLogger().info()
-      << "Vulkan extension enabled: "
-      << VK_EXT_SHADER_VIEWPORT_INDEX_LAYER_EXTENSION_NAME;
-
-  extensions.push_back(VK_KHR_SHADER_DRAW_PARAMETERS_EXTENSION_NAME);
-  Engine::getLogger().info() << "Vulkan extension enabled: "
-                             << VK_KHR_SHADER_DRAW_PARAMETERS_EXTENSION_NAME;
-
   const auto &portabilityExt = std::find_if(
       pdExtensions.cbegin(), pdExtensions.cend(), [](const auto &ext) {
         return String(static_cast<const char *>(ext.extensionName)) ==
@@ -79,11 +66,15 @@ VulkanDeviceObject::VulkanDeviceObject(
   queryResetFeatures.pNext = nullptr;
   queryResetFeatures.hostQueryReset = VK_TRUE;
 
-  VkPhysicalDeviceDescriptorIndexingFeaturesEXT descriptorIndexingFeatures{};
+  VkPhysicalDeviceDescriptorIndexingFeatures descriptorIndexingFeatures{};
   descriptorIndexingFeatures.sType =
-      VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DESCRIPTOR_INDEXING_FEATURES_EXT;
+      VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DESCRIPTOR_INDEXING_FEATURES;
   descriptorIndexingFeatures.pNext = &queryResetFeatures;
   descriptorIndexingFeatures.descriptorBindingPartiallyBound = true;
+  descriptorIndexingFeatures.runtimeDescriptorArray = true;
+  descriptorIndexingFeatures.descriptorBindingVariableDescriptorCount = true;
+  descriptorIndexingFeatures.descriptorBindingSampledImageUpdateAfterBind =
+      true;
 
   auto &features = physicalDevice.getFeatures();
 

--- a/engine/src/liquid/renderer/Material.cpp
+++ b/engine/src/liquid/renderer/Material.cpp
@@ -23,8 +23,6 @@ Material::Material(const std::vector<rhi::TextureHandle> &textures,
     mDescriptor.bind(0, mBuffer.getHandle(),
                      rhi::DescriptorType::UniformBuffer);
   }
-
-  mDescriptor.bind(1, mTextures, rhi::DescriptorType::CombinedImageSampler);
 }
 
 void Material::updateProperty(StringView name, const Property &value) {

--- a/engine/src/liquid/renderer/MaterialPBR.cpp
+++ b/engine/src/liquid/renderer/MaterialPBR.cpp
@@ -31,15 +31,22 @@ MaterialPBR::Properties::getTextures() const {
 
 const std::vector<std::pair<String, Property>>
 MaterialPBR::Properties::getProperties() const {
-  int index = 0;
-  int baseColorTextureIndex =
-      rhi::isHandleValid(baseColorTexture) ? index++ : -1;
+  int baseColorTextureIndex = rhi::isHandleValid(baseColorTexture)
+                                  ? static_cast<int32_t>(baseColorTexture)
+                                  : -1;
   int metallicRoughnessTextureIndex =
-      rhi::isHandleValid(metallicRoughnessTexture) ? index++ : -1;
-  int normalTextureIndex = rhi::isHandleValid(normalTexture) ? index++ : -1;
-  int occlusionTextureIndex =
-      rhi::isHandleValid(occlusionTexture) ? index++ : -1;
-  int emissiveTextureIndex = rhi::isHandleValid(emissiveTexture) ? index++ : -1;
+      rhi::isHandleValid(metallicRoughnessTexture)
+          ? static_cast<int32_t>(metallicRoughnessTexture)
+          : -1;
+  int normalTextureIndex = rhi::isHandleValid(normalTexture)
+                               ? static_cast<int32_t>(normalTexture)
+                               : -1;
+  int occlusionTextureIndex = rhi::isHandleValid(occlusionTexture)
+                                  ? static_cast<int32_t>(occlusionTexture)
+                                  : -1;
+  int emissiveTextureIndex = rhi::isHandleValid(emissiveTexture)
+                                 ? static_cast<int32_t>(emissiveTexture)
+                                 : -1;
 
   return {{"baseColorTexture", baseColorTextureIndex},
           {"baseColorTextureCoord", baseColorTextureCoord},

--- a/engine/tests/liquid-tests/renderer/Material.test.cpp
+++ b/engine/tests/liquid-tests/renderer/Material.test.cpp
@@ -33,8 +33,6 @@ TEST_F(MaterialTest, SetsBuffersAndTextures) {
 
   EXPECT_EQ(material.getDescriptor().getBindings().at(0).type,
             liquid::rhi::DescriptorType::UniformBuffer);
-  EXPECT_EQ(material.getDescriptor().getBindings().at(1).type,
-            liquid::rhi::DescriptorType::CombinedImageSampler);
 
   const char *data = static_cast<const char *>(buffer.getData());
 
@@ -57,8 +55,6 @@ TEST_F(MaterialTest, DoesNotCreateBuffersIfEmptyProperties) {
   EXPECT_FALSE(liquid::rhi::isHandleValid(material.getBuffer()));
   EXPECT_EQ(material.getDescriptor().getBindings().find(0),
             material.getDescriptor().getBindings().end());
-  EXPECT_EQ(material.getDescriptor().getBindings().at(1).type,
-            liquid::rhi::DescriptorType::CombinedImageSampler);
 }
 
 TEST_F(MaterialTest, DoesNotSetTexturesIfNoTexture) {

--- a/engine/tests/liquid-tests/renderer/MaterialPBR.test.cpp
+++ b/engine/tests/liquid-tests/renderer/MaterialPBR.test.cpp
@@ -91,29 +91,29 @@ TEST_F(MaterialPBRTest, GetsProperties) {
   EXPECT_PROP_EQ(15, "emissiveFactor", glm::vec3, glm::vec3(1.0, 0.2, 0.4));
 
   properties.baseColorTexture = liquid::rhi::TextureHandle(1);
-  EXPECT_PROP_EQ(0, "baseColorTexture", int, 0);
+  EXPECT_PROP_EQ(0, "baseColorTexture", int, 1);
 
   properties.normalTexture = liquid::rhi::TextureHandle(2);
-  EXPECT_PROP_EQ(0, "baseColorTexture", int, 0);
-  EXPECT_PROP_EQ(7, "normalTexture", int, 1);
+  EXPECT_PROP_EQ(0, "baseColorTexture", int, 1);
+  EXPECT_PROP_EQ(7, "normalTexture", int, 2);
 
   properties.occlusionTexture = liquid::rhi::TextureHandle(3);
-  EXPECT_PROP_EQ(0, "baseColorTexture", int, 0);
-  EXPECT_PROP_EQ(7, "normalTexture", int, 1);
-  EXPECT_PROP_EQ(10, "occlusionTexture", int, 2);
+  EXPECT_PROP_EQ(0, "baseColorTexture", int, 1);
+  EXPECT_PROP_EQ(7, "normalTexture", int, 2);
+  EXPECT_PROP_EQ(10, "occlusionTexture", int, 3);
 
   properties.metallicRoughnessTexture = liquid::rhi::TextureHandle(4);
-  EXPECT_PROP_EQ(0, "baseColorTexture", int, 0);
-  EXPECT_PROP_EQ(3, "metallicRoughnessTexture", int, 1);
+  EXPECT_PROP_EQ(0, "baseColorTexture", int, 1);
+  EXPECT_PROP_EQ(3, "metallicRoughnessTexture", int, 4);
   EXPECT_PROP_EQ(7, "normalTexture", int, 2);
   EXPECT_PROP_EQ(10, "occlusionTexture", int, 3);
 
   properties.emissiveTexture = liquid::rhi::TextureHandle(5);
-  EXPECT_PROP_EQ(0, "baseColorTexture", int, 0);
-  EXPECT_PROP_EQ(3, "metallicRoughnessTexture", int, 1);
+  EXPECT_PROP_EQ(0, "baseColorTexture", int, 1);
+  EXPECT_PROP_EQ(3, "metallicRoughnessTexture", int, 4);
   EXPECT_PROP_EQ(7, "normalTexture", int, 2);
   EXPECT_PROP_EQ(10, "occlusionTexture", int, 3);
-  EXPECT_PROP_EQ(13, "emissiveTexture", int, 4);
+  EXPECT_PROP_EQ(13, "emissiveTexture", int, 5);
 
 #undef EXPECT_PROP_EQ
 }


### PR DESCRIPTION
- Add global textures descriptor layout
- Add global textures descriptor set
- Update global textures descriptor set when textures are created
- Update global textures descriptor set when textures are recreated
- Update pbr, imgui, and text shaders to use global textures descriptor set