### PR TITLE
Rename generic pass names to graphics

### DIFF
--- a/editor/src/liquidator/core/EditorRenderer.cpp
+++ b/editor/src/liquidator/core/EditorRenderer.cpp
@@ -49,7 +49,7 @@ EditorRenderer::EditorRenderer(liquid::ShaderLibrary &shaderLibrary,
 }
 
 liquid::RenderGraphPass &EditorRenderer::attach(liquid::RenderGraph &graph) {
-  auto &pass = graph.addPass("editor-debug");
+  auto &pass = graph.addGraphicsPass("editor-debug");
 
   auto vEditorGridPipeline = pass.addPipeline(
       {mShaderLibrary.getShader("editor-grid.vert"),

--- a/editor/src/liquidator/core/MousePickingGraph.cpp
+++ b/editor/src/liquidator/core/MousePickingGraph.cpp
@@ -46,11 +46,11 @@ MousePickingGraph::MousePickingGraph(
   mEntitiesBuffer = renderStorage.createBuffer(defaultDesc);
   mSkinnedEntitiesBuffer = renderStorage.createBuffer(defaultDesc);
 
-  auto &pass = mRenderGraph.addPass("MousePicking");
+  auto &pass = mRenderGraph.addGraphicsPass("MousePicking");
   pass.write(depthBuffer, liquid::rhi::DepthStencilClear({1.0f, 0}));
 
   // Normal meshes
-  auto vPipeline = pass.addPipeline(liquid::rhi::PipelineDescription{
+  auto vPipeline = pass.addPipeline(liquid::rhi::GraphicsPipelineDescription{
       shaderLibrary.getShader("mouse-picking.default.vertex"),
       shaderLibrary.getShader("mouse-picking.selector.fragment"),
       liquid::rhi::PipelineVertexInputLayout::create<liquid::Vertex>(),
@@ -62,16 +62,17 @@ MousePickingGraph::MousePickingGraph(
       liquid::rhi::PipelineColorBlend{{}}});
 
   // Skinned meshes
-  auto vSkinnedPipeline = pass.addPipeline(liquid::rhi::PipelineDescription{
-      shaderLibrary.getShader("mouse-picking.skinned.vertex"),
-      shaderLibrary.getShader("mouse-picking.selector.fragment"),
-      liquid::rhi::PipelineVertexInputLayout::create<liquid::Vertex>(),
-      liquid::rhi::PipelineInputAssembly{
-          liquid::rhi::PrimitiveTopology::TriangleList},
-      liquid::rhi::PipelineRasterizer{liquid::rhi::PolygonMode::Fill,
-                                      liquid::rhi::CullMode::Back,
-                                      liquid::rhi::FrontFace::CounterClockwise},
-      liquid::rhi::PipelineColorBlend{{}}});
+  auto vSkinnedPipeline =
+      pass.addPipeline(liquid::rhi::GraphicsPipelineDescription{
+          shaderLibrary.getShader("mouse-picking.skinned.vertex"),
+          shaderLibrary.getShader("mouse-picking.selector.fragment"),
+          liquid::rhi::PipelineVertexInputLayout::create<liquid::Vertex>(),
+          liquid::rhi::PipelineInputAssembly{
+              liquid::rhi::PrimitiveTopology::TriangleList},
+          liquid::rhi::PipelineRasterizer{
+              liquid::rhi::PolygonMode::Fill, liquid::rhi::CullMode::Back,
+              liquid::rhi::FrontFace::CounterClockwise},
+          liquid::rhi::PipelineColorBlend{{}}});
 
   pass.setExecutor([this, vPipeline, vSkinnedPipeline,
                     &renderStorage](liquid::rhi::RenderCommandList &commandList,

--- a/editor/tests/liquidator-tests/mocks/MockRenderDevice.cpp
+++ b/editor/tests/liquidator-tests/mocks/MockRenderDevice.cpp
@@ -91,7 +91,7 @@ void MockRenderDevice::destroyFramebuffer(
     liquid::rhi::FramebufferHandle handle) {}
 
 liquid::rhi::PipelineHandle MockRenderDevice::createPipeline(
-    const liquid::rhi::PipelineDescription &description) {
+    const liquid::rhi::GraphicsPipelineDescription &description) {
   auto handle = getNewHandle<liquid::rhi::PipelineHandle>();
   mPipelines.insert_or_assign(handle, description);
   return handle;

--- a/editor/tests/liquidator-tests/mocks/MockRenderDevice.h
+++ b/editor/tests/liquidator-tests/mocks/MockRenderDevice.h
@@ -51,7 +51,7 @@ public:
   void destroyFramebuffer(liquid::rhi::FramebufferHandle handle);
 
   liquid::rhi::PipelineHandle
-  createPipeline(const liquid::rhi::PipelineDescription &description);
+  createPipeline(const liquid::rhi::GraphicsPipelineDescription &description);
 
   liquid::rhi::PipelineHandle
   createPipeline(const liquid::rhi::ComputePipelineDescription &description);
@@ -95,7 +95,7 @@ private:
       mFramebuffers;
 
   std::unordered_map<liquid::rhi::PipelineHandle,
-                     liquid::rhi::PipelineDescription>
+                     liquid::rhi::GraphicsPipelineDescription>
       mPipelines;
 
   std::unordered_map<liquid::rhi::PipelineHandle,

--- a/engine/rhi/core/include/liquid/rhi/PipelineDescription.h
+++ b/engine/rhi/core/include/liquid/rhi/PipelineDescription.h
@@ -279,7 +279,7 @@ struct PipelineColorBlend {
 /**
  * @brief Graphics pipeline description
  */
-struct PipelineDescription {
+struct GraphicsPipelineDescription {
   /**
    * Vertex shader
    */

--- a/engine/rhi/core/include/liquid/rhi/RenderDevice.h
+++ b/engine/rhi/core/include/liquid/rhi/RenderDevice.h
@@ -187,7 +187,7 @@ public:
    * @return Graphics pipeline
    */
   virtual PipelineHandle
-  createPipeline(const PipelineDescription &description) = 0;
+  createPipeline(const GraphicsPipelineDescription &description) = 0;
 
   /**
    * @brief Create compute pipeline

--- a/engine/rhi/vulkan/include/liquid/rhi-vulkan/VulkanPipeline.h
+++ b/engine/rhi/vulkan/include/liquid/rhi-vulkan/VulkanPipeline.h
@@ -23,7 +23,7 @@ public:
    * @param registry Resource registry
    * @param pipelineLayoutCache Pipeline layout cache
    */
-  VulkanPipeline(const PipelineDescription &description,
+  VulkanPipeline(const GraphicsPipelineDescription &description,
                  VulkanDeviceObject &device,
                  const VulkanResourceRegistry &registry,
                  VulkanPipelineLayoutCache &pipelineLayoutCache);

--- a/engine/rhi/vulkan/include/liquid/rhi-vulkan/VulkanRenderDevice.h
+++ b/engine/rhi/vulkan/include/liquid/rhi-vulkan/VulkanRenderDevice.h
@@ -177,7 +177,7 @@ public:
    * @return Graphics pipeline
    */
   virtual PipelineHandle
-  createPipeline(const PipelineDescription &description) override;
+  createPipeline(const GraphicsPipelineDescription &description) override;
 
   /**
    * @brief Create compute pipeline

--- a/engine/rhi/vulkan/src/VulkanPipeline.cpp
+++ b/engine/rhi/vulkan/src/VulkanPipeline.cpp
@@ -10,7 +10,7 @@
 
 namespace liquid::rhi {
 
-VulkanPipeline::VulkanPipeline(const PipelineDescription &description,
+VulkanPipeline::VulkanPipeline(const GraphicsPipelineDescription &description,
                                VulkanDeviceObject &device,
                                const VulkanResourceRegistry &registry,
                                VulkanPipelineLayoutCache &pipelineLayoutCache)

--- a/engine/rhi/vulkan/src/VulkanRenderDevice.cpp
+++ b/engine/rhi/vulkan/src/VulkanRenderDevice.cpp
@@ -166,8 +166,8 @@ void VulkanRenderDevice::destroyFramebuffer(FramebufferHandle handle) {
   mRegistry.deleteFramebuffer(handle);
 }
 
-PipelineHandle
-VulkanRenderDevice::createPipeline(const PipelineDescription &description) {
+PipelineHandle VulkanRenderDevice::createPipeline(
+    const GraphicsPipelineDescription &description) {
   return mRegistry.setPipeline(std::make_unique<VulkanPipeline>(
       description, mDevice, mRegistry, mPipelineLayoutCache));
 }

--- a/engine/src/liquid/imgui/ImguiRenderer.cpp
+++ b/engine/src/liquid/imgui/ImguiRenderer.cpp
@@ -83,10 +83,10 @@ ImguiRenderPassData ImguiRenderer::attach(RenderGraph &graph) {
   imguiDesc.format = rhi::Format::Rgba8Unorm;
   auto imgui = mRenderStorage.createTexture(imguiDesc);
 
-  auto &pass = graph.addPass("imgui");
+  auto &pass = graph.addGraphicsPass("imgui");
   pass.write(imgui, mClearColor);
 
-  auto pipeline = pass.addPipeline(rhi::PipelineDescription{
+  auto pipeline = pass.addPipeline(rhi::GraphicsPipelineDescription{
       mShaderLibrary.getShader("__engine.imgui.default.vertex"),
       mShaderLibrary.getShader("__engine.imgui.default.fragment"),
       rhi::PipelineVertexInputLayout{

--- a/engine/src/liquid/renderer/Presenter.cpp
+++ b/engine/src/liquid/renderer/Presenter.cpp
@@ -54,7 +54,7 @@ void Presenter::updateFramebuffers(const rhi::Swapchain &swapchain) {
   auto fragmentShader =
       mShaderLibrary.getShader("__engine.fullscreenQuad.default.fragment");
 
-  rhi::PipelineDescription pipelineDescription{};
+  rhi::GraphicsPipelineDescription pipelineDescription{};
   pipelineDescription.vertexShader = vertexShader;
   pipelineDescription.fragmentShader = fragmentShader;
   pipelineDescription.renderPass = mPresentPass;

--- a/engine/src/liquid/renderer/RenderGraph.h
+++ b/engine/src/liquid/renderer/RenderGraph.h
@@ -19,12 +19,12 @@ public:
   RenderGraph(StringView name);
 
   /**
-   * @brief Add pass
+   * @brief Add graphics pass
    *
    * @param name Pass name
    * @return Render graph pass
    */
-  RenderGraphPass &addPass(StringView name);
+  RenderGraphPass &addGraphicsPass(StringView name);
 
   /**
    * @brief Add compute pass

--- a/engine/src/liquid/renderer/RenderGraphEvaluator.cpp
+++ b/engine/src/liquid/renderer/RenderGraphEvaluator.cpp
@@ -19,8 +19,8 @@ void RenderGraphEvaluator::build(RenderGraph &graph) {
     if (pass.getType() == RenderGraphPassType::Compute) {
       buildComputePass(index, graph, graph.isDirty());
     } else {
-      buildPass(index, graph,
-                graph.isDirty() && hasSwapchainRelativeResources(pass));
+      buildGraphicsPass(index, graph,
+                        graph.isDirty() && hasSwapchainRelativeResources(pass));
     }
   }
 
@@ -58,8 +58,8 @@ void RenderGraphEvaluator::execute(rhi::RenderCommandList &commandList,
   }
 }
 
-void RenderGraphEvaluator::buildPass(size_t index, RenderGraph &graph,
-                                     bool force) {
+void RenderGraphEvaluator::buildGraphicsPass(size_t index, RenderGraph &graph,
+                                             bool force) {
   LIQUID_PROFILE_EVENT("RenderGraphEvaluator::buildPass");
   auto &pass = graph.getCompiledPasses().at(index);
 
@@ -75,8 +75,8 @@ void RenderGraphEvaluator::buildPass(size_t index, RenderGraph &graph,
 
   rhi::RenderPassDescription renderPassDesc{};
 
-  for (size_t i = 0; i < pass.getOutputs().size(); ++i) {
-    auto &output = pass.mOutputs.at(i);
+  for (size_t i = 0; i < pass.getTextureOutputs().size(); ++i) {
+    auto &output = pass.mTextureOutputs.at(i);
     const auto &attachment = pass.getAttachments().at(i);
 
     const auto &info =
@@ -202,7 +202,7 @@ RenderGraphEvaluator::createAttachment(const AttachmentData &attachment,
 
 bool RenderGraphEvaluator::hasSwapchainRelativeResources(
     RenderGraphPass &pass) {
-  for (auto rt : pass.getOutputs()) {
+  for (auto rt : pass.getTextureOutputs()) {
     auto handle = rt.texture;
     if (handle == rhi::TextureHandle(1) ||
         mDevice->getTextureDescription(handle).sizeMethod ==

--- a/engine/src/liquid/renderer/RenderGraphEvaluator.h
+++ b/engine/src/liquid/renderer/RenderGraphEvaluator.h
@@ -54,7 +54,7 @@ private:
    * @param graph Render graph
    * @param force Force build even if the pass resources exist
    */
-  void buildPass(size_t index, RenderGraph &graph, bool force);
+  void buildGraphicsPass(size_t index, RenderGraph &graph, bool force);
 
   /**
    * @brief Build compute pass resources

--- a/engine/src/liquid/renderer/RenderGraphPass.cpp
+++ b/engine/src/liquid/renderer/RenderGraphPass.cpp
@@ -8,12 +8,12 @@ RenderGraphPass::RenderGraphPass(StringView name, RenderGraphPassType type)
 
 void RenderGraphPass::write(rhi::TextureHandle handle,
                             const rhi::AttachmentClearValue &clearValue) {
-  mOutputs.push_back({handle});
+  mTextureOutputs.push_back({handle});
   mAttachments.push_back({clearValue});
 }
 
 void RenderGraphPass::read(rhi::TextureHandle handle) {
-  mInputs.push_back({handle});
+  mTextureInputs.push_back({handle});
 }
 
 void RenderGraphPass::write(rhi::BufferHandle handle, rhi::BufferType type) {
@@ -41,8 +41,8 @@ void RenderGraphPass::setExecutor(const ExecutorFn &executor) {
   mExecutor = executor;
 }
 
-VirtualPipelineHandle
-RenderGraphPass::addPipeline(const rhi::PipelineDescription &description) {
+VirtualPipelineHandle RenderGraphPass::addPipeline(
+    const rhi::GraphicsPipelineDescription &description) {
   LIQUID_ASSERT(mType == RenderGraphPassType::Graphics,
                 "Cannot create graphics pipeline in a non-graphics pass");
 

--- a/engine/src/liquid/renderer/RenderGraphPass.h
+++ b/engine/src/liquid/renderer/RenderGraphPass.h
@@ -210,7 +210,7 @@ public:
    * @return Virtual graphics pipeline handle
    */
   VirtualPipelineHandle
-  addPipeline(const rhi::PipelineDescription &description);
+  addPipeline(const rhi::GraphicsPipelineDescription &description);
 
   /**
    * @brief Add compute pipeline
@@ -236,27 +236,27 @@ public:
   inline const RenderGraphPassType &getType() const { return mType; }
 
   /**
-   * @brief Get input textures
+   * @brief Get texture inputs
    *
-   * @return Input render targets
+   * @return Texture inputs
    */
-  inline const std::vector<RenderTargetData> &getInputs() const {
-    return mInputs;
+  inline const std::vector<RenderTargetData> &getTextureInputs() const {
+    return mTextureInputs;
   }
 
   /**
-   * @brief Get output textures
+   * @brief Get texture outputs
    *
-   * @return Output render targets
+   * @return Texture outputs
    */
-  inline const std::vector<RenderTargetData> &getOutputs() const {
-    return mOutputs;
+  inline const std::vector<RenderTargetData> &getTextureOutputs() const {
+    return mTextureOutputs;
   }
 
   /**
-   * @brief Get input buffer
+   * @brief Get buffer inputs
    *
-   * @return Input buffers
+   * @return Buffer inputs
    */
   inline const std::vector<RenderGraphPassBufferData> &getBufferInputs() const {
     return mBufferInputs;
@@ -315,8 +315,8 @@ public:
 
 private:
   std::vector<AttachmentData> mAttachments;
-  std::vector<RenderTargetData> mOutputs;
-  std::vector<RenderTargetData> mInputs;
+  std::vector<RenderTargetData> mTextureOutputs;
+  std::vector<RenderTargetData> mTextureInputs;
 
   std::vector<RenderGraphPassBufferData> mBufferInputs;
   std::vector<RenderGraphPassBufferData> mBufferOutputs;

--- a/engine/src/liquid/renderer/RenderGraphRegistry.cpp
+++ b/engine/src/liquid/renderer/RenderGraphRegistry.cpp
@@ -4,7 +4,7 @@
 namespace liquid {
 
 VirtualPipelineHandle
-RenderGraphRegistry::set(const rhi::PipelineDescription &description) {
+RenderGraphRegistry::set(const rhi::GraphicsPipelineDescription &description) {
   mGraphicsPipelineDescriptions.push_back(description);
   mRealGraphicsPipelines.push_back(rhi::PipelineHandle::Invalid);
 

--- a/engine/src/liquid/renderer/RenderGraphRegistry.h
+++ b/engine/src/liquid/renderer/RenderGraphRegistry.h
@@ -45,7 +45,8 @@ public:
    * @param description Graphics pipeline description
    * @return Virtual pipeline handle
    */
-  VirtualPipelineHandle set(const rhi::PipelineDescription &description);
+  VirtualPipelineHandle
+  set(const rhi::GraphicsPipelineDescription &description);
 
   /**
    * @brief Set compute pipeline
@@ -57,7 +58,7 @@ public:
   set(const rhi::ComputePipelineDescription &description);
 
 private:
-  std::vector<rhi::PipelineDescription> mGraphicsPipelineDescriptions;
+  std::vector<rhi::GraphicsPipelineDescription> mGraphicsPipelineDescriptions;
   std::vector<rhi::ComputePipelineDescription> mComputePipelineDescriptions;
 
   std::vector<rhi::PipelineHandle> mRealGraphicsPipelines;

--- a/engine/src/liquid/renderer/SceneRenderer.cpp
+++ b/engine/src/liquid/renderer/SceneRenderer.cpp
@@ -92,10 +92,10 @@ SceneRenderPassData SceneRenderer::attach(RenderGraph &graph) {
   auto depthBuffer = mRenderStorage.createTexture(depthBufferDesc);
 
   {
-    auto &pass = graph.addPass("shadowPass");
+    auto &pass = graph.addGraphicsPass("shadowPass");
     pass.write(shadowmap, rhi::DepthStencilClear{1.0f, 0});
 
-    auto vPipeline = pass.addPipeline(rhi::PipelineDescription{
+    auto vPipeline = pass.addPipeline(rhi::GraphicsPipelineDescription{
         mShaderLibrary.getShader("__engine.shadowmap.default.vertex"),
         mShaderLibrary.getShader("__engine.shadowmap.default.fragment"),
         rhi::PipelineVertexInputLayout::create<Vertex>(),
@@ -103,7 +103,7 @@ SceneRenderPassData SceneRenderer::attach(RenderGraph &graph) {
         rhi::PipelineRasterizer{rhi::PolygonMode::Fill, rhi::CullMode::Front,
                                 rhi::FrontFace::Clockwise}});
 
-    auto vSkinnedPipeline = pass.addPipeline(rhi::PipelineDescription{
+    auto vSkinnedPipeline = pass.addPipeline(rhi::GraphicsPipelineDescription{
         mShaderLibrary.getShader("__engine.shadowmap.skinned.vertex"),
         mShaderLibrary.getShader("__engine.shadowmap.default.fragment"),
         rhi::PipelineVertexInputLayout::create<SkinnedVertex>(),
@@ -160,12 +160,12 @@ SceneRenderPassData SceneRenderer::attach(RenderGraph &graph) {
   } // shadow pass
 
   {
-    auto &pass = graph.addPass("meshPass");
+    auto &pass = graph.addGraphicsPass("meshPass");
     pass.read(shadowmap);
     pass.write(sceneColor, mClearColor);
     pass.write(depthBuffer, rhi::DepthStencilClear{1.0, 0});
 
-    auto vPipeline = pass.addPipeline(rhi::PipelineDescription{
+    auto vPipeline = pass.addPipeline(rhi::GraphicsPipelineDescription{
         mShaderLibrary.getShader("__engine.geometry.default.vertex"),
         mShaderLibrary.getShader("__engine.pbr.default.fragment"),
         rhi::PipelineVertexInputLayout::create<Vertex>(),
@@ -174,7 +174,7 @@ SceneRenderPassData SceneRenderer::attach(RenderGraph &graph) {
                                 rhi::FrontFace::Clockwise},
         rhi::PipelineColorBlend{{rhi::PipelineColorBlendAttachment{}}}});
 
-    auto vSkinnedPipeline = pass.addPipeline(rhi::PipelineDescription{
+    auto vSkinnedPipeline = pass.addPipeline(rhi::GraphicsPipelineDescription{
         mShaderLibrary.getShader("__engine.geometry.skinned.vertex"),
         mShaderLibrary.getShader("__engine.pbr.default.fragment"),
         rhi::PipelineVertexInputLayout::create<SkinnedVertex>(),
@@ -229,7 +229,7 @@ SceneRenderPassData SceneRenderer::attach(RenderGraph &graph) {
   } // mesh pass
 
   {
-    auto &pass = graph.addPass("environmentPass");
+    auto &pass = graph.addGraphicsPass("environmentPass");
     pass.write(sceneColor, mClearColor);
     pass.write(depthBuffer, rhi::DepthStencilClear{1.0f, 0});
     auto vPipeline = pass.addPipeline(
@@ -281,11 +281,11 @@ SceneRenderPassData SceneRenderer::attach(RenderGraph &graph) {
 
 void SceneRenderer::attachText(RenderGraph &graph,
                                const SceneRenderPassData &passData) {
-  auto &pass = graph.addPass("textPass");
+  auto &pass = graph.addGraphicsPass("textPass");
   pass.write(passData.sceneColor, mClearColor);
   pass.write(passData.depthBuffer, rhi::DepthStencilClear{1.0f, 0});
 
-  auto vTextPipeline = pass.addPipeline(rhi::PipelineDescription{
+  auto vTextPipeline = pass.addPipeline(rhi::GraphicsPipelineDescription{
       mShaderLibrary.getShader("__engine.text.default.vertex"),
       mShaderLibrary.getShader("__engine.text.default.fragment"),
       rhi::PipelineVertexInputLayout{},

--- a/engine/tests/liquid-tests/mocks/MockRenderDevice.cpp
+++ b/engine/tests/liquid-tests/mocks/MockRenderDevice.cpp
@@ -91,7 +91,7 @@ void MockRenderDevice::destroyFramebuffer(
     liquid::rhi::FramebufferHandle handle) {}
 
 liquid::rhi::PipelineHandle MockRenderDevice::createPipeline(
-    const liquid::rhi::PipelineDescription &description) {
+    const liquid::rhi::GraphicsPipelineDescription &description) {
   auto handle = getNewHandle<liquid::rhi::PipelineHandle>();
   mPipelines.insert_or_assign(handle, description);
   return handle;

--- a/engine/tests/liquid-tests/mocks/MockRenderDevice.h
+++ b/engine/tests/liquid-tests/mocks/MockRenderDevice.h
@@ -51,7 +51,7 @@ public:
   void destroyFramebuffer(liquid::rhi::FramebufferHandle handle);
 
   liquid::rhi::PipelineHandle
-  createPipeline(const liquid::rhi::PipelineDescription &description);
+  createPipeline(const liquid::rhi::GraphicsPipelineDescription &description);
 
   liquid::rhi::PipelineHandle
   createPipeline(const liquid::rhi::ComputePipelineDescription &description);
@@ -95,7 +95,7 @@ private:
       mFramebuffers;
 
   std::unordered_map<liquid::rhi::PipelineHandle,
-                     liquid::rhi::PipelineDescription>
+                     liquid::rhi::GraphicsPipelineDescription>
       mPipelines;
 
   std::unordered_map<liquid::rhi::PipelineHandle,

--- a/engine/tests/liquid-tests/renderer/RenderGraphPass.test.cpp
+++ b/engine/tests/liquid-tests/renderer/RenderGraphPass.test.cpp
@@ -25,8 +25,8 @@ TEST_F(RenderGraphPassTest, AddsTextureHandleToOutputOnWrite) {
   liquid::rhi::TextureHandle handle{2};
 
   graphicsPass.write(handle, glm::vec4());
-  EXPECT_EQ(graphicsPass.getOutputs().size(), 1);
-  EXPECT_EQ(graphicsPass.getOutputs().at(0).texture, handle);
+  EXPECT_EQ(graphicsPass.getTextureOutputs().size(), 1);
+  EXPECT_EQ(graphicsPass.getTextureOutputs().at(0).texture, handle);
 }
 
 TEST_F(RenderGraphPassTest, AddsClearValueToAttachmentDataOnWrite) {
@@ -49,9 +49,9 @@ TEST_F(RenderGraphPassTest, AddsTextureHandleToInputOnRead) {
 
   graphicsPass.read(handle);
   EXPECT_EQ(graphicsPass.getAttachments().size(), 0);
-  EXPECT_EQ(graphicsPass.getOutputs().size(), 0);
-  EXPECT_EQ(graphicsPass.getInputs().size(), 1);
-  EXPECT_EQ(graphicsPass.getInputs().at(0).texture, handle);
+  EXPECT_EQ(graphicsPass.getTextureOutputs().size(), 0);
+  EXPECT_EQ(graphicsPass.getTextureInputs().size(), 1);
+  EXPECT_EQ(graphicsPass.getTextureInputs().at(0).texture, handle);
 }
 
 TEST_F(RenderGraphPassTest, FailsWritingBufferWithVertexOnGraphicsPass) {


### PR DESCRIPTION
- Rename pipeline description to graphics pipeline description
- Rename input and outputs in render graph passes to texture inputs and outputs
- Rename addPass method to addGraphicsPass