### PR TITLE
Rename projects

### DIFF
--- a/editor/premake5.lua
+++ b/editor/premake5.lua
@@ -1,13 +1,14 @@
-project "Liquidator"
+project "LiquidEditor"
     basedir "../workspace/editor"
     kind "ConsoleApp"
+    targetname "Liquidator"
 
     includedirs {
         "./src"
     }
 
     loadSourceFiles{}
-    linkDependenciesWith{"LiquidEngine", "LiquidEngineRHIVulkan", "LiquidEngineRHICore", "LiquidEnginePlatformTools", "vendor-libimguizmo", "vendor-libmikktspace", "meshoptimizer"}
+    linkDependenciesWith{"LiquidEngine", "LiquidRHIVulkan", "LiquidRHICore", "LiquidPlatformTools", "vendor-libimguizmo", "vendor-libmikktspace", "meshoptimizer"}
     
     copyRuntime();
 
@@ -32,7 +33,7 @@ project "Liquidator"
 
     copyEngineAssets()
 
-project "LiquidatorTests"
+project "LiquidEditorTest"
     basedir "../workspace/editor-test"
     kind "ConsoleApp"
 
@@ -60,7 +61,7 @@ project "LiquidatorTests"
     }
 
     setupTestingOptions{}
-    links { "LiquidEngine", "LiquidEngineRHICore", "LiquidEngineRHIVulkan", "LiquidEnginePlatformTools", "vendor-libimguizmo", "vendor-libmikktspace" }
+    links { "LiquidEngine", "LiquidRHICore", "LiquidRHIVulkan", "LiquidPlatformTools", "vendor-libimguizmo", "vendor-libmikktspace" }
     linkGoogleTest{}
     linkDependenciesWithoutVulkan{}
 

--- a/editor/src/liquidator/core/GameExporter.cpp
+++ b/editor/src/liquidator/core/GameExporter.cpp
@@ -43,7 +43,7 @@ void GameExporter::exportGame(const Project &project,
 
   for (auto entry :
        std::filesystem::directory_iterator(std::filesystem::current_path())) {
-    if (entry.path().stem().string() == "Runtime") {
+    if (entry.path().stem().string() == "LiquidRuntime") {
       runtimePath = entry.path();
     }
   }

--- a/engine/platform-tools/premake5.lua
+++ b/engine/platform-tools/premake5.lua
@@ -1,4 +1,4 @@
-project "LiquidEnginePlatformTools"
+project "LiquidPlatformTools"
     basedir "../../workspace/platform-tools"
     kind "StaticLib"
 

--- a/engine/premake5.lua
+++ b/engine/premake5.lua
@@ -65,7 +65,7 @@ project "LiquidEngineTest"
     }
 
     setupTestingOptions{}
-    links { "LiquidEngine", "LiquidEngineRHICore" }
+    links { "LiquidEngine", "LiquidRHICore" }
     linkGoogleTest{}
     linkDependenciesWithoutVulkan{}
 

--- a/engine/rhi/core/premake5.lua
+++ b/engine/rhi/core/premake5.lua
@@ -1,4 +1,4 @@
-project "LiquidEngineRHICore"
+project "LiquidRHICore"
     basedir "../../../workspace/rhi-core"
     kind "StaticLib"
 

--- a/engine/rhi/vulkan/premake5.lua
+++ b/engine/rhi/vulkan/premake5.lua
@@ -1,4 +1,4 @@
-project "LiquidEngineRHIVulkan"
+project "LiquidRHIVulkan"
     basedir "../../../workspace/rhi-vulkan"
     kind "StaticLib"
 

--- a/runtime/premake5.lua
+++ b/runtime/premake5.lua
@@ -2,26 +2,25 @@ function copyRuntime()
   -- Make sure that runtime is built
   -- before it can be copied to current
   -- project
-  links { "Runtime" }
+  links { "LiquidRuntime" }
 
-  runtimeTargetName = 'Runtime';
+  runtimeTargetName = 'LiquidRuntime';
   runtimeTargetLocationRelativeToProjects = '../../workspace/runtime';
   postbuildcommands {
     "{COPYFILE} "..runtimeTargetLocationRelativeToProjects.."/bin/%{cfg.buildcfg}/"..getTargetExtension(runtimeTargetName).." %{cfg.buildtarget.directory}/"
   }
 end
 
-project "Runtime"
+project "LiquidRuntime"
     basedir "../workspace/runtime"
     kind "ConsoleApp"
-    
 
     includedirs {
         "./src"
     }
 
     loadSourceFiles{}
-    linkDependenciesWith{"LiquidEngine", "LiquidEngineRHIVulkan", "LiquidEngineRHICore", "LiquidEnginePlatformTools" }
+    linkDependenciesWith{"LiquidEngine", "LiquidRHIVulkan", "LiquidRHICore", "LiquidPlatformTools" }
 
     -- This is for development only since runtime
     -- will always be copied from the editor


### PR DESCRIPTION
- Remove engine word from RHI and platform tools projects
- Rename Liquidator to LiquidEditor
- Rename Runtime to LiquidRuntime