### PR TITLE
Remove global textures descriptor from Vulkan RHI

### DIFF
--- a/editor/src/liquidator/asset/AssetLoader.cpp
+++ b/editor/src/liquidator/asset/AssetLoader.cpp
@@ -5,15 +5,15 @@
 namespace liquidator {
 
 AssetLoader::AssetLoader(AssetManager &assetManager,
-                         liquid::rhi::RenderDevice *device)
-    : mAssetManager(assetManager), mDevice(device) {}
+                         liquid::RenderStorage &renderStorage)
+    : mAssetManager(assetManager), mRenderStorage(renderStorage) {}
 
 liquid::Result<bool> AssetLoader::loadFromPath(const liquid::Path &path,
                                                const liquid::Path &directory) {
   auto res = mAssetManager.importAsset(path, directory);
 
   if (res.hasData()) {
-    mAssetManager.getAssetRegistry().syncWithDevice(mDevice);
+    mAssetManager.getAssetRegistry().syncWithDevice(mRenderStorage);
   }
 
   return res;

--- a/editor/src/liquidator/asset/AssetLoader.h
+++ b/editor/src/liquidator/asset/AssetLoader.h
@@ -17,9 +17,9 @@ public:
    * @brief Create asset loader
    *
    * @param assetManager Asset manager
-   * @param device Render device
+   * @param renderStorage Render storage
    */
-  AssetLoader(AssetManager &assetManager, liquid::rhi::RenderDevice *device);
+  AssetLoader(AssetManager &assetManager, liquid::RenderStorage &renderStorage);
 
   /**
    * @brief Load asset from path
@@ -43,7 +43,7 @@ private:
   AssetManager &mAssetManager;
   liquid::platform_tools::NativeFileDialog mNativeFileDialog;
 
-  liquid::rhi::RenderDevice *mDevice;
+  liquid::RenderStorage &mRenderStorage;
 };
 
 } // namespace liquidator

--- a/editor/src/liquidator/asset/AssetManager.cpp
+++ b/editor/src/liquidator/asset/AssetManager.cpp
@@ -148,8 +148,8 @@ AssetManager::createLuaScript(const liquid::Path &assetPath) {
 }
 
 liquid::Result<bool>
-AssetManager::validateAndPreloadAssets(liquid::rhi::RenderDevice *device) {
-  LIQUID_PROFILE_EVENT("AssetManager::preloadAssets");
+AssetManager::validateAndPreloadAssets(liquid::RenderStorage &renderStorage) {
+  LIQUID_PROFILE_EVENT("AssetManager::validateAndPreloadAssets");
   std::vector<liquid::String> warnings;
 
   for (const auto &entry : std::filesystem::recursive_directory_iterator(
@@ -196,7 +196,7 @@ AssetManager::validateAndPreloadAssets(liquid::rhi::RenderDevice *device) {
     }
   }
 
-  return mAssetCache.preloadAssets(device);
+  return mAssetCache.preloadAssets(renderStorage);
 }
 
 liquid::Result<bool>

--- a/editor/src/liquidator/asset/AssetManager.h
+++ b/editor/src/liquidator/asset/AssetManager.h
@@ -129,11 +129,11 @@ public:
   /**
    * @brief Validate and preload assets
    *
-   * @param device Render device
+   * @param renderStorage Render storage
    * @return Result
    */
   liquid::Result<bool>
-  validateAndPreloadAssets(liquid::rhi::RenderDevice *device);
+  validateAndPreloadAssets(liquid::RenderStorage &renderStorage);
 
   /**
    * @brief Load original asset if hashes are changed

--- a/editor/src/liquidator/core/EditorRenderer.cpp
+++ b/editor/src/liquidator/core/EditorRenderer.cpp
@@ -7,10 +7,12 @@ namespace liquidator {
 
 EditorRenderer::EditorRenderer(liquid::ShaderLibrary &shaderLibrary,
                                IconRegistry &iconRegistry,
+                               liquid::RenderStorage &renderStorage,
                                liquid::rhi::RenderDevice *device)
     : mIconRegistry(iconRegistry), mShaderLibrary(shaderLibrary),
-      mFrameData{EditorRendererFrameData(mDevice),
-                 EditorRendererFrameData(mDevice)},
+      mRenderStorage(renderStorage),
+      mFrameData{EditorRendererFrameData(renderStorage),
+                 EditorRendererFrameData(renderStorage)},
       mDevice(device) {
 
   createCollidableShapes();
@@ -314,7 +316,7 @@ void EditorRenderer::createCollidableShapes() {
         // clang-format on
     };
 
-    mCollidableCube.buffer = mDevice->createBuffer(
+    mCollidableCube.buffer = mRenderStorage.createBuffer(
         {liquid::rhi::BufferType::Vertex,
          CollidableBoxVertices.size() * sizeof(liquid::Vertex),
          static_cast<const void *>(CollidableBoxVertices.data())});
@@ -367,7 +369,7 @@ void EditorRenderer::createCollidableShapes() {
     drawUnitCircle(CollidableSphereVertices, NumSegments, cZero, cSin, cCos);
     drawUnitCircle(CollidableSphereVertices, NumSegments, cSin, cCos, cZero);
 
-    mCollidableSphere.buffer = mDevice->createBuffer(
+    mCollidableSphere.buffer = mRenderStorage.createBuffer(
         {liquid::rhi::BufferType::Vertex,
          CollidableSphereVertices.size() * sizeof(liquid::Vertex),
          static_cast<const void *>(CollidableSphereVertices.data())});
@@ -425,7 +427,7 @@ void EditorRenderer::createCollidableShapes() {
     drawUnitHalfCircle(CollidableCapsuleVertices, NumSegments, cZero,
                        cSinCenter(-0.5f), cCos, -Pi);
 
-    mCollidableCapsule.buffer = mDevice->createBuffer(
+    mCollidableCapsule.buffer = mRenderStorage.createBuffer(
         {liquid::rhi::BufferType::Vertex,
          CollidableCapsuleVertices.size() * sizeof(liquid::Vertex),
          static_cast<const void *>(CollidableCapsuleVertices.data())});

--- a/editor/src/liquidator/core/EditorRenderer.h
+++ b/editor/src/liquidator/core/EditorRenderer.h
@@ -39,10 +39,13 @@ public:
    *
    * @param shaderLibrary Shader library
    * @param iconRegistry Icon registry
+   * @param renderStorage Render storage
    * @param device Render device
    */
   EditorRenderer(liquid::ShaderLibrary &shaderLibrary,
-                 IconRegistry &iconRegistry, liquid::rhi::RenderDevice *device);
+                 IconRegistry &iconRegistry,
+                 liquid::RenderStorage &renderStorage,
+                 liquid::rhi::RenderDevice *device);
 
   /**
    * @brief Attach to render graph
@@ -81,6 +84,7 @@ private:
   CollidableShapeDraw mCollidableSphere;
   CollidableShapeDraw mCollidableCapsule;
 
+  liquid::RenderStorage &mRenderStorage;
   std::array<EditorRendererFrameData, liquid::rhi::RenderDevice::NumFrames>
       mFrameData;
 };

--- a/editor/src/liquidator/core/EditorRendererFrameData.cpp
+++ b/editor/src/liquidator/core/EditorRendererFrameData.cpp
@@ -4,8 +4,8 @@
 namespace liquidator {
 
 EditorRendererFrameData::EditorRendererFrameData(
-    liquid::rhi::RenderDevice *device, size_t reservedSpace)
-    : mReservedSpace(reservedSpace), mDevice(device) {
+    liquid::RenderStorage &renderStorage, size_t reservedSpace)
+    : mReservedSpace(reservedSpace) {
   mSkeletonTransforms.reserve(mReservedSpace);
   mNumBones.reserve(mReservedSpace);
   mGizmoTransforms.reserve(reservedSpace);
@@ -16,39 +16,39 @@ EditorRendererFrameData::EditorRendererFrameData(
   defaultDesc.size = mReservedSpace * sizeof(glm::mat4);
   defaultDesc.mapped = true;
 
-  mSkeletonTransformsBuffer = mDevice->createBuffer(defaultDesc);
+  mSkeletonTransformsBuffer = renderStorage.createBuffer(defaultDesc);
 
   {
     auto desc = defaultDesc;
     desc.type = liquid::rhi::BufferType::Uniform;
     desc.size = sizeof(liquid::Camera);
-    mCameraBuffer = mDevice->createBuffer(desc);
+    mCameraBuffer = renderStorage.createBuffer(desc);
   }
 
   {
     auto desc = defaultDesc;
     desc.type = liquid::rhi::BufferType::Uniform;
     desc.size = sizeof(EditorGridData);
-    mEditorGridBuffer = mDevice->createBuffer(desc);
+    mEditorGridBuffer = renderStorage.createBuffer(desc);
   }
 
   {
     auto desc = defaultDesc;
     desc.size = mReservedSpace * MaxNumBones * sizeof(glm::mat4);
-    mSkeletonBoneTransformsBuffer = mDevice->createBuffer(desc);
+    mSkeletonBoneTransformsBuffer = renderStorage.createBuffer(desc);
   }
 
   {
     auto desc = defaultDesc;
     desc.data = mGizmoTransforms.data();
-    mGizmoTransformsBuffer = mDevice->createBuffer(desc);
+    mGizmoTransformsBuffer = renderStorage.createBuffer(desc);
   }
 
   {
     auto desc = defaultDesc;
     desc.size = sizeof(CollidableEntity);
     desc.type = liquid::rhi::BufferType::Uniform;
-    mCollidableEntityBuffer = mDevice->createBuffer(desc);
+    mCollidableEntityBuffer = renderStorage.createBuffer(desc);
   }
 }
 

--- a/editor/src/liquidator/core/EditorRendererFrameData.h
+++ b/editor/src/liquidator/core/EditorRendererFrameData.h
@@ -6,6 +6,7 @@
 
 #include "liquid/scene/Camera.h"
 #include "liquidator/editor-scene/EditorGrid.h"
+#include "liquid/renderer/RenderStorage.h"
 
 #include "liquid/entity/EntityDatabase.h"
 
@@ -54,10 +55,10 @@ public:
   /**
    * @brief Create frame data
    *
-   * @param device Render device
+   * @param renderStorage Render storage
    * @param reservedSpace Reserved space for buffer data
    */
