### PR TITLE
Allow multiple buffer usage types for a buffer

### DIFF
--- a/editor/src/liquidator/core/EditorRenderer.cpp
+++ b/editor/src/liquidator/core/EditorRenderer.cpp
@@ -283,7 +283,8 @@ void EditorRenderer::createCollidableShapes() {
     };
 
     mCollidableCube.buffer = mRenderStorage.createBuffer(
-        {rhi::BufferType::Vertex, CollidableBoxVertices.size() * sizeof(Vertex),
+        {rhi::BufferUsage::Vertex,
+         CollidableBoxVertices.size() * sizeof(Vertex),
          static_cast<const void *>(CollidableBoxVertices.data())});
     mCollidableCube.vertexCount =
         static_cast<uint32_t>(CollidableBoxVertices.size());
@@ -335,7 +336,7 @@ void EditorRenderer::createCollidableShapes() {
     drawUnitCircle(CollidableSphereVertices, NumSegments, cSin, cCos, cZero);
 
     mCollidableSphere.buffer = mRenderStorage.createBuffer(
-        {rhi::BufferType::Vertex,
+        {rhi::BufferUsage::Vertex,
          CollidableSphereVertices.size() * sizeof(Vertex),
          static_cast<const void *>(CollidableSphereVertices.data())});
     mCollidableSphere.vertexCount =
@@ -393,7 +394,7 @@ void EditorRenderer::createCollidableShapes() {
                        cSinCenter(-0.5f), cCos, -Pi);
 
     mCollidableCapsule.buffer = mRenderStorage.createBuffer(
-        {rhi::BufferType::Vertex,
+        {rhi::BufferUsage::Vertex,
          CollidableCapsuleVertices.size() * sizeof(Vertex),
          static_cast<const void *>(CollidableCapsuleVertices.data())});
     mCollidableCapsule.vertexCount =

--- a/editor/src/liquidator/core/EditorRendererFrameData.cpp
+++ b/editor/src/liquidator/core/EditorRendererFrameData.cpp
@@ -12,7 +12,7 @@ EditorRendererFrameData::EditorRendererFrameData(RenderStorage &renderStorage,
   mSkeletonVector.reset(new glm::mat4[mReservedSpace * MaxNumBones]);
 
   rhi::BufferDescription defaultDesc{};
-  defaultDesc.type = rhi::BufferType::Storage;
+  defaultDesc.usage = rhi::BufferUsage::Storage;
   defaultDesc.size = mReservedSpace * sizeof(glm::mat4);
   defaultDesc.mapped = true;
 
@@ -32,14 +32,14 @@ EditorRendererFrameData::EditorRendererFrameData(RenderStorage &renderStorage,
 
   {
     auto desc = defaultDesc;
-    desc.type = rhi::BufferType::Uniform;
+    desc.usage = rhi::BufferUsage::Uniform;
     desc.size = sizeof(Camera);
     mCameraBuffer = renderStorage.createBuffer(desc);
   }
 
   {
     auto desc = defaultDesc;
-    desc.type = rhi::BufferType::Uniform;
+    desc.usage = rhi::BufferUsage::Uniform;
     desc.size = sizeof(EditorGridData);
     mEditorGridBuffer = renderStorage.createBuffer(desc);
   }
@@ -47,7 +47,7 @@ EditorRendererFrameData::EditorRendererFrameData(RenderStorage &renderStorage,
   {
     auto desc = defaultDesc;
     desc.size = sizeof(CollidableEntity);
-    desc.type = rhi::BufferType::Uniform;
+    desc.usage = rhi::BufferUsage::Uniform;
     mCollidableEntityBuffer = renderStorage.createBuffer(desc);
   }
 

--- a/editor/src/liquidator/core/MousePickingGraph.cpp
+++ b/editor/src/liquidator/core/MousePickingGraph.cpp
@@ -32,12 +32,12 @@ MousePickingGraph::MousePickingGraph(
   auto depthBuffer = renderStorage.createTexture(depthBufferDesc);
 
   Entity nullEntity{0};
-  mSelectedEntityBuffer =
-      renderStorage.createBuffer({rhi::BufferType::Storage, sizeof(Entity),
-                                  &nullEntity, rhi::BufferUsage::HostRead});
+  mSelectedEntityBuffer = renderStorage.createBuffer(
+      {rhi::BufferUsage::Storage, sizeof(Entity), &nullEntity,
+       rhi::BufferAllocationUsage::HostRead});
 
   rhi::BufferDescription defaultDesc{};
-  defaultDesc.type = rhi::BufferType::Storage;
+  defaultDesc.usage = rhi::BufferUsage::Storage;
   defaultDesc.size = sizeof(Entity) * mFrameData.at(0).getReservedSpace();
   defaultDesc.mapped = true;
 

--- a/engine/rhi/core/include/liquid/rhi/BufferDescription.h
+++ b/engine/rhi/core/include/liquid/rhi/BufferDescription.h
@@ -2,7 +2,7 @@
 
 namespace liquid::rhi {
 
-enum class BufferType {
+enum class BufferUsage {
   None = 0,
   Vertex = 1 << 0,
   Index = 1 << 1,
@@ -13,24 +13,24 @@ enum class BufferType {
   TransferDestination = 1 << 6
 };
 
-EnableBitwiseEnum(BufferType);
+EnableBitwiseEnum(BufferUsage);
 
-enum class BufferUsage : uint8_t {
+enum class BufferAllocationUsage : uint8_t {
   None = 0,
   HostWrite = 1 << 0,
   HostRead = 1 << 1
 };
 
-EnableBitwiseEnum(BufferUsage);
+EnableBitwiseEnum(BufferAllocationUsage);
 
 /**
  * @brief Buffer description
  */
 struct BufferDescription {
   /**
-   * Buffer type
+   * Buffer usage
    */
-  BufferType type = rhi::BufferType::Vertex;
+  BufferUsage usage = rhi::BufferUsage::Vertex;
 
   /**
    * Buffer size
@@ -43,9 +43,9 @@ struct BufferDescription {
   const void *data = nullptr;
 
   /**
-   * @brief Buffer usage
+   * Buffer allocation usage
    */
-  BufferUsage usage = rhi::BufferUsage::HostWrite;
+  BufferAllocationUsage allocationUsage = rhi::BufferAllocationUsage::HostWrite;
 
   /**
    * @brief Keep buffer always mapped

--- a/engine/rhi/vulkan/include/liquid/rhi-vulkan/VulkanBuffer.h
+++ b/engine/rhi/vulkan/include/liquid/rhi-vulkan/VulkanBuffer.h
@@ -70,11 +70,11 @@ public:
   inline VmaAllocation getAllocation() const { return mAllocation; }
 
   /**
-   * @brief Get buffer type
+   * @brief Get buffer usage
    *
-   * @return Buffer type
+   * @return Buffer usage
    */
-  inline rhi::BufferType getType() const { return mType; }
+  inline rhi::BufferUsage getUsage() const { return mUsage; }
 
   /**
    * @brief Get buffer size
@@ -96,8 +96,8 @@ private:
 
   VkBuffer mBuffer = VK_NULL_HANDLE;
   VmaAllocation mAllocation = VK_NULL_HANDLE;
-  rhi::BufferType mType;
   rhi::BufferUsage mUsage;
+  rhi::BufferAllocationUsage mAllocationUsage;
   bool mMapped = false;
   size_t mSize = 0;
   void *mMappedData = nullptr;

--- a/engine/rhi/vulkan/src/VulkanBuffer.cpp
+++ b/engine/rhi/vulkan/src/VulkanBuffer.cpp
@@ -7,8 +7,9 @@ namespace liquid::rhi {
 
 VulkanBuffer::VulkanBuffer(const BufferDescription &description,
                            VulkanResourceAllocator &allocator)
-    : mAllocator(allocator), mType(description.type), mUsage(description.usage),
-      mSize(description.size), mMapped(description.mapped) {
+    : mAllocator(allocator), mUsage(description.usage),
+      mAllocationUsage(description.allocationUsage), mSize(description.size),
+      mMapped(description.mapped) {
   createBuffer(description);
 }
 
@@ -36,13 +37,13 @@ void VulkanBuffer::unmap() {
 
 void VulkanBuffer::resize(size_t size) {
   mSize = size;
-  createBuffer({mType, mSize, nullptr, mUsage, mMapped});
+  createBuffer({mUsage, mSize, nullptr, mAllocationUsage, mMapped});
 }
 
 void VulkanBuffer::createBuffer(const BufferDescription &description) {
   mSize = description.size;
-  mType = description.type;
   mUsage = description.usage;
+  mAllocationUsage = description.allocationUsage;
 
   VmaAllocationCreateFlags allocationFlags = 0;
 
@@ -50,31 +51,40 @@ void VulkanBuffer::createBuffer(const BufferDescription &description) {
     allocationFlags |= VMA_ALLOCATION_CREATE_MAPPED_BIT;
   }
 
-  if ((mUsage & BufferUsage::HostWrite) == BufferUsage::HostWrite) {
+  if ((mAllocationUsage & BufferAllocationUsage::HostWrite) ==
+      BufferAllocationUsage::HostWrite) {
     allocationFlags |= VMA_ALLOCATION_CREATE_HOST_ACCESS_SEQUENTIAL_WRITE_BIT;
   }
 
-  if ((mUsage & BufferUsage::HostRead) == BufferUsage::HostRead) {
+  if ((mAllocationUsage & BufferAllocationUsage::HostRead) ==
+      BufferAllocationUsage::HostRead) {
     allocationFlags |= VMA_ALLOCATION_CREATE_HOST_ACCESS_RANDOM_BIT;
   }
 
   VmaMemoryUsage memoryUsage = VMA_MEMORY_USAGE_CPU_TO_GPU;
-  VkBufferUsageFlags bufferUsage = VK_BUFFER_USAGE_FLAG_BITS_MAX_ENUM;
-  if (description.type == rhi::BufferType::Vertex) {
-    bufferUsage = VK_BUFFER_USAGE_VERTEX_BUFFER_BIT;
-  } else if (description.type == rhi::BufferType::Index) {
-    bufferUsage = VK_BUFFER_USAGE_INDEX_BUFFER_BIT;
-  } else if (description.type == rhi::BufferType::Uniform) {
-    bufferUsage = VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT;
-  } else if (description.type == rhi::BufferType::Storage) {
-    bufferUsage = VK_BUFFER_USAGE_STORAGE_BUFFER_BIT;
-  } else if (description.type == rhi::BufferType::TransferSource) {
-    bufferUsage = VK_BUFFER_USAGE_TRANSFER_SRC_BIT;
-  } else if (description.type == rhi::BufferType::TransferDestination) {
-    bufferUsage = VK_BUFFER_USAGE_TRANSFER_DST_BIT;
-  } else if (description.type == rhi::BufferType::Indirect) {
-    bufferUsage = VK_BUFFER_USAGE_INDIRECT_BUFFER_BIT;
+  VkBufferUsageFlags bufferUsage = 0;
+  if (BitwiseEnumContains(description.usage, rhi::BufferUsage::Vertex)) {
+    bufferUsage |= VK_BUFFER_USAGE_VERTEX_BUFFER_BIT;
+  } else if (BitwiseEnumContains(description.usage, rhi::BufferUsage::Index)) {
+    bufferUsage |= VK_BUFFER_USAGE_INDEX_BUFFER_BIT;
+  } else if (BitwiseEnumContains(description.usage,
+                                 rhi::BufferUsage::Uniform)) {
+    bufferUsage |= VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT;
+  } else if (BitwiseEnumContains(description.usage,
+                                 rhi::BufferUsage::Storage)) {
+    bufferUsage |= VK_BUFFER_USAGE_STORAGE_BUFFER_BIT;
+  } else if (BitwiseEnumContains(description.usage,
+                                 rhi::BufferUsage::TransferSource)) {
+    bufferUsage |= VK_BUFFER_USAGE_TRANSFER_SRC_BIT;
+  } else if (BitwiseEnumContains(description.usage,
+                                 rhi::BufferUsage::TransferDestination)) {
+    bufferUsage |= VK_BUFFER_USAGE_TRANSFER_DST_BIT;
+  } else if (BitwiseEnumContains(description.usage,
+                                 rhi::BufferUsage::Indirect)) {
+    bufferUsage |= VK_BUFFER_USAGE_INDIRECT_BUFFER_BIT;
   }
+
+  LIQUID_ASSERT(bufferUsage != 0, "Buffer usage cannot be empty");
 
   VkBufferCreateInfo createBufferInfo{};
   createBufferInfo.sType = VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO;

--- a/engine/src/liquid/asset/AssetRegistry.cpp
+++ b/engine/src/liquid/asset/AssetRegistry.cpp
@@ -129,7 +129,7 @@ void AssetRegistry::syncWithDevice(RenderStorage &renderStorage) {
 
     {
       rhi::BufferDescription description;
-      description.type = rhi::BufferType::Vertex;
+      description.usage = rhi::BufferUsage::Vertex;
       description.size = vbSize;
       description.data = nullptr;
       mesh.data.vertexBuffer = renderStorage.createBuffer(description);
@@ -148,7 +148,7 @@ void AssetRegistry::syncWithDevice(RenderStorage &renderStorage) {
 
     {
       rhi::BufferDescription description;
-      description.type = rhi::BufferType::Index;
+      description.usage = rhi::BufferUsage::Index;
       description.size = ibSize;
       description.data = nullptr;
       mesh.data.indexBuffer = renderStorage.createBuffer(description);
@@ -191,7 +191,7 @@ void AssetRegistry::syncWithDevice(RenderStorage &renderStorage) {
 
     {
       rhi::BufferDescription description;
-      description.type = rhi::BufferType::Vertex;
+      description.usage = rhi::BufferUsage::Vertex;
       description.size = vbSize;
       description.data = nullptr;
       mesh.data.vertexBuffer = renderStorage.createBuffer(description);
@@ -210,7 +210,7 @@ void AssetRegistry::syncWithDevice(RenderStorage &renderStorage) {
 
     {
       rhi::BufferDescription description;
-      description.type = rhi::BufferType::Index;
+      description.usage = rhi::BufferUsage::Index;
       description.size = ibSize;
       description.data = nullptr;
       mesh.data.indexBuffer = renderStorage.createBuffer(description);

--- a/engine/src/liquid/imgui/ImguiRenderer.cpp
+++ b/engine/src/liquid/imgui/ImguiRenderer.cpp
@@ -47,13 +47,13 @@ ImguiRenderer::ImguiRenderer(Window &window, ShaderLibrary &shaderLibrary,
 
   for (auto &x : mFrameData) {
     liquid::rhi::BufferDescription vertexDesc{};
-    vertexDesc.type = liquid::rhi::BufferType::Vertex;
+    vertexDesc.usage = liquid::rhi::BufferUsage::Vertex;
     vertexDesc.size = 1;
     vertexDesc.mapped = true;
     x.vertexBuffer = renderStorage.createBuffer(vertexDesc);
 
     liquid::rhi::BufferDescription indexDesc{};
-    indexDesc.type = liquid::rhi::BufferType::Index;
+    indexDesc.usage = liquid::rhi::BufferUsage::Index;
     indexDesc.size = 1;
     indexDesc.mapped = true;
     x.indexBuffer = renderStorage.createBuffer(indexDesc);

--- a/engine/src/liquid/renderer/Material.cpp
+++ b/engine/src/liquid/renderer/Material.cpp
@@ -18,7 +18,7 @@ Material::Material(const std::vector<rhi::TextureHandle> &textures,
   if (!mProperties.empty()) {
     auto size = updateBufferData();
     mBuffer =
-        renderStorage.createBuffer({rhi::BufferType::Uniform, size, mData});
+        renderStorage.createBuffer({rhi::BufferUsage::Uniform, size, mData});
     mDescriptor = renderStorage.createMaterialDescriptor(mBuffer);
   }
 }

--- a/engine/src/liquid/renderer/RenderGraph.cpp
+++ b/engine/src/liquid/renderer/RenderGraph.cpp
@@ -244,29 +244,30 @@ void RenderGraph::compile(rhi::RenderDevice *device) {
       rhi::Access srcAccess{rhi::Access::None};
       rhi::Access dstAccess{rhi::Access::None};
 
-      if ((input.type & rhi::BufferType::Vertex) == rhi::BufferType::Vertex) {
+      if ((input.usage & rhi::BufferUsage::Vertex) ==
+          rhi::BufferUsage::Vertex) {
         stage |= rhi::PipelineStage::VertexInput;
         srcAccess = rhi::Access::ShaderWrite;
         dstAccess |= rhi::Access::VertexAttributeRead;
       }
 
-      if ((input.type & rhi::BufferType::Index) == rhi::BufferType::Index) {
+      if ((input.usage & rhi::BufferUsage::Index) == rhi::BufferUsage::Index) {
         stage |= rhi::PipelineStage::VertexInput;
         srcAccess |= rhi::Access::ShaderWrite;
         dstAccess |= rhi::Access::IndexRead;
       }
 
-      if ((input.type & rhi::BufferType::Indirect) ==
-          rhi::BufferType::Indirect) {
+      if ((input.usage & rhi::BufferUsage::Indirect) ==
+          rhi::BufferUsage::Indirect) {
         stage |= rhi::PipelineStage::DrawIndirect;
         srcAccess |= rhi::Access::ShaderWrite;
         dstAccess |= rhi::Access::IndirectCommandRead;
       }
 
-      if (((input.type & rhi::BufferType::Storage) ==
-           rhi::BufferType::Storage) ||
-          ((input.type & rhi::BufferType::Uniform) ==
-           rhi::BufferType::Uniform)) {
+      if (((input.usage & rhi::BufferUsage::Storage) ==
+           rhi::BufferUsage::Storage) ||
+          ((input.usage & rhi::BufferUsage::Uniform) ==
+           rhi::BufferUsage::Uniform)) {
         if (pass.getType() == RenderGraphPassType::Compute) {
           stage |= rhi::PipelineStage::ComputeShader;
         } else {
@@ -291,10 +292,10 @@ void RenderGraph::compile(rhi::RenderDevice *device) {
       rhi::Access srcAccess{rhi::Access::None};
       rhi::Access dstAccess{rhi::Access::None};
 
-      if (((output.type & rhi::BufferType::Storage) ==
-           rhi::BufferType::Storage) ||
-          ((output.type & rhi::BufferType::Uniform) ==
-           rhi::BufferType::Uniform)) {
+      if (((output.usage & rhi::BufferUsage::Storage) ==
+           rhi::BufferUsage::Storage) ||
+          ((output.usage & rhi::BufferUsage::Uniform) ==
+           rhi::BufferUsage::Uniform)) {
         if (pass.getType() == RenderGraphPassType::Compute) {
           stage |= rhi::PipelineStage::ComputeShader;
         } else {

--- a/engine/src/liquid/renderer/RenderGraphPass.cpp
+++ b/engine/src/liquid/renderer/RenderGraphPass.cpp
@@ -16,25 +16,25 @@ void RenderGraphPass::read(rhi::TextureHandle handle) {
   mTextureInputs.push_back({handle});
 }
 
-void RenderGraphPass::write(rhi::BufferHandle handle, rhi::BufferType type) {
+void RenderGraphPass::write(rhi::BufferHandle handle, rhi::BufferUsage usage) {
   LIQUID_ASSERT(
-      !BitwiseEnumContains(type, liquid::rhi::BufferType::Vertex) &&
-          !BitwiseEnumContains(type, liquid::rhi::BufferType::Index) &&
-          !BitwiseEnumContains(type, liquid::rhi::BufferType::Indirect),
+      !BitwiseEnumContains(usage, liquid::rhi::BufferUsage::Vertex) &&
+          !BitwiseEnumContains(usage, liquid::rhi::BufferUsage::Index) &&
+          !BitwiseEnumContains(usage, liquid::rhi::BufferUsage::Indirect),
       "Buffers can only be written from Uniform or Storage");
-  mBufferOutputs.push_back({handle, type});
+  mBufferOutputs.push_back({handle, usage});
 }
 
-void RenderGraphPass::read(rhi::BufferHandle handle, rhi::BufferType type) {
+void RenderGraphPass::read(rhi::BufferHandle handle, rhi::BufferUsage usage) {
   if (mType == RenderGraphPassType::Compute) {
     LIQUID_ASSERT(
-        !BitwiseEnumContains(type, liquid::rhi::BufferType::Vertex) &&
-            !BitwiseEnumContains(type, liquid::rhi::BufferType::Index),
+        !BitwiseEnumContains(usage, liquid::rhi::BufferUsage::Vertex) &&
+            !BitwiseEnumContains(usage, liquid::rhi::BufferUsage::Index),
         "Compute pass can only read "
         "buffers from uniform, storage, "
         "or indirect");
   }
-  mBufferInputs.push_back({handle, type});
+  mBufferInputs.push_back({handle, usage});
 }
 
 void RenderGraphPass::setExecutor(const ExecutorFn &executor) {

--- a/engine/src/liquid/renderer/RenderGraphPass.h
+++ b/engine/src/liquid/renderer/RenderGraphPass.h
@@ -58,14 +58,14 @@ struct RenderTargetData {
  */
 struct RenderGraphPassBufferData {
   /**
-   * @brief Buffer
+   * Buffer
    */
   rhi::BufferHandle buffer = rhi::BufferHandle::Invalid;
 
   /**
-   * @brief Buffer type
+   * Buffer usage
    */
-  rhi::BufferType type = rhi::BufferType::None;
+  rhi::BufferUsage usage = rhi::BufferUsage::None;
 };
 
 /**
@@ -184,17 +184,17 @@ public:
    * @brief Set output buffer
    *
    * @param handle Buffer handle
-   * @param type Buffer type
+   * @param usage Buffer usage
    */
-  void write(rhi::BufferHandle handle, rhi::BufferType type);
+  void write(rhi::BufferHandle handle, rhi::BufferUsage usage);
 
   /**
    * @brief Set input buffer
    *
    * @param handle Buffer handle
-   * @param type Buffer type
+   * @param usage Buffer usage
    */
-  void read(rhi::BufferHandle handle, rhi::BufferType type);
+  void read(rhi::BufferHandle handle, rhi::BufferUsage usage);
 
   /**
    * @brief Set executor function

--- a/engine/src/liquid/renderer/RenderStorage.cpp
+++ b/engine/src/liquid/renderer/RenderStorage.cpp
@@ -88,11 +88,11 @@ rhi::Buffer
 RenderStorage::createBuffer(const liquid::rhi::BufferDescription &description) {
   auto buffer = mDevice->createBuffer(description);
 
-  if (description.type == rhi::BufferType::Storage) {
+  if (description.usage == rhi::BufferUsage::Storage) {
     mGlobalBuffersDescriptor.write(0, {buffer.getHandle()},
                                    rhi::DescriptorType::StorageBuffer,
                                    rhi::castHandleToUint(buffer.getHandle()));
-  } else if (description.type == rhi::BufferType::Uniform) {
+  } else if (description.usage == rhi::BufferUsage::Uniform) {
     mGlobalBuffersDescriptor.write(1, {buffer.getHandle()},
                                    rhi::DescriptorType::UniformBuffer,
                                    rhi::castHandleToUint(buffer.getHandle()));

--- a/engine/src/liquid/renderer/SceneRendererFrameData.cpp
+++ b/engine/src/liquid/renderer/SceneRendererFrameData.cpp
@@ -17,7 +17,7 @@ SceneRendererFrameData::SceneRendererFrameData(RenderStorage &renderStorage,
   mTextGlyphs.reserve(mReservedSpace);
 
   rhi::BufferDescription defaultDesc{};
-  defaultDesc.type = rhi::BufferType::Storage;
+  defaultDesc.usage = rhi::BufferUsage::Storage;
   defaultDesc.size = mReservedSpace * sizeof(glm::mat4);
   defaultDesc.mapped = true;
 
@@ -46,21 +46,21 @@ SceneRendererFrameData::SceneRendererFrameData(RenderStorage &renderStorage,
   {
     auto desc = defaultDesc;
     desc.size = sizeof(Camera);
-    desc.type = rhi::BufferType::Uniform;
+    desc.usage = rhi::BufferUsage::Uniform;
     mCameraBuffer = renderStorage.createBuffer(desc);
   }
 
   {
     auto desc = defaultDesc;
     desc.size = sizeof(SceneData);
-    desc.type = rhi::BufferType::Uniform;
+    desc.usage = rhi::BufferUsage::Uniform;
     mSceneBuffer = renderStorage.createBuffer(desc);
   }
 
   {
     auto desc = defaultDesc;
     desc.size = sizeof(SkyboxData);
-    desc.type = rhi::BufferType::Uniform;
+    desc.usage = rhi::BufferUsage::Uniform;
     mSkyboxBuffer = renderStorage.createBuffer(desc);
   }
 

--- a/engine/src/liquid/renderer/TextureUtils.cpp
+++ b/engine/src/liquid/renderer/TextureUtils.cpp
@@ -11,7 +11,7 @@ void TextureUtils::copyDataToTexture(
   rhi::BufferDescription stagingBufferDesc{};
   stagingBufferDesc.size = getBufferSizeFromLevels(destinationLevels);
   stagingBufferDesc.data = source;
-  stagingBufferDesc.type = rhi::BufferType::TransferSource;
+  stagingBufferDesc.usage = rhi::BufferUsage::TransferSource;
 
   auto stagingBuffer = device->createBuffer(stagingBufferDesc);
 
@@ -64,7 +64,7 @@ void TextureUtils::copyTextureToData(
   rhi::BufferDescription stagingBufferDesc{};
   stagingBufferDesc.size = getBufferSizeFromLevels(sourceLevels);
   stagingBufferDesc.data = nullptr;
-  stagingBufferDesc.type = rhi::BufferType::TransferDestination;
+  stagingBufferDesc.usage = rhi::BufferUsage::TransferDestination;
 
   auto stagingBuffer = device->createBuffer(stagingBufferDesc);
 

--- a/engine/tests/liquid-tests/renderer/RenderGraph.test.cpp
+++ b/engine/tests/liquid-tests/renderer/RenderGraph.test.cpp
@@ -87,14 +87,14 @@ TEST_F(RenderGraphTest, TopologicallySortRenderGraph) {
 
   {
     auto &pass = graph.addGraphicsPass("A");
-    pass.write(buffers.at("a-b"), liquid::rhi::BufferType::Storage);
+    pass.write(buffers.at("a-b"), liquid::rhi::BufferUsage::Storage);
     pass.write(textures.at("a-d"), glm::vec4());
   }
 
   {
     auto &pass = graph.addGraphicsPass("B");
-    pass.read(buffers.at("a-b"), liquid::rhi::BufferType::Vertex);
-    pass.read(buffers.at("d-b"), liquid::rhi::BufferType::Index);
+    pass.read(buffers.at("a-b"), liquid::rhi::BufferUsage::Vertex);
+    pass.read(buffers.at("d-b"), liquid::rhi::BufferUsage::Index);
     pass.write(textures.at("b-c"), glm::vec4());
     pass.write(textures.at("b-g"), glm::vec4());
   }
@@ -109,7 +109,7 @@ TEST_F(RenderGraphTest, TopologicallySortRenderGraph) {
   {
     auto &pass = graph.addGraphicsPass("D");
     pass.read(textures.at("a-d"));
-    pass.write(buffers.at("d-b"), liquid::rhi::BufferType::Uniform);
+    pass.write(buffers.at("d-b"), liquid::rhi::BufferUsage::Uniform);
     pass.write(textures.at("d-e"), glm::vec4());
     pass.write(textures.at("d-g"), glm::vec4());
   }
@@ -561,12 +561,12 @@ TEST_F(RenderGraphTest, SetsPassBarrierForUniformBufferReadInGraphicsPass) {
 
   {
     auto &pass = graph.addGraphicsPass("A");
-    pass.write(buffer1, liquid::rhi::BufferType::Storage);
+    pass.write(buffer1, liquid::rhi::BufferUsage::Storage);
   }
 
   {
     auto &pass = graph.addGraphicsPass("C");
-    pass.read(buffer1, liquid::rhi::BufferType::Uniform);
+    pass.read(buffer1, liquid::rhi::BufferUsage::Uniform);
   }
 
   graph.compile(&device);
@@ -589,12 +589,12 @@ TEST_F(RenderGraphTest, SetsPassBarrierForUniformBufferReadInComputePass) {
 
   {
     auto &pass = graph.addGraphicsPass("A");
-    pass.write(buffer1, liquid::rhi::BufferType::Storage);
+    pass.write(buffer1, liquid::rhi::BufferUsage::Storage);
   }
 
   {
     auto &pass = graph.addComputePass("C");
-    pass.read(buffer1, liquid::rhi::BufferType::Uniform);
+    pass.read(buffer1, liquid::rhi::BufferUsage::Uniform);
   }
 
   graph.compile(&device);
@@ -617,12 +617,12 @@ TEST_F(RenderGraphTest, SetsPassBarrierForStorageBufferReadInGraphicsPass) {
 
   {
     auto &pass = graph.addGraphicsPass("A");
-    pass.write(buffer1, liquid::rhi::BufferType::Storage);
+    pass.write(buffer1, liquid::rhi::BufferUsage::Storage);
   }
 
   {
     auto &pass = graph.addGraphicsPass("B");
-    pass.read(buffer1, liquid::rhi::BufferType::Storage);
+    pass.read(buffer1, liquid::rhi::BufferUsage::Storage);
   }
 
   graph.compile(&device);
@@ -645,12 +645,12 @@ TEST_F(RenderGraphTest, SetsPassBarrierForStorageBufferReadInComputePass) {
 
   {
     auto &pass = graph.addComputePass("A");
-    pass.write(buffer1, liquid::rhi::BufferType::Storage);
+    pass.write(buffer1, liquid::rhi::BufferUsage::Storage);
   }
 
   {
     auto &pass = graph.addComputePass("B");
-    pass.read(buffer1, liquid::rhi::BufferType::Storage);
+    pass.read(buffer1, liquid::rhi::BufferUsage::Storage);
   }
 
   graph.compile(&device);
@@ -673,12 +673,12 @@ TEST_F(RenderGraphTest, SetsPassBarrierForVertexBufferReadInGraphicsPass) {
 
   {
     auto &pass = graph.addGraphicsPass("A");
-    pass.write(buffer1, liquid::rhi::BufferType::Storage);
+    pass.write(buffer1, liquid::rhi::BufferUsage::Storage);
   }
 
   {
     auto &pass = graph.addGraphicsPass("B");
-    pass.read(buffer1, liquid::rhi::BufferType::Vertex);
+    pass.read(buffer1, liquid::rhi::BufferUsage::Vertex);
   }
 
   graph.compile(&device);
@@ -702,12 +702,12 @@ TEST_F(RenderGraphTest, SetsPassBarrierForIndexBufferReadInGraphicsPass) {
 
   {
     auto &pass = graph.addGraphicsPass("A");
-    pass.write(buffer1, liquid::rhi::BufferType::Storage);
+    pass.write(buffer1, liquid::rhi::BufferUsage::Storage);
   }
 
   {
     auto &pass = graph.addGraphicsPass("B");
-    pass.read(buffer1, liquid::rhi::BufferType::Index);
+    pass.read(buffer1, liquid::rhi::BufferUsage::Index);
   }
 
   graph.compile(&device);
@@ -730,12 +730,12 @@ TEST_F(RenderGraphTest, SetsPassBarrierForIndirectBufferReadInGraphicsPass) {
 
   {
     auto &pass = graph.addComputePass("A");
-    pass.write(buffer1, liquid::rhi::BufferType::Storage);
+    pass.write(buffer1, liquid::rhi::BufferUsage::Storage);
   }
 
   {
     auto &pass = graph.addGraphicsPass("C");
-    pass.read(buffer1, liquid::rhi::BufferType::Indirect);
+    pass.read(buffer1, liquid::rhi::BufferUsage::Indirect);
   }
 
   graph.compile(&device);
@@ -760,17 +760,17 @@ TEST_F(RenderGraphTest, SetsPassBarrierForAllBufferReadsInGraphicsPass) {
 
   {
     auto &pass = graph.addComputePass("A");
-    pass.write(buffer1, liquid::rhi::BufferType::Storage);
-    pass.write(buffer2, liquid::rhi::BufferType::Storage);
+    pass.write(buffer1, liquid::rhi::BufferUsage::Storage);
+    pass.write(buffer2, liquid::rhi::BufferUsage::Storage);
   }
 
   {
     auto &pass = graph.addGraphicsPass("C");
-    pass.read(buffer1, liquid::rhi::BufferType::Indirect |
-                           liquid::rhi::BufferType::Vertex |
-                           liquid::rhi::BufferType::Index);
-    pass.read(buffer2, liquid::rhi::BufferType::Uniform |
-                           liquid::rhi::BufferType::Storage);
+    pass.read(buffer1, liquid::rhi::BufferUsage::Indirect |
+                           liquid::rhi::BufferUsage::Vertex |
+                           liquid::rhi::BufferUsage::Index);
+    pass.read(buffer2, liquid::rhi::BufferUsage::Uniform |
+                           liquid::rhi::BufferUsage::Storage);
   }
 
   graph.compile(&device);
@@ -800,15 +800,15 @@ TEST_F(RenderGraphTest, SetsPassBarrierForAllBufferReadsInComputePass) {
 
   {
     auto &pass = graph.addGraphicsPass("A");
-    pass.write(buffer1, liquid::rhi::BufferType::Storage);
-    pass.write(buffer2, liquid::rhi::BufferType::Storage);
+    pass.write(buffer1, liquid::rhi::BufferUsage::Storage);
+    pass.write(buffer2, liquid::rhi::BufferUsage::Storage);
   }
 
   {
     auto &pass = graph.addComputePass("C");
-    pass.read(buffer1, liquid::rhi::BufferType::Indirect);
-    pass.read(buffer2, liquid::rhi::BufferType::Uniform |
-                           liquid::rhi::BufferType::Storage);
+    pass.read(buffer1, liquid::rhi::BufferUsage::Indirect);
+    pass.read(buffer2, liquid::rhi::BufferUsage::Uniform |
+                           liquid::rhi::BufferUsage::Storage);
   }
 
   graph.compile(&device);
@@ -835,7 +835,7 @@ TEST_F(RenderGraphTest, SetsPassBarrierForUniformBufferWriteInGraphicsPass) {
 
   {
     auto &pass = graph.addGraphicsPass("A");
-    pass.write(buffer1, liquid::rhi::BufferType::Uniform);
+    pass.write(buffer1, liquid::rhi::BufferUsage::Uniform);
   }
 
   graph.compile(&device);
@@ -857,7 +857,7 @@ TEST_F(RenderGraphTest, SetsPassBarrierForUniformBufferWriteInComputePass) {
 
   {
     auto &pass = graph.addComputePass("A");
-    pass.write(buffer1, liquid::rhi::BufferType::Uniform);
+    pass.write(buffer1, liquid::rhi::BufferUsage::Uniform);
   }
 
   graph.compile(&device);
@@ -879,7 +879,7 @@ TEST_F(RenderGraphTest, SetsPassBarrierForStorageBufferWriteInGraphicsPass) {
 
   {
     auto &pass = graph.addGraphicsPass("A");
-    pass.write(buffer1, liquid::rhi::BufferType::Storage);
+    pass.write(buffer1, liquid::rhi::BufferUsage::Storage);
   }
 
   graph.compile(&device);
@@ -901,7 +901,7 @@ TEST_F(RenderGraphTest, SetsPassBarrierForStorageBufferWriteInComputePass) {
 
   {
     auto &pass = graph.addComputePass("A");
-    pass.write(buffer1, liquid::rhi::BufferType::Storage);
+    pass.write(buffer1, liquid::rhi::BufferUsage::Storage);
   }
 
   graph.compile(&device);
@@ -924,8 +924,8 @@ TEST_F(RenderGraphTest, SetsPassBarriersForAllBufferWritesInGraphicsPass) {
 
   {
     auto &pass = graph.addGraphicsPass("A");
-    pass.write(buffer1, liquid::rhi::BufferType::Storage);
-    pass.write(buffer1, liquid::rhi::BufferType::Uniform);
+    pass.write(buffer1, liquid::rhi::BufferUsage::Storage);
+    pass.write(buffer1, liquid::rhi::BufferUsage::Uniform);
   }
 
   graph.compile(&device);
@@ -950,8 +950,8 @@ TEST_F(RenderGraphTest, SetsPassBarriersForAllBufferWritesInComputePass) {
 
   {
     auto &pass = graph.addGraphicsPass("A");
-    pass.write(buffer1, liquid::rhi::BufferType::Storage);
-    pass.write(buffer1, liquid::rhi::BufferType::Uniform);
+    pass.write(buffer1, liquid::rhi::BufferUsage::Storage);
+    pass.write(buffer1, liquid::rhi::BufferUsage::Uniform);
   }
 
   graph.compile(&device);

--- a/engine/tests/liquid-tests/renderer/RenderGraphPass.test.cpp
+++ b/engine/tests/liquid-tests/renderer/RenderGraphPass.test.cpp
@@ -57,73 +57,75 @@ TEST_F(RenderGraphPassTest, AddsTextureHandleToInputOnRead) {
 TEST_F(RenderGraphPassTest, FailsWritingBufferWithVertexOnGraphicsPass) {
   liquid::rhi::BufferHandle handle{2};
 
-  EXPECT_DEATH(graphicsPass.write(handle, liquid::rhi::BufferType::Vertex),
+  EXPECT_DEATH(graphicsPass.write(handle, liquid::rhi::BufferUsage::Vertex),
                ".*");
 }
 
 TEST_F(RenderGraphPassTest, FailsWritingBufferWithVertexOnComputePass) {
   liquid::rhi::BufferHandle handle{2};
 
-  EXPECT_DEATH(computePass.write(handle, liquid::rhi::BufferType::Vertex),
+  EXPECT_DEATH(computePass.write(handle, liquid::rhi::BufferUsage::Vertex),
                ".*");
 }
 
 TEST_F(RenderGraphPassTest, FailsWritingBufferWithIndexOnGraphicsPass) {
   liquid::rhi::BufferHandle handle{2};
 
-  EXPECT_DEATH(graphicsPass.write(handle, liquid::rhi::BufferType::Index),
+  EXPECT_DEATH(graphicsPass.write(handle, liquid::rhi::BufferUsage::Index),
                ".*");
 }
 
 TEST_F(RenderGraphPassTest, FailsWritingBufferWithIndexOnComputePass) {
   liquid::rhi::BufferHandle handle{2};
 
-  EXPECT_DEATH(computePass.write(handle, liquid::rhi::BufferType::Index), ".*");
+  EXPECT_DEATH(computePass.write(handle, liquid::rhi::BufferUsage::Index),
+               ".*");
 }
 
 TEST_F(RenderGraphPassTest, FailsWritingBufferWithIndirectOnGraphicsPass) {
   liquid::rhi::BufferHandle handle{2};
 
-  EXPECT_DEATH(graphicsPass.write(handle, liquid::rhi::BufferType::Indirect),
+  EXPECT_DEATH(graphicsPass.write(handle, liquid::rhi::BufferUsage::Indirect),
                ".*");
 }
 
 TEST_F(RenderGraphPassTest, FailsWritingBufferWithIndirectOnComputePass) {
   liquid::rhi::BufferHandle handle{2};
 
-  EXPECT_DEATH(computePass.write(handle, liquid::rhi::BufferType::Indirect),
+  EXPECT_DEATH(computePass.write(handle, liquid::rhi::BufferUsage::Indirect),
                ".*");
 }
 
 TEST_F(RenderGraphPassTest, FailsReadingBufferWithVertexOnComputePass) {
   liquid::rhi::BufferHandle handle{2};
 
-  EXPECT_DEATH(computePass.read(handle, liquid::rhi::BufferType::Vertex), ".*");
+  EXPECT_DEATH(computePass.read(handle, liquid::rhi::BufferUsage::Vertex),
+               ".*");
 }
 
 TEST_F(RenderGraphPassTest, FailsReadingBufferWithIndexOnComputePass) {
   liquid::rhi::BufferHandle handle{2};
 
-  EXPECT_DEATH(computePass.read(handle, liquid::rhi::BufferType::Index), ".*");
+  EXPECT_DEATH(computePass.read(handle, liquid::rhi::BufferUsage::Index), ".*");
 }
 
 TEST_F(RenderGraphPassTest, AddsBufferHandleToOutputOnWrite) {
   liquid::rhi::BufferHandle handle{2};
 
-  graphicsPass.write(handle, liquid::rhi::BufferType::Storage);
+  graphicsPass.write(handle, liquid::rhi::BufferUsage::Storage);
   EXPECT_EQ(graphicsPass.getBufferOutputs().size(), 1);
   EXPECT_EQ(graphicsPass.getBufferOutputs().at(0).buffer, handle);
-  EXPECT_EQ(graphicsPass.getBufferOutputs().at(0).type,
-            liquid::rhi::BufferType::Storage);
+  EXPECT_EQ(graphicsPass.getBufferOutputs().at(0).usage,
+            liquid::rhi::BufferUsage::Storage);
 }
 
 TEST_F(RenderGraphPassTest, AddsBufferHandleToInputOnRead) {
   liquid::rhi::BufferHandle handle{2};
 
-  computePass.read(handle, liquid::rhi::BufferType::Storage);
+  computePass.read(handle, liquid::rhi::BufferUsage::Storage);
   EXPECT_EQ(computePass.getBufferOutputs().size(), 0);
   EXPECT_EQ(computePass.getBufferInputs().size(), 1);
   EXPECT_EQ(computePass.getBufferInputs().at(0).buffer, handle);
-  EXPECT_EQ(computePass.getBufferInputs().at(0).type,
-            liquid::rhi::BufferType::Storage);
+  EXPECT_EQ(computePass.getBufferInputs().at(0).usage,
+            liquid::rhi::BufferUsage::Storage);
 }


### PR DESCRIPTION
- Rename old buffer usage to buffer allocation usage
- Rename buffer type to buffer usage
- Use bitwise enum to set Vulkan buffer usage flags