### PR TITLE
Extend test coverage report

### DIFF
--- a/.github/workflows/github-actions-pr.yml
+++ b/.github/workflows/github-actions-pr.yml
@@ -94,23 +94,27 @@ jobs:
 
       - name: Build
         run: |
-          make --directory workspace -j$(nproc)
+          make --directory workspace -j$(nproc) config=test
 
-      - name: Test
+      - name: Test engine
         run: |
-          cd workspace/engine-test/bin/Debug
+          cd workspace/engine-test/bin/Test
           ./LiquidEngineTest
+
+      - name: Test editor
+        run: |
+          cd workspace/editor-test/bin/Test
+          ./LiquidEditorTest
 
       - name: Coverage
         run: |
-          lcov -c --directory workspace/engine-test/obj -o coverage-report.info
-          lcov -r coverage-report.info "*vendor*" "/usr*" "*engine/tests*" -o coverage-report.info
+          ./scripts/generate-coverage-report.sh
 
       - name: Upload to Codecov
         uses: codecov/codecov-action@v2
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          files: ./coverage-report.info
+          files: ./coverage/report.info
           flags: engine-unit
           verbose: true
           fail_ci_if_error: true

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@ vendor/
 # Doxygen
 autodocs/
 doxy.warn
+
+# Coverage
+coverage/

--- a/.premake/core/dependencies.lua
+++ b/.premake/core/dependencies.lua
@@ -29,7 +29,7 @@ function linkDependenciesWithoutVulkan()
         "PhysXFoundation_static"
     }
 
-    filter { "system:windows", "configurations:Debug" }
+    filter { "system:windows", "configurations:Debug or configurations:Test" }
         links { "yaml-cppd", "freetyped", "dwmapi" }
 
     filter { "system:windows", "configurations:Release or configurations:Profile" }
@@ -66,7 +66,7 @@ end
 
 -- Link Google Test
 function linkGoogleTest()
-    filter { "system:windows", "configurations:Debug" }
+    filter { "system:windows", "configurations:Debug or configurations:Test" }
         links { "gtestd", "gmockd" }
 
     filter {"system:windows", "configurations:Release"}

--- a/.premake/core/library.lua
+++ b/.premake/core/library.lua
@@ -6,7 +6,7 @@ function setupLibraryDirectories()
         "KHRONOS_STATIC"
     }
 
-    filter { "configurations:Debug" }
+    filter { "configurations:Debug or configurations:Test" }
         sysincludedirs {
             "../vendor/Debug/include",
             "../vendor/Debug/include/freetype2",

--- a/.premake/core/testing.lua
+++ b/.premake/core/testing.lua
@@ -1,5 +1,5 @@
 function setupTestingOptions()
-    filter { "toolset:clang" }
+    filter { "configurations:Test", "toolset:clang" }
         buildoptions {
             "-fprofile-instr-generate",
             "-fcoverage-mapping"
@@ -10,7 +10,7 @@ function setupTestingOptions()
             "-fcoverage-mapping"
         }
 
-    filter { "toolset:gcc" }
+    filter { "configurations:Test", "toolset:gcc" }
         buildoptions {
             "-fprofile-arcs",
             "-ftest-coverage"

--- a/.premake/core/toolset.lua
+++ b/.premake/core/toolset.lua
@@ -35,7 +35,7 @@ function setupToolsetOptions()
             ["ENABLE_STRICT_OBJC_MSGSEND"] = "YES",
         }
 
-        filter { "configurations:Debug" }
+        filter { "configurations:Debug or configurations:Test" }
             xcodebuildsettings {
                 ["CLANG_ENABLE_OBJC_WEAK"] = "YES",
                 ["CODE_SIGN_IDENTITY"] = "-"

--- a/.premake/workspace.lua
+++ b/.premake/workspace.lua
@@ -6,12 +6,13 @@ workspace "LiquidEngine"
     architecture "x86_64"
 
     -- Set editor as starting project
-    startproject "Liquidator"
+    startproject "LiquidEditor"
     
     setupLibraryDirectories{}
     setupPlatformDefines{}
     linkPlatformLibraries{}
     setupToolsetOptions{}
+    setupTestingOptions{}
     
     includedirs {
         "../engine/src",
@@ -20,12 +21,12 @@ workspace "LiquidEngine"
         "../engine/platform-tools/include"
     }
     
-    configurations { "Debug", "Release", "Profile" }
+    configurations { "Debug", "Release", "Profile", "Test" }
 
     filter { "toolset:msc-*" }
         flags { "FatalCompileWarnings" }
 
-    filter {"configurations:Debug"}
+    filter {"configurations:Debug or configurations:Test"}
         defines { "LIQUID_DEBUG" }
         symbols "On"
 
@@ -35,3 +36,6 @@ workspace "LiquidEngine"
 
     filter {"configurations:Profile"}
         defines { "LIQUID_PROFILER" }
+
+    defines { "configurations:Test" }
+        defines { "LIQUID_TEST" }

--- a/editor/premake5.lua
+++ b/editor/premake5.lua
@@ -38,7 +38,7 @@ project "LiquidEditorTest"
     kind "ConsoleApp"
 
     configurations {
-        "Debug"
+        "Debug", "Test"
     }
 
     includedirs {
@@ -60,7 +60,6 @@ project "LiquidEditorTest"
         "src/main.cpp"
     }
 
-    setupTestingOptions{}
     links { "LiquidEngine", "LiquidRHICore", "LiquidRHIVulkan", "LiquidPlatformTools", "vendor-libimguizmo", "vendor-libmikktspace" }
     linkGoogleTest{}
     linkDependenciesWithoutVulkan{}
@@ -68,7 +67,6 @@ project "LiquidEditorTest"
     copyEngineAssets()
 
     postbuildcommands {
-        "{MKDIR} %{cfg.buildtarget.directory}/fixtures",
         "{COPYDIR} ../../editor/tests/fixtures %{cfg.buildtarget.directory}/fixtures"
     }
 

--- a/engine/premake5.lua
+++ b/engine/premake5.lua
@@ -45,7 +45,7 @@ project "LiquidEngineTest"
     kind "ConsoleApp"
 
     configurations {
-        "Debug"
+        "Debug", "Test"
     }
 
     includedirs {
@@ -64,7 +64,6 @@ project "LiquidEngineTest"
         "src/liquid/rhi/vulkan/VmaImpl.cpp",
     }
 
-    setupTestingOptions{}
     links { "LiquidEngine", "LiquidRHICore" }
     linkGoogleTest{}
     linkDependenciesWithoutVulkan{}

--- a/scripts/clang-tidy-all.sh
+++ b/scripts/clang-tidy-all.sh
@@ -1,7 +1,5 @@
 #!/bin/sh
 
-
-
 if [ -z $1 ]; then
     CMD=clang-tidy
 else

--- a/scripts/generate-coverage-report.sh
+++ b/scripts/generate-coverage-report.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+rm -rf coverage/
+mkdir -p coverage/
+lcov -c --directory workspace -o coverage/report.info
+lcov -r coverage/report.info "*vendor*" "/usr*" "*engine/tests*" "*editor/tests*" -o coverage/report.info
+
+if [ $1 = 'html' ]; then
+    genhtml coverage/report.info --output-directory coverage/ --prefix $(pwd)
+fi


### PR DESCRIPTION
- Add Test environment in premake config
- Test environment will include all the options of Debug environment
- Create test artifacts during build on test environment
- Create script to generate code coverage report for both codecov and html
- Fix starting project
- Test both engine and editor in CI
- Update copydir command for editor fixtures