-  EditorRendererFrameData(liquid::rhi::RenderDevice *device,
+  EditorRendererFrameData(liquid::RenderStorage &renderStorage,
                           size_t reservedSpace = DefaultReservedSpace);
 
   /**
@@ -197,13 +198,6 @@ public:
   }
 
   /**
-   * @brief Get render device
-   *
-   * @return Render device
-   */
-  inline liquid::rhi::RenderDevice *getRenderDevice() { return mDevice; }
-
-  /**
    * @brief Get collidable shape type
    *
    * @return Collidable shape type
@@ -242,8 +236,6 @@ private:
   CollidableEntity mCollidableEntityParams{};
 
   liquid::rhi::Buffer mCollidableEntityBuffer;
-
-  liquid::rhi::RenderDevice *mDevice;
 };
 
 } // namespace liquidator

--- a/editor/src/liquidator/core/MousePickingGraph.cpp
+++ b/editor/src/liquidator/core/MousePickingGraph.cpp
@@ -6,7 +6,8 @@ namespace liquidator {
 MousePickingGraph::MousePickingGraph(
     liquid::ShaderLibrary &shaderLibrary,
     const std::array<liquid::SceneRendererFrameData, 2> &frameData,
-    liquid::AssetRegistry &assetRegistry, liquid::rhi::RenderDevice *device)
+    liquid::AssetRegistry &assetRegistry, liquid::RenderStorage &renderStorage,
+    liquid::rhi::RenderDevice *device)
     : mDevice(device), mFrameData(frameData), mAssetRegistry(assetRegistry),
       mGraphEvaluator(device), mRenderGraph("MousePicking") {
   static constexpr uint32_t FramebufferSizePercentage = 100;
@@ -29,10 +30,10 @@ MousePickingGraph::MousePickingGraph(
   depthBufferDesc.height = FramebufferSizePercentage;
   depthBufferDesc.layers = 1;
   depthBufferDesc.format = liquid::rhi::Format::Depth32Float;
-  auto depthBuffer = mDevice->createTexture(depthBufferDesc);
+  auto depthBuffer = renderStorage.createTexture(depthBufferDesc);
 
   liquid::Entity nullEntity{0};
-  mSelectedEntityBuffer = device->createBuffer(
+  mSelectedEntityBuffer = renderStorage.createBuffer(
       {liquid::rhi::BufferType::Storage, sizeof(liquid::Entity), &nullEntity,
        liquid::rhi::BufferUsage::HostRead});
 
@@ -42,8 +43,8 @@ MousePickingGraph::MousePickingGraph(
       sizeof(liquid::Entity) * mFrameData.at(0).getReservedSpace();
   defaultDesc.mapped = true;
 
-  mEntitiesBuffer = device->createBuffer(defaultDesc);
-  mSkinnedEntitiesBuffer = device->createBuffer(defaultDesc);
+  mEntitiesBuffer = renderStorage.createBuffer(defaultDesc);
+  mSkinnedEntitiesBuffer = renderStorage.createBuffer(defaultDesc);
 
   auto &pass = mRenderGraph.addPass("MousePicking");
   pass.write(depthBuffer, liquid::rhi::DepthStencilClear({1.0f, 0}));

--- a/editor/src/liquidator/core/MousePickingGraph.h
+++ b/editor/src/liquidator/core/MousePickingGraph.h
@@ -26,12 +26,14 @@ public:
    * @param shaderLibrary Shader library
    * @param frameData Scene renderer frame data
    * @param assetRegistry Asset registry
+   * @param renderStorage Render storage
    * @param device Render device
    */
   MousePickingGraph(
       liquid::ShaderLibrary &shaderLibrary,
       const std::array<liquid::SceneRendererFrameData, 2> &frameData,
-      liquid::AssetRegistry &assetRegistry, liquid::rhi::RenderDevice *device);
+      liquid::AssetRegistry &assetRegistry,
+      liquid::RenderStorage &renderStorage, liquid::rhi::RenderDevice *device);
 
   ~MousePickingGraph();
 

