### PR TITLE
Recreate textures on resize from render storage

### DIFF
--- a/editor/src/liquidator/core/MousePickingGraph.cpp
+++ b/editor/src/liquidator/core/MousePickingGraph.cpp
@@ -9,7 +9,7 @@ MousePickingGraph::MousePickingGraph(
     AssetRegistry &assetRegistry, RenderStorage &renderStorage,
     rhi::RenderDevice *device)
     : mDevice(device), mFrameData(frameData), mAssetRegistry(assetRegistry),
-      mGraphEvaluator(device), mRenderGraph("MousePicking") {
+      mGraphEvaluator(renderStorage), mRenderGraph("MousePicking") {
   static constexpr uint32_t FramebufferSizePercentage = 100;
 
   shaderLibrary.addShader(
@@ -23,13 +23,13 @@ MousePickingGraph::MousePickingGraph(
       mDevice->createShader({"assets/shaders/mouse-picking.frag.spv"}));
 
   rhi::TextureDescription depthBufferDesc{};
-  depthBufferDesc.sizeMethod = rhi::TextureSizeMethod::FramebufferRatio;
   depthBufferDesc.usage = rhi::TextureUsage::Depth | rhi::TextureUsage::Sampled;
   depthBufferDesc.width = FramebufferSizePercentage;
   depthBufferDesc.height = FramebufferSizePercentage;
   depthBufferDesc.layers = 1;
   depthBufferDesc.format = rhi::Format::Depth32Float;
-  auto depthBuffer = renderStorage.createTexture(depthBufferDesc);
+  auto depthBuffer =
+      renderStorage.createFramebufferRelativeTexture(depthBufferDesc);
 
   Entity nullEntity{0};
   mSelectedEntityBuffer = renderStorage.createBuffer(

--- a/editor/src/liquidator/screens/EditorScreen.cpp
+++ b/editor/src/liquidator/screens/EditorScreen.cpp
@@ -151,8 +151,9 @@ void EditorScreen::start(const Project &project) {
   mousePicking.setFramebufferSize(mWindow);
   graph.setFramebufferExtent(mWindow.getFramebufferSize());
 
-  mWindow.addResizeHandler([&graph](auto width, auto height) {
+  mWindow.addResizeHandler([&graph, &renderer](auto width, auto height) {
     graph.setFramebufferExtent({width, height});
+    renderer.getRenderStorage().setFramebufferSize(width, height);
   });
 
   mWindow.addFocusHandler(
@@ -283,6 +284,11 @@ void EditorScreen::start(const Project &project) {
     preloadStatusDialog.render();
 
     imgui.endRendering();
+
+    if (renderer.getRenderStorage().recreateFramebufferRelativeTextures()) {
+      presenter.updateFramebuffers(mDevice->getSwapchain());
+      return;
+    }
 
     const auto &renderFrame = mDevice->beginFrame();
 

--- a/editor/tests/liquidator-tests/mocks/MockRenderDevice.cpp
+++ b/editor/tests/liquidator-tests/mocks/MockRenderDevice.cpp
@@ -73,6 +73,10 @@ liquid::rhi::TextureHandle MockRenderDevice::createTexture(
   return handle;
 }
 
+void MockRenderDevice::updateTexture(
+    liquid::rhi::TextureHandle handle,
+    const liquid::rhi::TextureDescription &description) {}
+
 void MockRenderDevice::destroyTexture(liquid::rhi::TextureHandle handle) {}
 
 const liquid::rhi::TextureDescription MockRenderDevice::getTextureDescription(
@@ -133,3 +137,5 @@ size_t MockRenderDevice::addTextureUpdateListener(
 }
 
 void MockRenderDevice::removeTextureUpdateListener(size_t handle) {}
+
+void MockRenderDevice::recreateSwapchain() {}

--- a/editor/tests/liquidator-tests/mocks/MockRenderDevice.h
+++ b/editor/tests/liquidator-tests/mocks/MockRenderDevice.h
@@ -41,6 +41,9 @@ public:
   liquid::rhi::TextureHandle
   createTexture(const liquid::rhi::TextureDescription &description);
 
+  void updateTexture(liquid::rhi::TextureHandle handle,
+                     const liquid::rhi::TextureDescription &description);
+
   void destroyTexture(liquid::rhi::TextureHandle handle);
 
   const liquid::rhi::TextureDescription
@@ -78,6 +81,8 @@ public:
           &listener);
 
   void removeTextureUpdateListener(size_t handle);
+
+  void recreateSwapchain();
 
 private:
   template <class THandle> inline THandle getNewHandle() {

--- a/engine/assets/shaders/pbr.frag
+++ b/engine/assets/shaders/pbr.frag
@@ -495,6 +495,8 @@ void main() {
             .rgb *
         uMaterialData.emissiveFactor;
     color += emissive;
+  } else {
+    color += uMaterialData.emissiveFactor;
   }
 
   outColor = linearToSrgb(vec4(color, baseColor.a));

--- a/engine/assets/shaders/skybox.frag
+++ b/engine/assets/shaders/skybox.frag
@@ -3,7 +3,6 @@
 #extension GL_EXT_nonuniform_qualifier : enable
 
 layout(location = 0) in vec3 inTexCoord;
-layout(location = 1) in flat uint inTextureIndex;
 
 layout(location = 0) out vec4 outColor;
 

--- a/engine/rhi/core/include/liquid/rhi/RenderDevice.h
+++ b/engine/rhi/core/include/liquid/rhi/RenderDevice.h
@@ -106,6 +106,11 @@ public:
   virtual Swapchain getSwapchain() = 0;
 
   /**
+   * @brief Recreate swapchain
+   */
+  virtual void recreateSwapchain() = 0;
+
+  /**
    * @brief Create shader
    *
    * @param description Shader description
@@ -153,6 +158,15 @@ public:
    */
   virtual TextureHandle
   createTexture(const TextureDescription &description) = 0;
+
+  /**
+   * @brief Update texture
+   *
+   * @param handle Texture handle
+   * @param description Texture description
+   */
+  virtual void updateTexture(TextureHandle handle,
+                             const TextureDescription &description) = 0;
 
   /**
    * @brief Get texture description
@@ -242,22 +256,6 @@ public:
    * @param handle Pipeline handle
    */
   virtual void destroyPipeline(PipelineHandle handle) = 0;
-
-  /**
-   * @brief Add listener to texture update event
-   *
-   * @param listener Listener function
-   * @return Listener handle
-   */
-  virtual size_t addTextureUpdateListener(
-      const std::function<void(const std::set<TextureHandle> &)> &listener) = 0;
-
-  /**
-   * @brief Remove listener for texture update events
-   *
-   * @param handle Listener handle
-   */
-  virtual void removeTextureUpdateListener(size_t handle) = 0;
 };
 
 } // namespace liquid::rhi

--- a/engine/rhi/core/include/liquid/rhi/TextureDescription.h
+++ b/engine/rhi/core/include/liquid/rhi/TextureDescription.h
@@ -6,8 +6,6 @@ namespace liquid::rhi {
 
 enum class TextureType { Standard, Cubemap };
 
-enum class TextureSizeMethod { Fixed, FramebufferRatio };
-
 enum class TextureUsage : uint8_t {
   None = 0,
   Color = 1 << 0,
@@ -28,11 +26,6 @@ struct TextureDescription {
    * Texture type
    */
   TextureType type = TextureType::Standard;
-
-  /**
-   * Texture size method
-   */
-  TextureSizeMethod sizeMethod = TextureSizeMethod::Fixed;
 
   /**
    * Texture usage

--- a/engine/rhi/vulkan/include/liquid/rhi-vulkan/VulkanRenderBackend.h
+++ b/engine/rhi/vulkan/include/liquid/rhi-vulkan/VulkanRenderBackend.h
@@ -70,19 +70,6 @@ public:
     return mWindow.getFramebufferSize();
   }
 
-  /**
-   * @brief Check if framebuffer is resized
-   *
-   * @retval true Framebuffer is resized
-   * @retval false Framebuffer is not resized
-   */
-  inline bool isFramebufferResized() const { return mFramebufferResized; }
-
-  /**
-   * @brief Finish framebuffer resize
-   */
-  void finishFramebufferResize();
-
 private:
   /**
    * @brief Create vulkan instance
@@ -106,8 +93,6 @@ private:
   std::unique_ptr<VulkanRenderDevice> mDevice;
 
   Window &mWindow;
-  bool mFramebufferResized = false;
-  uint32_t mResizeListener = 0;
 };
 
 } // namespace liquid::rhi

--- a/engine/rhi/vulkan/include/liquid/rhi-vulkan/VulkanRenderDevice.h
+++ b/engine/rhi/vulkan/include/liquid/rhi-vulkan/VulkanRenderDevice.h
@@ -89,6 +89,11 @@ public:
   Swapchain getSwapchain() override;
 
   /**
+   * @brief Recreate swapchain
+   */
+  void recreateSwapchain() override;
+
+  /**
    * @brief Get device stats
    *
    * @return Device stats
@@ -142,6 +147,15 @@ public:
    * @return Texture
    */
   TextureHandle createTexture(const TextureDescription &description) override;
+
+  /**
+   * @brief Update texture
+   *
+   * @param handle Texture handle
+   * @param description Texture description
+   */
+  void updateTexture(TextureHandle handle,
+                     const TextureDescription &description) override;
 
   /**
    * @brief Get texture description
@@ -232,34 +246,6 @@ public:
    */
   void destroyPipeline(PipelineHandle handle) override;
 
-  /**
-   * @brief Add listener to texture update event
-   *
-   * @param listener Listener function
-   * @return Listener handle
-   */
-  size_t addTextureUpdateListener(
-      const std::function<void(const std::set<TextureHandle> &)> &listener)
-      override;
-
-  /**
-   * @brief Remove listener for texture update events
-   *
-   * @param handle Listener handle
-   */
-  void removeTextureUpdateListener(size_t handle) override;
-
-private:
-  /**
-   * @brief Recreate swapchain
-   */
-  void recreateSwapchain();
-
-  /**
-   * @brief Update framebuffer relative textures
-   */
-  void updateFramebufferRelativeTextures();
-
 private:
   VulkanRenderBackend &mBackend;
   VulkanPhysicalDevice mPhysicalDevice;
@@ -278,11 +264,6 @@ private:
   VulkanSwapchain mSwapchain;
 
   DeviceStats mStats;
-
-  bool mSwapchainRecreated = false;
-
-  std::vector<std::function<void(const std::set<TextureHandle> &)>>
-      mTextureUpdateListeners;
 };
 
 } // namespace liquid::rhi

--- a/engine/rhi/vulkan/include/liquid/rhi-vulkan/VulkanResourceRegistry.h
+++ b/engine/rhi/vulkan/include/liquid/rhi-vulkan/VulkanResourceRegistry.h
@@ -134,24 +134,6 @@ public:
   void deleteTexture(TextureHandle handle);
 
   /**
-   * @brief Delete dangling swapchain relative textures
-   *
-   * If a texture does not exist or is not swapchain
-   * relative, remove it from the swapchain relative
-   * textures list
-   */
-  void deleteDanglingSwapchainRelativeTextures();
-
-  /**
-   * @brief Get swapchain relative textures
-   *
-   * @return Swapchain relative textures
-   */
-  inline const std::set<TextureHandle> &getSwapchainRelativeTextures() const {
-    return mSwapchainRelativeTextures;
-  }
-
-  /**
    * @brief Get textures
    *
    * @return List of textures
@@ -263,8 +245,6 @@ private:
   RenderPassMap mRenderPasses;
   FramebufferMap mFramebuffers;
   PipelineMap mPipelines;
-
-  std::set<TextureHandle> mSwapchainRelativeTextures;
 };
 
 } // namespace liquid::rhi

--- a/engine/rhi/vulkan/include/liquid/rhi-vulkan/VulkanTexture.h
+++ b/engine/rhi/vulkan/include/liquid/rhi-vulkan/VulkanTexture.h
@@ -36,13 +36,9 @@ public:
    * @param description Texture description
    * @param allocator Vma allocator
    * @param device Vulkan device
-   * @param uploadContext Upload context
-   * @param swapchainExtent Swapchain extent
    */
   VulkanTexture(const TextureDescription &description,
-                VulkanResourceAllocator &allocator, VulkanDeviceObject &device,
-                VulkanUploadContext &uploadContext,
-                const glm::uvec2 &swapchainExtent);
+                VulkanResourceAllocator &allocator, VulkanDeviceObject &device);
 
   /**
    * @brief Destroy texture
@@ -95,16 +91,6 @@ public:
    * @return Image aspect flags
    */
   inline VkImageAspectFlags getImageAspectFlags() const { return mAspectFlags; }
-
-  /**
-   * @brief Check if texture resizes with framebuffer
-   *
-   * @retval true Texture resizes with framebuffer
-   * @retval false Texture does not resize with framebuffer
-   */
-  inline bool isFramebufferRelative() const {
-    return mDescription.sizeMethod == TextureSizeMethod::FramebufferRatio;
-  }
 
   /**
    * @brief Get description

--- a/engine/rhi/vulkan/src/VulkanRenderBackend.cpp
+++ b/engine/rhi/vulkan/src/VulkanRenderBackend.cpp
@@ -26,14 +26,9 @@ VulkanRenderBackend::VulkanRenderBackend(Window &window, bool enableValidations)
 
   mSurface = createSurfaceFromWindow(mInstance, window);
   LOG_DEBUG_VK("Surface created", mSurface);
-
-  mResizeListener = window.addResizeHandler(
-      [this](auto width, auto height) { mFramebufferResized = true; });
 }
 
 VulkanRenderBackend::~VulkanRenderBackend() {
-  mWindow.removeResizeHandler(mResizeListener);
-
   mDevice.reset();
 
   if (mSurface) {
@@ -56,10 +51,6 @@ RenderDevice *VulkanRenderBackend::createDefaultDevice() {
   }
 
   return mDevice.get();
-}
-
-void VulkanRenderBackend::finishFramebufferResize() {
-  mFramebufferResized = false;
 }
 
 void VulkanRenderBackend::createInstance(StringView applicationName,

--- a/engine/rhi/vulkan/src/VulkanResourceRegistry.cpp
+++ b/engine/rhi/vulkan/src/VulkanResourceRegistry.cpp
@@ -41,11 +41,6 @@ TextureHandle
 VulkanResourceRegistry::setTexture(std::unique_ptr<VulkanTexture> &&texture) {
   auto handle = TextureHandle{mTextures.lastHandle};
   mTextures.lastHandle++;
-
-  if (texture->isFramebufferRelative()) {
-    mSwapchainRelativeTextures.insert(handle);
-  }
-
   mTextures.map.insert_or_assign(handle, std::move(texture));
   return handle;
 }
@@ -57,17 +52,6 @@ void VulkanResourceRegistry::recreateTexture(
 
 void VulkanResourceRegistry::deleteTexture(TextureHandle handle) {
   mTextures.map.erase(handle);
-}
-
-void VulkanResourceRegistry::deleteDanglingSwapchainRelativeTextures() {
-  for (auto it = mSwapchainRelativeTextures.begin();
-       it != mSwapchainRelativeTextures.end(); ++it) {
-    auto textureIt = mTextures.map.find(*it);
-    if (textureIt == mTextures.map.end() ||
-        !textureIt->second->isFramebufferRelative()) {
-      it = mSwapchainRelativeTextures.erase(it);
-    }
-  }
 }
 
 TextureViewHandle VulkanResourceRegistry::setTextureView(

--- a/engine/rhi/vulkan/src/VulkanTexture.cpp
+++ b/engine/rhi/vulkan/src/VulkanTexture.cpp
@@ -22,9 +22,7 @@ VulkanTexture::VulkanTexture(VkImage image, VkImageView imageView,
 
 VulkanTexture::VulkanTexture(const TextureDescription &description,
                              VulkanResourceAllocator &allocator,
-                             VulkanDeviceObject &device,
-                             VulkanUploadContext &uploadContext,
-                             const glm::uvec2 &swapchainExtent)
+                             VulkanDeviceObject &device)
     : mAllocator(allocator), mDevice(device),
       mFormat(VulkanMapping::getFormat(description.format)),
       mDescription(description) {
@@ -49,13 +47,8 @@ VulkanTexture::VulkanTexture(const TextureDescription &description,
   static constexpr uint32_t HundredPercent = 100;
 
   VkExtent3D extent{};
-  if (isFramebufferRelative()) {
-    extent.width = description.width * swapchainExtent.x / HundredPercent;
-    extent.height = description.height * swapchainExtent.y / HundredPercent;
-  } else {
-    extent.width = description.width;
-    extent.height = description.height;
-  }
+  extent.width = description.width;
+  extent.height = description.height;
   extent.depth = description.depth;
 
   VkImageUsageFlags usageFlags = 0;

--- a/engine/src/liquid/imgui/ImguiRenderer.cpp
+++ b/engine/src/liquid/imgui/ImguiRenderer.cpp
@@ -76,13 +76,13 @@ ImguiRenderPassData ImguiRenderer::attach(RenderGraph &graph) {
   static constexpr uint32_t FramebufferSizePercentage = 100;
 
   rhi::TextureDescription imguiDesc{};
-  imguiDesc.sizeMethod = rhi::TextureSizeMethod::FramebufferRatio;
   imguiDesc.usage = rhi::TextureUsage::Color | rhi::TextureUsage::Sampled;
   imguiDesc.width = FramebufferSizePercentage;
   imguiDesc.height = FramebufferSizePercentage;
   imguiDesc.layers = 1;
   imguiDesc.format = rhi::Format::Rgba8Unorm;
-  auto imgui = mRenderStorage.createTexture(imguiDesc);
+  auto imgui =
+      mRenderStorage.createFramebufferRelativeTexture(imguiDesc, false);
 
   auto &pass = graph.addGraphicsPass("imgui");
   pass.write(imgui, mClearColor);

--- a/engine/src/liquid/renderer/Presenter.cpp
+++ b/engine/src/liquid/renderer/Presenter.cpp
@@ -86,6 +86,11 @@ void Presenter::updateFramebuffers(const rhi::Swapchain &swapchain) {
 
     mFramebuffers.at(i) = mDevice->createFramebuffer(framebufferDescription);
   }
+
+  if (rhi::isHandleValid(mPresentTexture)) {
+    mPresentDescriptor.write(0, {mPresentTexture},
+                             rhi::DescriptorType::CombinedImageSampler);
+  }
 }
 
 void Presenter::present(rhi::RenderCommandList &commandList,
@@ -93,7 +98,7 @@ void Presenter::present(rhi::RenderCommandList &commandList,
 
   if (handle != mPresentTexture) {
     mPresentTexture = handle;
-    mPresentDescriptor.write(0, {handle},
+    mPresentDescriptor.write(0, {mPresentTexture},
                              rhi::DescriptorType::CombinedImageSampler);
   }
 

--- a/engine/src/liquid/renderer/RenderGraph.h
+++ b/engine/src/liquid/renderer/RenderGraph.h
@@ -6,6 +6,8 @@
 
 namespace liquid {
 
+enum class GraphDirty { None, PassChanges, SizeUpdate };
+
 /**
  * @brief Render graph
  */
@@ -82,7 +84,7 @@ public:
    * @retval true Passes have changed
    * @retval false Passes have not changed
    */
-  inline bool isDirty() const { return mDirty; }
+  inline bool isDirty() const { return mDirty != GraphDirty::None; }
 
   /**
    * @brief Update dirty flag
@@ -101,7 +103,7 @@ private:
   std::vector<RenderGraphPass> mCompiledPasses;
 
   glm::uvec2 mFramebufferExtent{};
-  bool mDirty = true;
+  GraphDirty mDirty = GraphDirty::None;
 
   String mName;
 };

--- a/engine/src/liquid/renderer/RenderGraphEvaluator.h
+++ b/engine/src/liquid/renderer/RenderGraphEvaluator.h
@@ -6,6 +6,7 @@
 #include "liquid/rhi/RenderDevice.h"
 
 #include "RenderGraph.h"
+#include "RenderStorage.h"
 
 namespace liquid {
 
@@ -25,9 +26,9 @@ public:
   /**
    * @brief Create render graph evaluator
    *
-   * @param device Render device
+   * @param renderStorage Render storage
    */
-  RenderGraphEvaluator(rhi::RenderDevice *device);
+  RenderGraphEvaluator(RenderStorage &renderStorage);
 
   /**
    * @brief Build render graph
@@ -87,6 +88,7 @@ private:
   bool hasSwapchainRelativeResources(RenderGraphPass &pass);
 
 private:
+  RenderStorage &mRenderStorage;
   rhi::RenderDevice *mDevice = nullptr;
 };
 

--- a/engine/src/liquid/renderer/RenderStorage.h
+++ b/engine/src/liquid/renderer/RenderStorage.h
@@ -28,16 +28,29 @@ public:
   /**
    * @brief Destroy render storage
    */
-  ~RenderStorage();
+  ~RenderStorage() = default;
 
   /**
    * @brief Create texture
    *
    * @param description Texture description
+   * @param addToDescriptor Add texture to global descriptor
    * @return Texture handle
    */
   rhi::TextureHandle
-  createTexture(const liquid::rhi::TextureDescription &description);
+  createTexture(const liquid::rhi::TextureDescription &description,
+                bool addToDescriptor = true);
+
+  /**
+   * @brief Create framebuffer relative texture
+   *
+   * @param description Texture description
+   * @param addToDescriptor Add texture to global descriptor
+   * @return Texture handle
+   */
+  rhi::TextureHandle createFramebufferRelativeTexture(
+      const liquid::rhi::TextureDescription &description,
+      bool addToDescriptor = true);
 
   /**
    * @brief Create buffer
@@ -80,6 +93,31 @@ public:
    */
   inline rhi::RenderDevice *getDevice() { return mDevice; }
 
+  /**
+   * @brief Recreate framebuffer relative textures
+   *
+   * @retval true Framebuffer relative textures recreated
+   * @retval false Framebuffer relative textures do not require recreate
+   */
+  bool recreateFramebufferRelativeTextures();
+
+  /**
+   * @brief Check if texture is framebuffer relative
+   *
+   * @param handle Texture handle
+   * @retval true Texture is framebuffer relative
+   * @retval false Texture is not framebuffer relative
+   */
+  bool isFramebufferRelative(rhi::TextureHandle handle);
+
+  /**
+   * @brief Set framebuffer size
+   *
+   * @param width Framebuffer width
+   * @param height Framebuffer height
+   */
+  void setFramebufferSize(uint32_t width, uint32_t height);
+
 private:
   rhi::RenderDevice *mDevice = nullptr;
 
@@ -89,6 +127,14 @@ private:
   rhi::Descriptor mGlobalBuffersDescriptor;
 
   size_t mResizeListener = 0;
+
+  std::map<rhi::TextureHandle, rhi::TextureDescription>
+      mFramebufferRelativeTextures;
+
+  bool mNeedsSwapchainResize = false;
+
+  uint32_t mWidth = 0;
+  uint32_t mHeight = 0;
 };
 
 } // namespace liquid

--- a/engine/src/liquid/renderer/Renderer.cpp
+++ b/engine/src/liquid/renderer/Renderer.cpp
@@ -13,7 +13,7 @@ namespace liquid {
 
 Renderer::Renderer(AssetRegistry &assetRegistry, Window &window,
                    rhi::RenderDevice *device)
-    : mGraphEvaluator(device), mDevice(device),
+    : mGraphEvaluator(mRenderStorage), mDevice(device),
       mImguiRenderer(window, mShaderLibrary, mRenderStorage, device),
       mRenderStorage(device), mAssetRegistry(assetRegistry),
       mSceneRenderer(mShaderLibrary, mAssetRegistry, mRenderStorage, device) {}

--- a/engine/src/liquid/renderer/SceneRenderer.cpp
+++ b/engine/src/liquid/renderer/SceneRenderer.cpp
@@ -67,7 +67,6 @@ SceneRenderPassData SceneRenderer::attach(RenderGraph &graph) {
   static constexpr uint32_t SwapchainSizePercentage = 100;
 
   rhi::TextureDescription shadowMapDesc{};
-  shadowMapDesc.sizeMethod = rhi::TextureSizeMethod::Fixed;
   shadowMapDesc.usage = rhi::TextureUsage::Depth | rhi::TextureUsage::Sampled;
   shadowMapDesc.width = ShadowMapDimensions;
   shadowMapDesc.height = ShadowMapDimensions;
@@ -80,22 +79,22 @@ SceneRenderPassData SceneRenderer::attach(RenderGraph &graph) {
   }
 
   rhi::TextureDescription sceneColorDesc{};
-  sceneColorDesc.sizeMethod = rhi::TextureSizeMethod::FramebufferRatio;
   sceneColorDesc.usage = rhi::TextureUsage::Color | rhi::TextureUsage::Sampled;
   sceneColorDesc.width = SwapchainSizePercentage;
   sceneColorDesc.height = SwapchainSizePercentage;
   sceneColorDesc.layers = 1;
   sceneColorDesc.format = rhi::Format::Bgra8Srgb;
-  auto sceneColor = mRenderStorage.createTexture(sceneColorDesc);
+  auto sceneColor =
+      mRenderStorage.createFramebufferRelativeTexture(sceneColorDesc);
 
   rhi::TextureDescription depthBufferDesc{};
-  depthBufferDesc.sizeMethod = rhi::TextureSizeMethod::FramebufferRatio;
   depthBufferDesc.usage = rhi::TextureUsage::Depth | rhi::TextureUsage::Sampled;
   depthBufferDesc.width = SwapchainSizePercentage;
   depthBufferDesc.height = SwapchainSizePercentage;
   depthBufferDesc.layers = 1;
   depthBufferDesc.format = rhi::Format::Depth32Float;
-  auto depthBuffer = mRenderStorage.createTexture(depthBufferDesc);
+  auto depthBuffer =
+      mRenderStorage.createFramebufferRelativeTexture(depthBufferDesc, false);
 
   {
     auto &pass = graph.addGraphicsPass("shadowPass");

--- a/engine/src/liquid/renderer/TextureUtils.cpp
+++ b/engine/src/liquid/renderer/TextureUtils.cpp
@@ -47,7 +47,7 @@ void TextureUtils::copyDataToTexture(
 
   barrier.srcLayout = rhi::ImageLayout::TransferDestinationOptimal;
   barrier.dstLayout = destinationLayout;
-  barrier.srcAccess = rhi::Access::None;
+  barrier.srcAccess = rhi::Access::TransferWrite;
   barrier.dstAccess = rhi::Access::None;
   commandList.pipelineBarrier(rhi::PipelineStage::Transfer,
                               rhi::PipelineStage::PipeTop, {}, {barrier});

--- a/engine/tests/liquid-tests/mocks/MockRenderDevice.cpp
+++ b/engine/tests/liquid-tests/mocks/MockRenderDevice.cpp
@@ -73,6 +73,10 @@ liquid::rhi::TextureHandle MockRenderDevice::createTexture(
   return handle;
 }
 
+void MockRenderDevice::updateTexture(
+    liquid::rhi::TextureHandle handle,
+    const liquid::rhi::TextureDescription &description) {}
+
 void MockRenderDevice::destroyTexture(liquid::rhi::TextureHandle handle) {}
 
 const liquid::rhi::TextureDescription MockRenderDevice::getTextureDescription(
@@ -133,3 +137,5 @@ size_t MockRenderDevice::addTextureUpdateListener(
 }
 
 void MockRenderDevice::removeTextureUpdateListener(size_t handle) {}
+
+void MockRenderDevice::recreateSwapchain() {}

--- a/engine/tests/liquid-tests/mocks/MockRenderDevice.h
+++ b/engine/tests/liquid-tests/mocks/MockRenderDevice.h
@@ -41,6 +41,9 @@ public:
   liquid::rhi::TextureHandle
   createTexture(const liquid::rhi::TextureDescription &description);
 
+  void updateTexture(liquid::rhi::TextureHandle handle,
+                     const liquid::rhi::TextureDescription &description);
+
   void destroyTexture(liquid::rhi::TextureHandle handle);
 
   const liquid::rhi::TextureDescription
@@ -78,6 +81,8 @@ public:
           &listener);
 
   void removeTextureUpdateListener(size_t handle);
+
+  void recreateSwapchain();
 
 private:
   template <class THandle> inline THandle getNewHandle() {

--- a/engine/tests/liquid-tests/renderer/RenderGraph.test.cpp
+++ b/engine/tests/liquid-tests/renderer/RenderGraph.test.cpp
@@ -1098,6 +1098,21 @@ TEST_F(RenderGraphTest, CompilationRemovesLonelyNodes) {
   EXPECT_EQ(graph.getPasses().size(), 4);
 }
 
+TEST_F(RenderGraphTest, RecompilationRecreatesCompiledPassesList) {
+  liquid::rhi::TextureHandle handle = device.createTexture({});
+
+  graph.addGraphicsPass("A").write(handle, glm::vec4());
+  graph.addGraphicsPass("E").read(handle);
+
+  graph.compile(&device);
+  EXPECT_EQ(graph.getCompiledPasses().size(), 2);
+
+  graph.setFramebufferExtent({});
+
+  graph.compile(&device);
+  EXPECT_EQ(graph.getCompiledPasses().size(), 2);
+}
+
 TEST_F(RenderGraphDeathTest, CompilationFailsIfMultipleNodesHaveTheSameName) {
   liquid::rhi::TextureHandle handle{2};
 

--- a/runtime/src/main.cpp
+++ b/runtime/src/main.cpp
@@ -6,9 +6,10 @@
 #include "runtime/Runtime.h"
 
 int main() {
-  liquid::Engine::setPath(std::filesystem::current_path() / "engine");
-
   auto gamePath = std::filesystem::current_path();
+
+  liquid::Engine::setPath(gamePath / "engine");
+
   auto launchPath = gamePath / "launch.yml";
 
   std::ifstream stream(launchPath);

--- a/runtime/src/runtime/Runtime.cpp
+++ b/runtime/src/runtime/Runtime.cpp
@@ -68,8 +68,9 @@ void Runtime::start() {
   liquid::EntityDeleter entityDeleter;
 
   graph.setFramebufferExtent(window.getFramebufferSize());
-  window.addResizeHandler([&graph](auto width, auto height) {
+  window.addResizeHandler([&graph, &renderer](auto width, auto height) {
     graph.setFramebufferExtent({width, height});
+    renderer.getRenderStorage().setFramebufferSize(width, height);
   });
 
   liquid::SceneIO sceneIO(assetCache.getRegistry(), scene);
@@ -96,6 +97,11 @@ void Runtime::start() {
 
   mainLoop.setRenderFn([&]() {
     const auto &renderFrame = device->beginFrame();
+
+    if (renderer.getRenderStorage().recreateFramebufferRelativeTextures()) {
+      presenter.updateFramebuffers(renderer.getRenderDevice()->getSwapchain());
+      return;
+    }
 
     if (renderFrame.frameIndex < std::numeric_limits<uint32_t>::max()) {
       renderer.getSceneRenderer().updateFrameData(


### PR DESCRIPTION
- Expose a method to recreate swapchain from render device
- Expose a method to update texture from render device
- Move framebuffer relative textures from RHI to render storage
- Remove recreating swapchain on framebuffer resize in RHI
- Remove listening to framebuffer resize event in RHI
- Fix unused location in skybox vertex shader
- Remove framebuffer relative size from texture description
- Fix a bug where recompiling render graph would create instead of replace existing passes
- Use emissive factor as emissive color in PBR if texture is not provided