--- a/editor/src/liquidator/screens/EditorScreen.cpp
+++ b/editor/src/liquidator/screens/EditorScreen.cpp
@@ -84,7 +84,7 @@ void EditorScreen::start(const Project &project) {
 
   presenter.updateFramebuffers(mDevice->getSwapchain());
 
-  auto res = assetManager.validateAndPreloadAssets(mDevice);
+  auto res = assetManager.validateAndPreloadAssets(renderer.getRenderStorage());
   liquidator::AssetLoadStatusDialog preloadStatusDialog("Loaded with warnings");
 
   if (res.hasWarnings()) {
@@ -117,17 +117,20 @@ void EditorScreen::start(const Project &project) {
   editorManager.loadEditorState(statePath);
 
   liquid::MainLoop mainLoop(mWindow, fpsCounter);
-  liquidator::AssetLoader assetLoader(assetManager, mDevice);
+  liquidator::AssetLoader assetLoader(assetManager,
+                                      renderer.getRenderStorage());
 
   liquid::ImguiDebugLayer debugLayer(mDevice->getDeviceInformation(),
                                      mDevice->getDeviceStats(), fpsCounter);
 
   liquidator::UIRoot ui(entityManager, assetLoader);
-  ui.getIconRegistry().loadIcons(mDevice, std::filesystem::current_path() /
-                                              "assets" / "icons");
+  ui.getIconRegistry().loadIcons(renderer.getRenderStorage(),
+                                 std::filesystem::current_path() / "assets" /
+                                     "icons");
 
-  liquidator::EditorRenderer editorRenderer(renderer.getShaderLibrary(),
-                                            ui.getIconRegistry(), mDevice);
+  liquidator::EditorRenderer editorRenderer(
+      renderer.getShaderLibrary(), ui.getIconRegistry(),
+      renderer.getRenderStorage(), mDevice);
 
   liquid::RenderGraph graph("Main");
 
@@ -145,9 +148,9 @@ void EditorScreen::start(const Project &project) {
 
   renderer.getSceneRenderer().attachText(graph, scenePassGroup);
 
-  MousePickingGraph mousePicking(renderer.getShaderLibrary(),
-                                 renderer.getSceneRenderer().getFrameData(),
-                                 assetManager.getAssetRegistry(), mDevice);
+  MousePickingGraph mousePicking(
+      renderer.getShaderLibrary(), renderer.getSceneRenderer().getFrameData(),
+      assetManager.getAssetRegistry(), renderer.getRenderStorage(), mDevice);
 
   mousePicking.setFramebufferSize(mWindow);
   graph.setFramebufferExtent(mWindow.getFramebufferSize());

--- a/editor/src/liquidator/screens/ProjectSelectorScreen.cpp
+++ b/editor/src/liquidator/screens/ProjectSelectorScreen.cpp
@@ -25,8 +25,10 @@ std::optional<Project> ProjectSelectorScreen::start() {
   liquid::AssetRegistry assetRegistry;
   liquid::ShaderLibrary shaderLibrary;
   liquid::RenderGraphEvaluator graphEvaluator(mDevice);
+  liquid::RenderStorage renderStorage(mDevice);
 
-  liquid::ImguiRenderer imguiRenderer(mWindow, shaderLibrary, mDevice);
+  liquid::ImguiRenderer imguiRenderer(mWindow, shaderLibrary, renderStorage,
+                                      mDevice);
   liquid::Presenter presenter(shaderLibrary, mDevice);
 
   liquidator::ProjectManager projectManager;
@@ -58,7 +60,7 @@ std::optional<Project> ProjectSelectorScreen::start() {
         graph.setFramebufferExtent({width, height});
       });
 
-  iconRegistry.loadIcons(mDevice,
+  iconRegistry.loadIcons(renderStorage,
                          std::filesystem::current_path() / "assets" / "icons");
 
   mainLoop.setUpdateFn([&project, this](float dt) {

--- a/editor/src/liquidator/ui/IconRegistry.cpp
+++ b/editor/src/liquidator/ui/IconRegistry.cpp
@@ -6,9 +6,9 @@
 
 namespace liquidator {
 
-void IconRegistry::loadIcons(liquid::rhi::RenderDevice *device,
+void IconRegistry::loadIcons(liquid::RenderStorage &renderStorage,
                              const std::filesystem::path &iconsPath) {
-  liquid::ImageTextureLoader loader(device);
+  liquid::ImageTextureLoader loader(renderStorage);
 
   mIconMap.insert_or_assign(
       EditorIcon::Unknown,

--- a/editor/src/liquidator/ui/IconRegistry.h
+++ b/editor/src/liquidator/ui/IconRegistry.h
@@ -2,6 +2,7 @@
 
 #include "liquid/rhi/RenderHandle.h"
 #include "liquid/rhi/RenderDevice.h"
+#include "liquid/renderer/RenderStorage.h"
 
 namespace liquidator {
 
@@ -40,10 +41,10 @@ public:
   /**
    * @brief Load icons from path
    *
-   * @param device Render device
+   * @param renderStorage Render storage
    * @param iconsPath Path to icons
    */
-  void loadIcons(liquid::rhi::RenderDevice *device,
+  void loadIcons(liquid::RenderStorage &renderStorage,
                  const std::filesystem::path &iconsPath);
 
   /**

--- a/editor/tests/liquidator-tests/asset/AssetManager.test.cpp
+++ b/editor/tests/liquidator-tests/asset/AssetManager.test.cpp
@@ -103,13 +103,14 @@ TEST_F(AssetManagerTest,
   stream.close();
 
   MockRenderDevice device;
+  liquid::RenderStorage renderStorage(&device);
 
   createEmptyFile(texturePath);
 
   EXPECT_TRUE(fs::exists(textureHashPath));
   EXPECT_TRUE(fs::exists(texturePath));
 
-  manager.validateAndPreloadAssets(&device);
+  manager.validateAndPreloadAssets(renderStorage);
 
   EXPECT_FALSE(fs::exists(textureHashPath));
   EXPECT_FALSE(fs::exists(texturePath));
@@ -140,12 +141,13 @@ TEST_F(AssetManagerTest,
   createEmptyFile(prefabMeshPath);
 
   MockRenderDevice device;
+  liquid::RenderStorage renderStorage(&device);
 
   EXPECT_TRUE(fs::exists(prefabPath));
   EXPECT_TRUE(fs::exists(prefabMeshPath));
   EXPECT_TRUE(fs::exists(prefabHashPath));
 
-  manager.validateAndPreloadAssets(&device);
+  manager.validateAndPreloadAssets(renderStorage);
 
   EXPECT_FALSE(fs::exists(prefabPath));
   EXPECT_FALSE(fs::exists(prefabMeshPath));

--- a/editor/tests/liquidator-tests/mocks/MockRenderDevice.cpp
+++ b/editor/tests/liquidator-tests/mocks/MockRenderDevice.cpp
@@ -98,3 +98,11 @@ liquid::rhi::PipelineHandle MockRenderDevice::createPipeline(
 }
 
 void MockRenderDevice::destroyPipeline(liquid::rhi::PipelineHandle handle) {}
+
+size_t MockRenderDevice::addTextureUpdateListener(
+    const std::function<void(const std::set<liquid::rhi::TextureHandle> &)>
+        &listener) {
+  return 0;
+}
+
+void MockRenderDevice::removeTextureUpdateListener(size_t handle) {}

--- a/editor/tests/liquidator-tests/mocks/MockRenderDevice.h
+++ b/editor/tests/liquidator-tests/mocks/MockRenderDevice.h
@@ -59,6 +59,12 @@ public:
     return mBuffers.at(handle);
   }
 
+  size_t addTextureUpdateListener(
+      const std::function<void(const std::set<liquid::rhi::TextureHandle> &)>
+          &listener);
+
+  void removeTextureUpdateListener(size_t handle);
+
 private:
   template <class THandle> inline THandle getNewHandle() {
     auto handle = THandle{mLastHandle};

--- a/engine/rhi/core/include/liquid/rhi/Descriptor.h
+++ b/engine/rhi/core/include/liquid/rhi/Descriptor.h
@@ -9,8 +9,6 @@ enum class DescriptorType {
   StorageBuffer,
   CombinedImageSampler,
 
-  // Bindless textures
-  GlobalTextures
 };
 
 /**
@@ -58,15 +56,6 @@ public:
    * @return Current object
    */
   Descriptor &bind(uint32_t binding, BufferHandle buffer, DescriptorType type);
-
-  /**
-   * @brief Bind global textures
-   *
-   * Bindless textures
-   *
-   * @return Current object
-   */
-  Descriptor &bindGlobalTextures();
 
   /**
    * @brief Get bindings

--- a/engine/rhi/core/include/liquid/rhi/NewDescriptor.h
+++ b/engine/rhi/core/include/liquid/rhi/NewDescriptor.h
@@ -58,7 +58,7 @@ public:
   inline DescriptorHandle getHandle() const { return mHandle; }
 
 private:
-  std::unique_ptr<NativeDescriptor> mNativeDescriptor;
+  NativeDescriptor *mNativeDescriptor = nullptr;
   DescriptorHandle mHandle{0};
 };
 

--- a/engine/rhi/core/include/liquid/rhi/RenderDevice.h
+++ b/engine/rhi/core/include/liquid/rhi/RenderDevice.h
@@ -195,6 +195,22 @@ public:
    * @param handle Pipeline handle
    */
   virtual void destroyPipeline(PipelineHandle handle) = 0;
+
+  /**
+   * @brief Add listener to texture update event
+   *
+   * @param listener Listener function
+   * @return Listener handle
+   */
+  virtual size_t addTextureUpdateListener(
+      const std::function<void(const std::set<TextureHandle> &)> &listener) = 0;
+
+  /**
+   * @brief Remove listener for texture update events
+   *
+   * @param handle Listener handle
+   */
+  virtual void removeTextureUpdateListener(size_t handle) = 0;
 };
 
 } // namespace liquid::rhi

--- a/engine/rhi/core/src/Descriptor.cpp
+++ b/engine/rhi/core/src/Descriptor.cpp
@@ -35,9 +35,4 @@ Descriptor &Descriptor::bind(uint32_t binding, BufferHandle buffer,
   return *this;
 }
 
-Descriptor &Descriptor::bindGlobalTextures() {
-  bindings.insert({0, DescriptorBinding{DescriptorType::GlobalTextures}});
-  return *this;
-}
-
 } // namespace liquid::rhi

--- a/engine/rhi/core/src/NewDescriptor.cpp
+++ b/engine/rhi/core/src/NewDescriptor.cpp
@@ -4,8 +4,8 @@
 
 namespace liquid::rhi::n {
 
-Descriptor ::Descriptor(NativeDescriptor *nativeDescriptor,
-                        DescriptorHandle handle)
+Descriptor::Descriptor(NativeDescriptor *nativeDescriptor,
+                       DescriptorHandle handle)
     : mNativeDescriptor(nativeDescriptor), mHandle(handle) {}
 
 Descriptor &Descriptor::write(uint32_t binding,

--- a/engine/rhi/vulkan/include/liquid/rhi-vulkan/VulkanDescriptorManager.h
+++ b/engine/rhi/vulkan/include/liquid/rhi-vulkan/VulkanDescriptorManager.h
@@ -52,22 +52,6 @@ public:
    */
   void clear();
 
-  /**
-   * @brief Create global textures descriptor set
-   *
-   * Bindless textures
-   *
-   * @param layout Global texture descriptor set layout
-   */
-  void createGlobalTexturesDescriptorSet(DescriptorLayoutHandle layout);
-
-  /**
-   * @brief Add global texture to global textures descriptor
-   *
-   * @param handle Texture handle
-   */
-  void addGlobalTexture(rhi::TextureHandle handle);
-
 private:
   /**
    * @brief Create descriptor set
@@ -94,8 +78,6 @@ private:
   VkDevice mDevice;
 
   const rhi::VulkanResourceRegistry &mRegistry;
-
-  n::Descriptor mGlobalTexturesDescriptor;
 };
 
 } // namespace liquid::rhi

--- a/engine/rhi/vulkan/include/liquid/rhi-vulkan/VulkanPipelineLayoutCache.h
+++ b/engine/rhi/vulkan/include/liquid/rhi-vulkan/VulkanPipelineLayoutCache.h
@@ -52,17 +52,6 @@ public:
   void clear();
 
   /**
-   * @brief Get global textures descriptor set layout
-   *
-   * Bindless textures
-   *
-   * @return Global textures descriptor layout
-   **/
-  inline DescriptorLayoutHandle getGlobalTexturesDescriptorSetLayout() {
-    return DescriptorLayoutHandle{1};
-  }
-
-  /**
    * @brief Get Vulkan descriptor set layout
    *
    * @param handle Descriptor layout handle
@@ -93,13 +82,6 @@ private:
    */
   VkDescriptorSetLayout
   createDescriptorLayout(const DescriptorLayoutDescription &description);
-
-  /**
-   * @brief Create global textures descriptor layout
-   *
-   * Bindless textures
-   */
-  void createGlobalTexturesDescriptorLayout();
 
   /**
    * @brief Destroy all descriptor layouts

--- a/engine/rhi/vulkan/include/liquid/rhi-vulkan/VulkanRenderDevice.h
+++ b/engine/rhi/vulkan/include/liquid/rhi-vulkan/VulkanRenderDevice.h
@@ -187,6 +187,23 @@ public:
    */
   void destroyPipeline(PipelineHandle handle) override;
 
+  /**
+   * @brief Add listener to texture update event
+   *
+   * @param listener Listener function
+   * @return Listener handle
+   */
+  size_t addTextureUpdateListener(
+      const std::function<void(const std::set<TextureHandle> &)> &listener)
+      override;
+
+  /**
+   * @brief Remove listener for texture update events
+   *
+   * @param handle Listener handle
+   */
+  void removeTextureUpdateListener(size_t handle) override;
+
 private:
   /**
    * @brief Recreate swapchain
@@ -219,6 +236,9 @@ private:
   DeviceStats mStats;
 
   bool mSwapchainRecreated = false;
+
+  std::vector<std::function<void(const std::set<TextureHandle> &)>>
+      mTextureUpdateListeners;
 };
 
 } // namespace liquid::rhi

--- a/engine/rhi/vulkan/src/VulkanDescriptorManager.cpp
+++ b/engine/rhi/vulkan/src/VulkanDescriptorManager.cpp
@@ -16,19 +16,11 @@ namespace liquid::rhi {
 VulkanDescriptorManager::VulkanDescriptorManager(
     VulkanDeviceObject &device, const VulkanResourceRegistry &registry,
     VulkanDescriptorPool &descriptorPool)
-    : mDevice(device), mRegistry(registry), mDescriptorPool(descriptorPool),
-      mGlobalTexturesDescriptor(nullptr, DescriptorHandle::Invalid) {}
+    : mDevice(device), mRegistry(registry), mDescriptorPool(descriptorPool) {}
 
 VkDescriptorSet
 VulkanDescriptorManager::getOrCreateDescriptor(const Descriptor &descriptor,
                                                VkDescriptorSetLayout layout) {
-  // Bindless textures
-  if (descriptor.getBindings().size() == 1 &&
-      descriptor.getBindings().at(0).type == DescriptorType::GlobalTextures) {
-    return mDescriptorPool.getDescriptorSet(
-        mGlobalTexturesDescriptor.getHandle());
-  }
-
   const String &hash = createHash(descriptor, layout);
   const auto &found = mDescriptorCache.find(hash);
 
@@ -44,17 +36,6 @@ VulkanDescriptorManager::getOrCreateDescriptor(const Descriptor &descriptor,
 }
 
 void VulkanDescriptorManager::clear() { mDescriptorCache.clear(); }
-
-void VulkanDescriptorManager::createGlobalTexturesDescriptorSet(
-    DescriptorLayoutHandle layout) {
-  mGlobalTexturesDescriptor = mDescriptorPool.createDescriptor(layout);
-}
-
-void VulkanDescriptorManager::addGlobalTexture(rhi::TextureHandle handle) {
-  mGlobalTexturesDescriptor.write(0, {handle},
-                                  DescriptorType::CombinedImageSampler,
-                                  castHandleToUint(handle));
-}
 
 VkDescriptorSet
 VulkanDescriptorManager::createDescriptorSet(const Descriptor &descriptor,

--- a/engine/rhi/vulkan/src/VulkanPipelineLayoutCache.cpp
+++ b/engine/rhi/vulkan/src/VulkanPipelineLayoutCache.cpp
@@ -38,9 +38,7 @@ static bool bindingsMatch(const DescriptorLayoutBindingDescription &a,
 }
 
 VulkanPipelineLayoutCache::VulkanPipelineLayoutCache(VulkanDeviceObject &device)
-    : mDevice(device) {
-  createGlobalTexturesDescriptorLayout();
-}
+    : mDevice(device) {}
 
 VulkanPipelineLayoutCache::~VulkanPipelineLayoutCache() {
   destroyAllDescriptorLayouts();
@@ -48,13 +46,6 @@ VulkanPipelineLayoutCache::~VulkanPipelineLayoutCache() {
 
 DescriptorLayoutHandle VulkanPipelineLayoutCache::getOrCreateDescriptorLayout(
     const DescriptorLayoutDescription &description) {
-
-  // Bindless textures
-  if (description.bindings.size() == 1 &&
-      description.bindings.at(0).name == "uGlobalTextures") {
-    return static_cast<DescriptorLayoutHandle>(1);
-  }
-
   for (size_t i = 0; i < mDescriptorLayoutDescriptions.size(); ++i) {
     const auto &existing = mDescriptorLayoutDescriptions.at(i);
     if (existing.bindings.size() != description.bindings.size()) {
@@ -84,8 +75,6 @@ void VulkanPipelineLayoutCache::clear() {
 
   mDescriptorSetLayouts.clear();
   mDescriptorLayoutDescriptions.clear();
-
-  createGlobalTexturesDescriptorLayout();
 }
 
 VkDescriptorSetLayout VulkanPipelineLayoutCache::createDescriptorLayout(
@@ -136,24 +125,6 @@ VkDescriptorSetLayout VulkanPipelineLayoutCache::createDescriptorLayout(
       "Failed to create descriptor set layout");
 
   return layout;
-}
-
-void VulkanPipelineLayoutCache::createGlobalTexturesDescriptorLayout() {
-  static constexpr uint32_t NumSamplers = 1000;
-
-  DescriptorLayoutBindingDescription binding{};
-  binding.name = "uGlobalTextures";
-  binding.type = DescriptorLayoutBindingType::Dynamic;
-  binding.binding = 0;
-  binding.descriptorCount = NumSamplers;
-  binding.descriptorType = DescriptorType::CombinedImageSampler;
-  binding.shaderStage = ShaderStage::Fragment;
-
-  DescriptorLayoutDescription desc{{binding}};
-  mDescriptorLayoutDescriptions.push_back(desc);
-
-  VkDescriptorSetLayout layout = createDescriptorLayout(desc);
-  mDescriptorSetLayouts.push_back(layout);
 }
 
 void VulkanPipelineLayoutCache::destroyAllDescriptorLayouts() {

--- a/engine/src/liquid/asset/AssetCache.cpp
+++ b/engine/src/liquid/asset/AssetCache.cpp
@@ -43,7 +43,7 @@ Result<bool> AssetCache::checkAssetFile(InputBinaryStream &file,
   return Result<bool>::Ok(true);
 }
 
-Result<bool> AssetCache::preloadAssets(rhi::RenderDevice *device) {
+Result<bool> AssetCache::preloadAssets(RenderStorage &renderStorage) {
   LIQUID_PROFILE_EVENT("AssetCache::preloadAssets");
   std::vector<String> warnings;
 
@@ -63,7 +63,7 @@ Result<bool> AssetCache::preloadAssets(rhi::RenderDevice *device) {
     }
   }
 
-  mRegistry.syncWithDevice(device);
+  mRegistry.syncWithDevice(renderStorage);
 
   return Result<bool>::Ok(true, warnings);
 }

--- a/engine/src/liquid/asset/AssetCache.h
+++ b/engine/src/liquid/asset/AssetCache.h
@@ -202,10 +202,10 @@ public:
   /**
    * @brief Preload all assets in assets directory
    *
-   * @param device Render device
+   * @param renderStorage Render storage
    * @return Preload result
    */
-  Result<bool> preloadAssets(rhi::RenderDevice *device);
+  Result<bool> preloadAssets(RenderStorage &renderStorage);
 
   /**
    * @brief Get asset name from path

--- a/engine/src/liquid/asset/AssetRegistry.cpp
+++ b/engine/src/liquid/asset/AssetRegistry.cpp
@@ -21,7 +21,7 @@ void AssetRegistry::createDefaultObjects() {
       mFonts.addAsset(default_objects::createDefaultFont());
 }
 
-void AssetRegistry::syncWithDevice(rhi::RenderDevice *device) {
+void AssetRegistry::syncWithDevice(RenderStorage &renderStorage) {
   LIQUID_PROFILE_EVENT("AssetRegistry::syncWithDevice");
 
   // Synchronize textures
@@ -42,7 +42,7 @@ void AssetRegistry::syncWithDevice(rhi::RenderDevice *device) {
       description.size = texture.size;
       description.format = texture.data.format;
 
-      texture.data.deviceHandle = device->createTexture(description);
+      texture.data.deviceHandle = renderStorage.createTexture(description);
     }
   }
 
@@ -59,7 +59,7 @@ void AssetRegistry::syncWithDevice(rhi::RenderDevice *device) {
                           rhi::TextureUsage::Sampled;
       description.format = rhi::Format::Rgba8Srgb;
 
-      font.data.deviceHandle = device->createTexture(description);
+      font.data.deviceHandle = renderStorage.createTexture(description);
     }
   }
 
@@ -103,7 +103,7 @@ void AssetRegistry::syncWithDevice(rhi::RenderDevice *device) {
           getTextureFromRegistry(material.emissiveTexture);
       properties.emissiveTextureCoord = material.emissiveTextureCoord;
 
-      material.deviceHandle.reset(new MaterialPBR(properties, device));
+      material.deviceHandle.reset(new MaterialPBR(properties, renderStorage));
     }
   }
 
@@ -123,7 +123,7 @@ void AssetRegistry::syncWithDevice(rhi::RenderDevice *device) {
         description.type = rhi::BufferType::Vertex;
         description.size = geometry.vertices.size() * sizeof(Vertex);
         description.data = geometry.vertices.data();
-        mesh.data.vertexBuffers.at(i) = device->createBuffer(description);
+        mesh.data.vertexBuffers.at(i) = renderStorage.createBuffer(description);
       }
 
       if (!geometry.indices.empty()) {
@@ -131,7 +131,7 @@ void AssetRegistry::syncWithDevice(rhi::RenderDevice *device) {
         description.type = rhi::BufferType::Index;
         description.size = geometry.indices.size() * sizeof(uint32_t);
         description.data = geometry.indices.data();
-        mesh.data.indexBuffers.at(i) = device->createBuffer(description);
+        mesh.data.indexBuffers.at(i) = renderStorage.createBuffer(description);
       }
 
       auto material = geometry.material != MaterialAssetHandle::Invalid
@@ -158,7 +158,7 @@ void AssetRegistry::syncWithDevice(rhi::RenderDevice *device) {
         description.type = rhi::BufferType::Vertex;
         description.size = geometry.vertices.size() * sizeof(SkinnedVertex);
         description.data = geometry.vertices.data();
-        mesh.data.vertexBuffers.at(i) = device->createBuffer(description);
+        mesh.data.vertexBuffers.at(i) = renderStorage.createBuffer(description);
       }
 
       if (!geometry.indices.empty()) {
@@ -166,7 +166,7 @@ void AssetRegistry::syncWithDevice(rhi::RenderDevice *device) {
         description.type = rhi::BufferType::Index;
         description.size = geometry.indices.size() * sizeof(uint32_t);
         description.data = geometry.indices.data();
-        mesh.data.indexBuffers.at(i) = device->createBuffer(description);
+        mesh.data.indexBuffers.at(i) = renderStorage.createBuffer(description);
       }
 
       auto material = geometry.material != MaterialAssetHandle::Invalid

--- a/engine/src/liquid/asset/AssetRegistry.h
+++ b/engine/src/liquid/asset/AssetRegistry.h
@@ -18,6 +18,8 @@
 
 #include "liquid/rhi/RenderDevice.h"
 
+#include "liquid/renderer/RenderStorage.h"
+
 namespace liquid {
 
 /**
@@ -77,9 +79,9 @@ public:
   /**
    * @brief Synchronize assets with device
    *
-   * @param device Render device
+   * @param renderStorage Render storage
    */
-  void syncWithDevice(rhi::RenderDevice *device);
+  void syncWithDevice(RenderStorage &renderStorage);
 
   /**
    * @brief Get textures

--- a/engine/src/liquid/imgui/ImguiRenderer.h
+++ b/engine/src/liquid/imgui/ImguiRenderer.h
@@ -6,6 +6,7 @@
 #include "liquid/renderer/RenderGraph.h"
 #include "liquid/rhi/RenderDevice.h"
 #include "liquid/renderer/ShaderLibrary.h"
+#include "liquid/renderer/RenderStorage.h"
 
 #include "liquid/imgui/Imgui.h"
 
@@ -73,10 +74,11 @@ public:
    *
    * @param window Window
    * @param device Render device
+   * @param renderStorage Render storage
    * @param shaderLibrary Shader library
    */
   ImguiRenderer(Window &window, ShaderLibrary &shaderLibrary,
-                rhi::RenderDevice *device);
+                RenderStorage &renderStorage, rhi::RenderDevice *device);
 
   /**
    * @brief Destroy imgui renderer
@@ -161,7 +163,9 @@ private:
 
 private:
   ShaderLibrary &mShaderLibrary;
+  RenderStorage &mRenderStorage;
   rhi::TextureHandle mFontTexture = rhi::TextureHandle::Invalid;
+
   std::array<FrameData, rhi::RenderDevice::NumFrames> mFrameData;
 
   glm::vec4 mClearColor{DefaultClearColor};

--- a/engine/src/liquid/loaders/ImageTextureLoader.cpp
+++ b/engine/src/liquid/loaders/ImageTextureLoader.cpp
@@ -6,8 +6,8 @@
 
 namespace liquid {
 
-ImageTextureLoader::ImageTextureLoader(rhi::RenderDevice *device)
-    : mDevice(device) {}
+ImageTextureLoader::ImageTextureLoader(RenderStorage &renderStorage)
+    : mRenderStorage(renderStorage) {}
 
 rhi::TextureHandle ImageTextureLoader::loadFromFile(const String &filename) {
   liquid::rhi::TextureDescription description;
@@ -26,7 +26,7 @@ rhi::TextureHandle ImageTextureLoader::loadFromFile(const String &filename) {
   description.type = rhi::TextureType::Standard;
   description.size = width * height * channels;
 
-  return mDevice->createTexture(description);
+  return mRenderStorage.createTexture(description);
 }
 
 } // namespace liquid

--- a/engine/src/liquid/loaders/ImageTextureLoader.h
+++ b/engine/src/liquid/loaders/ImageTextureLoader.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "liquid/rhi/RenderDevice.h"
+#include "liquid/renderer/RenderStorage.h"
 
 namespace liquid {
 
@@ -14,9 +14,9 @@ public:
   /**
    * @brief Create image texture loader
    *
-   * @param device Render device
+   * @param renderStorage Render storage
    */
-  ImageTextureLoader(rhi::RenderDevice *device);
+  ImageTextureLoader(RenderStorage &renderStorage);
 
   /**
    * @brief Load image from filename
@@ -27,7 +27,7 @@ public:
   rhi::TextureHandle loadFromFile(const String &filename);
 
 private:
-  rhi::RenderDevice *mDevice;
+  RenderStorage &mRenderStorage;
 };
 
 } // namespace liquid

--- a/engine/src/liquid/renderer/Material.cpp
+++ b/engine/src/liquid/renderer/Material.cpp
@@ -2,13 +2,11 @@
 #include "liquid/core/Engine.h"
 #include "Material.h"
 
-#include "liquid/rhi/RenderDevice.h"
-
 namespace liquid {
 
 Material::Material(const std::vector<rhi::TextureHandle> &textures,
                    const std::vector<std::pair<String, Property>> &properties,
-                   rhi::RenderDevice *device)
+                   RenderStorage &renderStorage)
     : mTextures(textures) {
 
   for (size_t i = 0; i < properties.size(); ++i) {
@@ -19,7 +17,8 @@ Material::Material(const std::vector<rhi::TextureHandle> &textures,
 
   if (!mProperties.empty()) {
     auto size = updateBufferData();
-    mBuffer = device->createBuffer({rhi::BufferType::Uniform, size, mData});
+    mBuffer =
+        renderStorage.createBuffer({rhi::BufferType::Uniform, size, mData});
     mDescriptor.bind(0, mBuffer.getHandle(),
                      rhi::DescriptorType::UniformBuffer);
   }

--- a/engine/src/liquid/renderer/Material.h
+++ b/engine/src/liquid/renderer/Material.h
@@ -3,8 +3,8 @@
 #include "liquid/core/Property.h"
 
 #include "liquid/rhi/RenderHandle.h"
-#include "liquid/rhi/RenderDevice.h"
 #include "liquid/rhi/Descriptor.h"
+#include "liquid/renderer/RenderStorage.h"
 
 namespace liquid {
 
@@ -18,11 +18,11 @@ public:
    *
    * @param textures Textures
    * @param properties Material properties
-   * @param device Render device
+   * @param renderStorage Render storage
    */
   Material(const std::vector<rhi::TextureHandle> &textures,
            const std::vector<std::pair<String, Property>> &properties,
-           rhi::RenderDevice *device);
+           RenderStorage &renderStorage);
 
   /**
    * @brief Update property

--- a/engine/src/liquid/renderer/MaterialPBR.cpp
+++ b/engine/src/liquid/renderer/MaterialPBR.cpp
@@ -51,7 +51,8 @@ MaterialPBR::Properties::getProperties() const {
 }
 
 MaterialPBR::MaterialPBR(const Properties &properties,
-                         rhi::RenderDevice *device)
-    : Material(properties.getTextures(), properties.getProperties(), device) {}
+                         RenderStorage &renderStorage)
+    : Material(properties.getTextures(), properties.getProperties(),
+               renderStorage) {}
 
 } // namespace liquid

--- a/engine/src/liquid/renderer/MaterialPBR.h
+++ b/engine/src/liquid/renderer/MaterialPBR.h
@@ -116,9 +116,9 @@ public:
    * @brief Create PBR material
    *
    * @param properties PBR properties
-   * @param device Render device
+   * @param renderStorage Render storage
    */
-  MaterialPBR(const Properties &properties, rhi::RenderDevice *device);
+  MaterialPBR(const Properties &properties, RenderStorage &renderStorage);
 };
 
 } // namespace liquid

--- a/engine/src/liquid/renderer/RenderStorage.cpp
+++ b/engine/src/liquid/renderer/RenderStorage.cpp
@@ -1,0 +1,54 @@
+#include "liquid/core/Base.h"
+#include "RenderStorage.h"
+
+namespace liquid {
+
+RenderStorage::RenderStorage(rhi::RenderDevice *device) : mDevice(device) {
+  static constexpr uint32_t NumSamplers = 1000;
+
+  rhi::DescriptorLayoutBindingDescription binding{};
+  binding.binding = 0;
+  binding.type = rhi::DescriptorLayoutBindingType::Dynamic;
+  binding.name = "uGlobalTextures";
+  binding.descriptorCount = NumSamplers;
+  binding.descriptorType = rhi::DescriptorType::CombinedImageSampler;
+  binding.shaderStage = rhi::ShaderStage::Fragment;
+
+  rhi::DescriptorLayoutDescription description{{binding}};
+  auto layout = mDevice->createDescriptorLayout(description);
+
+  mGlobalTexturesDescriptor = mDevice->createDescriptor(layout);
+
+  mResizeListener =
+      device->addTextureUpdateListener([this](const auto &textures) {
+        for (auto texture : textures) {
+          mGlobalTexturesDescriptor.write(
+              0, {texture}, rhi::DescriptorType::CombinedImageSampler,
+              rhi::castHandleToUint(texture));
+        }
+      });
+}
+
+RenderStorage::~RenderStorage() {
+  mDevice->removeTextureUpdateListener(mResizeListener);
+}
+
+rhi::TextureHandle RenderStorage::createTexture(
+    const liquid::rhi::TextureDescription &description) {
+  auto texture = mDevice->createTexture(description);
+
+  mGlobalTexturesDescriptor.write(0, {texture},
+                                  rhi::DescriptorType::CombinedImageSampler,
+                                  rhi::castHandleToUint(texture));
+
+  return texture;
+}
+
+rhi::Buffer
+RenderStorage::createBuffer(const liquid::rhi::BufferDescription &description) {
+  auto buffer = mDevice->createBuffer(description);
+
+  return buffer;
+}
+
+} // namespace liquid

--- a/engine/src/liquid/renderer/RenderStorage.h
+++ b/engine/src/liquid/renderer/RenderStorage.h
@@ -1,0 +1,67 @@
+#pragma once
+
+#include "liquid/rhi/TextureDescription.h"
+#include "liquid/rhi/RenderDevice.h"
+
+namespace liquid {
+
+/**
+ * @brief Render storage
+ *
+ * Abstracts away low level render device
+ * implementations from the codebase
+ */
+class RenderStorage {
+public:
+  /**
+   * @brief Create render storage
+   *
+   * @param device Render device
+   */
+  RenderStorage(rhi::RenderDevice *device);
+
+  RenderStorage(const RenderStorage &) = delete;
+  RenderStorage &operator=(const RenderStorage &) = delete;
+  RenderStorage(RenderStorage &&) = delete;
+  RenderStorage &operator=(RenderStorage &&) = delete;
+
+  /**
+   * @brief Destroy render storage
+   */
+  ~RenderStorage();
+
+  /**
+   * @brief Create texture
+   *
+   * @param description Texture description
+   * @return Texture handle
+   */
+  rhi::TextureHandle
+  createTexture(const liquid::rhi::TextureDescription &description);
+
+  /**
+   * @brief Create buffer
+   *
+   * @param description Buffer description
+   * @return Buffer
+   */
+  rhi::Buffer createBuffer(const liquid::rhi::BufferDescription &description);
+
+  /**
+   * @brief Get global textures descriptor
+   *
+   * @return Global textures descriptor
+   */
+  inline const rhi::n::Descriptor &getGlobalTexturesDescriptor() const {
+    return mGlobalTexturesDescriptor;
+  }
+
+private:
+  rhi::RenderDevice *mDevice = nullptr;
+
+  rhi::n::Descriptor mGlobalTexturesDescriptor;
+
+  size_t mResizeListener = 0;
+};
+
+} // namespace liquid

--- a/engine/src/liquid/renderer/Renderer.cpp
+++ b/engine/src/liquid/renderer/Renderer.cpp
@@ -14,9 +14,9 @@ namespace liquid {
 Renderer::Renderer(AssetRegistry &assetRegistry, Window &window,
                    rhi::RenderDevice *device)
     : mGraphEvaluator(device), mDevice(device),
-      mImguiRenderer(window, mShaderLibrary, device),
-      mAssetRegistry(assetRegistry),
-      mSceneRenderer(mShaderLibrary, mAssetRegistry, device) {}
+      mImguiRenderer(window, mShaderLibrary, mRenderStorage, device),
+      mRenderStorage(device), mAssetRegistry(assetRegistry),
+      mSceneRenderer(mShaderLibrary, mAssetRegistry, mRenderStorage, device) {}
 
 void Renderer::render(RenderGraph &graph, rhi::RenderCommandList &commandList,
                       uint32_t frameIndex) {

--- a/engine/src/liquid/renderer/Renderer.h
+++ b/engine/src/liquid/renderer/Renderer.h
@@ -104,10 +104,19 @@ public:
    */
   inline void wait() { mDevice->waitForIdle(); }
 
+  /**
+   * @brief Get render storage
+   *
+   * @return Render storage
+   */
+  inline RenderStorage &getRenderStorage() { return mRenderStorage; }
+
 private:
-  RenderGraphEvaluator mGraphEvaluator;
-  rhi::RenderDevice *mDevice;
   ShaderLibrary mShaderLibrary;
+  rhi::RenderDevice *mDevice;
+  RenderStorage mRenderStorage;
+
+  RenderGraphEvaluator mGraphEvaluator;
   AssetRegistry &mAssetRegistry;
   ImguiRenderer mImguiRenderer;
   SceneRenderer mSceneRenderer;

--- a/engine/src/liquid/renderer/SceneRenderer.h
+++ b/engine/src/liquid/renderer/SceneRenderer.h
@@ -35,10 +35,11 @@ public:
    *
    * @param shaderLibrary Shader library
    * @param assetRegistry Asset registry
+   * @param renderStorage Render storage
    * @param device Render device
    */
   SceneRenderer(ShaderLibrary &shaderLibrary, AssetRegistry &assetRegistry,
-                rhi::RenderDevice *device);
+                RenderStorage &renderStorage, rhi::RenderDevice *device);
 
   /**
    * @brief Set clear color
@@ -121,6 +122,7 @@ private:
   ShaderLibrary &mShaderLibrary;
   AssetRegistry &mAssetRegistry;
   rhi::RenderDevice *mDevice;
+  RenderStorage &mRenderStorage;
   std::array<SceneRendererFrameData, rhi::RenderDevice::NumFrames> mFrameData;
 };
 

--- a/engine/src/liquid/renderer/SceneRendererFrameData.cpp
+++ b/engine/src/liquid/renderer/SceneRendererFrameData.cpp
@@ -5,9 +5,10 @@
 
 namespace liquid {
 
-SceneRendererFrameData::SceneRendererFrameData(rhi::RenderDevice *device,
+SceneRendererFrameData::SceneRendererFrameData(RenderStorage &renderStorage,
+                                               rhi::RenderDevice *device,
                                                size_t reservedSpace)
-    : mReservedSpace(reservedSpace), mDevice(device) {
+    : mReservedSpace(reservedSpace) {
 
   mLights.reserve(MaxNumLights);
   mShadowMaps.reserve(MaxShadowMaps);
@@ -20,46 +21,46 @@ SceneRendererFrameData::SceneRendererFrameData(rhi::RenderDevice *device,
   defaultDesc.size = mReservedSpace * sizeof(glm::mat4);
   defaultDesc.mapped = true;
 
-  mMeshTransformsBuffer = mDevice->createBuffer(defaultDesc);
-  mSkinnedMeshTransformsBuffer = mDevice->createBuffer(defaultDesc);
-  mTextTransformsBuffer = mDevice->createBuffer(defaultDesc);
+  mMeshTransformsBuffer = renderStorage.createBuffer(defaultDesc);
+  mSkinnedMeshTransformsBuffer = renderStorage.createBuffer(defaultDesc);
+  mTextTransformsBuffer = renderStorage.createBuffer(defaultDesc);
 
   {
     auto desc = defaultDesc;
     desc.size = mReservedSpace * MaxNumJoints * sizeof(glm::mat4);
-    mSkeletonsBuffer = mDevice->createBuffer(desc);
+    mSkeletonsBuffer = renderStorage.createBuffer(desc);
   }
 
   {
     auto desc = defaultDesc;
     desc.size = mReservedSpace * sizeof(GlyphData);
-    mTextGlyphsBuffer = mDevice->createBuffer(desc);
+    mTextGlyphsBuffer = renderStorage.createBuffer(desc);
   }
 
   {
     auto desc = defaultDesc;
     desc.size = mLights.capacity() * sizeof(LightData);
-    mLightsBuffer = mDevice->createBuffer(desc);
+    mLightsBuffer = renderStorage.createBuffer(desc);
   }
 
   {
     auto desc = defaultDesc;
     desc.size = sizeof(Camera);
     desc.type = rhi::BufferType::Uniform;
-    mCameraBuffer = mDevice->createBuffer(desc);
+    mCameraBuffer = renderStorage.createBuffer(desc);
   }
 
   {
     auto desc = defaultDesc;
     desc.size = sizeof(SceneData);
     desc.type = rhi::BufferType::Uniform;
-    mSceneBuffer = mDevice->createBuffer(desc);
+    mSceneBuffer = renderStorage.createBuffer(desc);
   }
 
   {
     auto desc = defaultDesc;
     desc.size = mShadowMaps.capacity() * sizeof(ShadowMapData);
-    mShadowMapsBuffer = mDevice->createBuffer(desc);
+    mShadowMapsBuffer = renderStorage.createBuffer(desc);
   }
 
   static constexpr uint32_t MaxDescriptors = 20;

--- a/engine/src/liquid/renderer/SceneRendererFrameData.h
+++ b/engine/src/liquid/renderer/SceneRendererFrameData.h
@@ -184,10 +184,12 @@ public:
   /**
    * @brief Create frame data
    *
+   * @param renderStorage Render Storage
    * @param device Render device
    * @param reservedSpace Reserved space for buffer data
    */
-  SceneRendererFrameData(rhi::RenderDevice *device,
+  SceneRendererFrameData(RenderStorage &renderStorage,
+                         rhi::RenderDevice *device,
                          size_t reservedSpace = DefaultReservedSpace);
 
   /**
@@ -480,8 +482,6 @@ private:
   std::unordered_map<FontAssetHandle, std::vector<TextData>> mTextGroups;
 
   size_t mReservedSpace = 0;
-
-  rhi::RenderDevice *mDevice = nullptr;
 };
 
 } // namespace liquid

--- a/engine/tests/liquid-tests/loaders/ImageTextureLoader.test.cpp
+++ b/engine/tests/liquid-tests/loaders/ImageTextureLoader.test.cpp
@@ -6,13 +6,16 @@
 
 class ImageTextureLoaderTest : public ::testing::Test {
 public:
+  ImageTextureLoaderTest() : renderStorage(&device) {}
   MockRenderDevice device;
+  liquid::RenderStorage renderStorage;
 };
 
 using ImageTextureLoaderDeathTest = ImageTextureLoaderTest;
 
 TEST_F(ImageTextureLoaderTest, LoadsImageUsingStb) {
-  liquid::ImageTextureLoader loader(&device);
+  liquid::ImageTextureLoader loader(renderStorage);
+
   auto texture = loader.loadFromFile("white-image-100x100.png");
 
   EXPECT_TRUE(liquid::rhi::isHandleValid(texture));
@@ -26,6 +29,7 @@ TEST_F(ImageTextureLoaderTest, LoadsImageUsingStb) {
 }
 
 TEST_F(ImageTextureLoaderDeathTest, ThrowsErrorOnFailedLoad) {
-  liquid::ImageTextureLoader loader(&device);
+  liquid::ImageTextureLoader loader(renderStorage);
+
   EXPECT_DEATH(loader.loadFromFile("non-existent-image.png"), ".*");
 }

--- a/engine/tests/liquid-tests/mocks/MockRenderDevice.cpp
+++ b/engine/tests/liquid-tests/mocks/MockRenderDevice.cpp
@@ -98,3 +98,11 @@ liquid::rhi::PipelineHandle MockRenderDevice::createPipeline(
 }
 
 void MockRenderDevice::destroyPipeline(liquid::rhi::PipelineHandle handle) {}
+
+size_t MockRenderDevice::addTextureUpdateListener(
+    const std::function<void(const std::set<liquid::rhi::TextureHandle> &)>
+        &listener) {
+  return 0;
+}
+
+void MockRenderDevice::removeTextureUpdateListener(size_t handle) {}

--- a/engine/tests/liquid-tests/mocks/MockRenderDevice.h
+++ b/engine/tests/liquid-tests/mocks/MockRenderDevice.h
@@ -59,6 +59,12 @@ public:
     return mBuffers.at(handle);
   }
 
+  size_t addTextureUpdateListener(
+      const std::function<void(const std::set<liquid::rhi::TextureHandle> &)>
+          &listener);
+
+  void removeTextureUpdateListener(size_t handle);
+
 private:
   template <class THandle> inline THandle getNewHandle() {
     auto handle = THandle{mLastHandle};

--- a/engine/tests/liquid-tests/renderer/Material.test.cpp
+++ b/engine/tests/liquid-tests/renderer/Material.test.cpp
@@ -7,7 +7,10 @@
 
 class MaterialTest : public ::testing::Test {
 public:
+  MaterialTest() : renderStorage(&device) {}
+
   MockRenderDevice device;
+  liquid::RenderStorage renderStorage;
 };
 
 TEST_F(MaterialTest, SetsBuffersAndTextures) {
@@ -20,7 +23,7 @@ TEST_F(MaterialTest, SetsBuffersAndTextures) {
           {"specular", liquid::Property(glm::vec3(0.5, 0.2, 0.3))},
           {"diffuse", liquid::Property(glm::vec4(1.0, 1.0, 1.0, 1.0))},
       },
-      &device);
+      renderStorage);
 
   EXPECT_EQ(material.getTextures(), textures);
   EXPECT_EQ(material.hasTextures(), true);
@@ -48,7 +51,7 @@ TEST_F(MaterialTest, DoesNotCreateBuffersIfEmptyProperties) {
   std::vector<liquid::rhi::TextureHandle> textures{
       liquid::rhi::TextureHandle(1)};
 
-  liquid::Material material(textures, {}, &device);
+  liquid::Material material(textures, {}, renderStorage);
 
   EXPECT_EQ(material.getTextures(), textures);
   EXPECT_EQ(material.hasTextures(), true);
@@ -58,7 +61,7 @@ TEST_F(MaterialTest, DoesNotCreateBuffersIfEmptyProperties) {
 }
 
 TEST_F(MaterialTest, DoesNotSetTexturesIfNoTexture) {
-  liquid::Material material({}, {}, &device);
+  liquid::Material material({}, {}, renderStorage);
 
   EXPECT_EQ(material.getTextures().size(), 0);
   EXPECT_EQ(material.hasTextures(), false);
@@ -74,7 +77,7 @@ TEST_F(MaterialTest, DoesNotUpdatePropertyIfPropertyDoesNotExist) {
                                 {"specular", liquid::Property(testVec3)},
                                 {"diffuse", liquid::Property(testReal)},
                             },
-                            &device);
+                            renderStorage);
 
   const auto &properties = material.getProperties();
   {
@@ -118,7 +121,7 @@ TEST_F(MaterialTest, DoesNotUpdatePropertyIfNewPropertyTypeIsDifferent) {
                                 {"specular", liquid::Property(testVec3)},
                                 {"diffuse", liquid::Property(testReal)},
                             },
-                            &device);
+                            renderStorage);
 
   const auto &properties = material.getProperties();
   {
@@ -163,7 +166,7 @@ TEST_F(MaterialTest, UpdatesPropertyIfNameAndTypeMatch) {
                                 {"specular", liquid::Property(testVec3)},
                                 {"diffuse", liquid::Property(testReal)},
                             },
-                            &device);
+                            renderStorage);
 
   const auto &properties = material.getProperties();
   {

--- a/engine/tests/liquid-tests/renderer/MaterialPBR.test.cpp
+++ b/engine/tests/liquid-tests/renderer/MaterialPBR.test.cpp
@@ -7,7 +7,10 @@
 
 class MaterialPBRTest : public ::testing::Test {
 public:
+  MaterialPBRTest() : renderStorage(&device) {}
+
   MockRenderDevice device;
+  liquid::RenderStorage renderStorage;
 };
 
 TEST_F(MaterialPBRTest, GetsTextures) {
@@ -137,7 +140,7 @@ TEST_F(MaterialPBRTest, SetsShadersPropertiesAndTextures) {
       0,
       glm::vec3(1.0f, 0.2f, 0.4f)};
 
-  liquid::MaterialPBR material(properties, &device);
+  liquid::MaterialPBR material(properties, renderStorage);
 
   const auto &buffer = device.getBuffer(material.getBuffer());
 

--- a/runtime/src/runtime/Runtime.cpp
+++ b/runtime/src/runtime/Runtime.cpp
@@ -40,13 +40,14 @@ void Runtime::start() {
 
   liquid::rhi::VulkanRenderBackend backend(window);
   auto *device = backend.createDefaultDevice();
-  auto res = assetCache.preloadAssets(device);
+  liquid::Renderer renderer(assetCache.getRegistry(), window, device);
+
+  auto res = assetCache.preloadAssets(renderer.getRenderStorage());
 
   liquid::FPSCounter fpsCounter;
   liquid::MainLoop mainLoop(window, fpsCounter);
 
   liquid::RenderGraph graph("Main");
-  liquid::Renderer renderer(assetCache.getRegistry(), window, device);
 
   static constexpr glm::vec4 BlueishClearValue{0.52f, 0.54f, 0.89f, 1.0f};
 


### PR DESCRIPTION
- Add render storage in renderer
- Create all textures through the render storage
- Create all buffers through the render storage
- Create global textures descriptor in the render storage
- Update the global descriptors when new textures are added
- Add listeners when textures are updated