### PR TITLE
Handle actions in editor

### DIFF
--- a/editor/src/liquidator/actions/Action.h
+++ b/editor/src/liquidator/actions/Action.h
@@ -1,0 +1,42 @@
+#pragma once
+
+#include "liquidator/state/WorkspaceState.h"
+#include "liquidator/ui/FontAwesome.h"
+
+namespace liquid::editor {
+
+/**
+ * @brief Action executor result
+ */
+struct ActionExecutorResult {};
+
+/**
+ * @brief Editor action
+ */
+class Action {
+public:
+  /**
+   * Action name
+   */
+  StringView name;
+
+  /**
+   * Action icon
+   */
+  StringView icon;
+
+  /**
+   * Action executor
+   */
+  std::function<ActionExecutorResult(WorkspaceState &, std::any data)>
+      onExecute;
+
+  /**
+   * Action predicate
+   */
+  std::function<bool(WorkspaceState &)> predicate = [](WorkspaceState &) {
+    return true;
+  };
+};
+
+} // namespace liquid::editor

--- a/editor/src/liquidator/actions/ActionExecutor.cpp
+++ b/editor/src/liquidator/actions/ActionExecutor.cpp
@@ -1,0 +1,14 @@
+#include "liquid/core/Base.h"
+#include "ActionExecutor.h"
+
+namespace liquid::editor {
+
+ActionExecutor::ActionExecutor(WorkspaceState &state) : mState(state) {}
+
+void ActionExecutor::execute(const Action &action, std::any data) {
+  LIQUID_ASSERT((bool)action.onExecute,
+                "Action \"" + String(action.name) + "\" has no executor");
+  action.onExecute(mState, data);
+}
+
+} // namespace liquid::editor

--- a/editor/src/liquidator/actions/ActionExecutor.h
+++ b/editor/src/liquidator/actions/ActionExecutor.h
@@ -1,0 +1,31 @@
+#pragma once
+
+#include "liquidator/actions/Action.h"
+
+namespace liquid::editor {
+
+/**
+ * @brief Action executor
+ */
+class ActionExecutor {
+public:
+  /**
+   * @brief Create action executor
+   *
+   * @param state Workspace state
+   */
+  ActionExecutor(WorkspaceState &state);
+
+  /**
+   * @brief Execute action
+   *
+   * @param action Action
+   * @param data Action data
+   */
+  void execute(const Action &action, std::any data = {});
+
+private:
+  WorkspaceState &mState;
+};
+
+} // namespace liquid::editor

--- a/editor/src/liquidator/actions/MoveCameraToEntityAction.h
+++ b/editor/src/liquidator/actions/MoveCameraToEntityAction.h
@@ -1,0 +1,32 @@
+#pragma once
+
+#include "liquidator/actions/Action.h"
+#include "liquidator/editor-scene/EditorCamera.h"
+
+#include <glm/gtc/matrix_access.hpp>
+
+namespace liquid::editor {
+
+static Action MoveCameraToEntityAction{
+    "MoveCameraToEntity", "", [](WorkspaceState &state, std::any data) {
+      auto entity = std::any_cast<Entity>(data);
+
+      auto &scene = state.scene;
+
+      auto &transformComponent =
+          scene.entityDatabase.get<WorldTransform>(entity);
+
+      const auto &translation =
+          glm::vec3(glm::column(transformComponent.worldTransform, 3));
+
+      static constexpr glm::vec3 DistanceFromCenter{0.0f, 0.0f, 10.0f};
+
+      auto &lookAt = scene.entityDatabase.get<CameraLookAt>(state.camera);
+
+      lookAt.up = EditorCamera::DefaultUp;
+      lookAt.center = translation;
+      lookAt.eye = translation - DistanceFromCenter;
+      return ActionExecutorResult{};
+    }};
+
+} // namespace liquid::editor

--- a/editor/src/liquidator/actions/SetActiveTransformActions.h
+++ b/editor/src/liquidator/actions/SetActiveTransformActions.h
@@ -1,0 +1,37 @@
+#pragma once
+
+#include "liquidator/actions/Action.h"
+
+namespace liquid::editor {
+
+static const Action SetActiveTransformToMoveAction{
+    "SetActiveTransformToMove", fa::Arrows,
+    [](WorkspaceState &state, std::any data) {
+      state.activeTransform = TransformOperation::Move;
+      return ActionExecutorResult{};
+    },
+    [](WorkspaceState &state) {
+      return state.activeTransform == TransformOperation::Move;
+    }};
+
+static const Action SetActiveTransformToRotateAction{
+    "SetActiveTransformToRotate", fa::Rotate,
+    [](WorkspaceState &state, std::any data) {
+      state.activeTransform = TransformOperation::Rotate;
+      return ActionExecutorResult{};
+    },
+    [](WorkspaceState &state) {
+      return state.activeTransform == TransformOperation::Rotate;
+    }};
+
+static const Action SetActiveTransformToScaleAction{
+    "SetActiveTransformToScale", fa::ExpandAlt,
+    [](WorkspaceState &state, std::any data) {
+      state.activeTransform = TransformOperation::Scale;
+      return ActionExecutorResult{};
+    },
+    [](WorkspaceState &state) {
+      return state.activeTransform == TransformOperation::Scale;
+    }};
+
+} // namespace liquid::editor

--- a/editor/src/liquidator/actions/SetGridDataActions.h
+++ b/editor/src/liquidator/actions/SetGridDataActions.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include "liquidator/actions/Action.h"
+
+namespace liquid::editor {
+
+static Action SetGridLinesAction{
+    "Toggle grid lines", "",
+    [](WorkspaceState &state, std::any data) {
+      state.grid.x = std::any_cast<bool>(data) ? 1 : 0;
+
+      return ActionExecutorResult{};
+    },
+    [](WorkspaceState &state) { return state.grid.x == 1; }};
+
+static Action SetGridAxisLinesAction{
+    "Toggle axis lines", "",
+    [](WorkspaceState &state, std::any data) {
+      state.grid.y = std::any_cast<bool>(data) ? 1 : 0;
+
+      return ActionExecutorResult{};
+    },
+    [](WorkspaceState &state) { return state.grid.y == 1; }};
+
+} // namespace liquid::editor

--- a/editor/src/liquidator/actions/SimulationModeActions.h
+++ b/editor/src/liquidator/actions/SimulationModeActions.h
@@ -1,0 +1,31 @@
+#pragma once
+
+#include "liquidator/actions/Action.h"
+
+namespace liquid::editor {
+
+static Action StartSimulationModeAction{
+    "Start simulation", fa::Play,
+    [](WorkspaceState &state, std::any data) {
+      state.mode = WorkspaceMode::Simulation;
+      state.simulationScene.entityDatabase.destroy();
+      state.scene.entityDatabase.duplicate(
+          state.simulationScene.entityDatabase);
+      state.simulationScene.activeCamera = state.scene.activeCamera;
+      state.simulationScene.dummyCamera = state.scene.dummyCamera;
+      state.simulationScene.environment = state.scene.environment;
+      return ActionExecutorResult{};
+    },
+    [](WorkspaceState &state) { return state.mode == WorkspaceMode::Edit; }};
+
+static Action StopSimulationModeAction{
+    "Stop simulation", fa::Stop,
+    [](WorkspaceState &state, std::any data) {
+      state.mode = WorkspaceMode::Edit;
+      return ActionExecutorResult{};
+    },
+    [](WorkspaceState &state) {
+      return state.mode == WorkspaceMode::Simulation;
+    }};
+
+} // namespace liquid::editor

--- a/editor/src/liquidator/core/EditorSimulator.h
+++ b/editor/src/liquidator/core/EditorSimulator.h
@@ -13,6 +13,7 @@
 #include "liquid/window/Window.h"
 
 #include "liquidator/editor-scene/EditorCamera.h"
+#include "liquidator/state/WorkspaceState.h"
 
 namespace liquid::editor {
 
@@ -42,26 +43,9 @@ public:
    * updates
    *
    * @param dt Time delta
-   * @param scene Scene
+   * @param state Workspace state
    */
-  void update(float dt, Scene &scene);
-
-  /**
-   * @brief Cleanup simulation database
-   *
-   * @param simulationDatabase Simulation database
-   */
-  void cleanupSimulationDatabase(EntityDatabase &simulationDatabase);
-
-  /**
-   * @brief Switch to simulation updater
-   */
-  void useSimulationUpdate();
-
-  /**
-   * @brief Switch to editing updater
-   */
-  void useEditorUpdate();
+  void update(float dt, WorkspaceState &state);
 
   /**
    * @brief Get physics system
@@ -72,23 +56,30 @@ public:
 
 private:
   /**
+   * @brief Cleanup simulation database
+   *
+   * @param simulationDatabase Simulation database
+   */
+  void cleanupSimulationDatabase(EntityDatabase &simulationDatabase);
+
+  /**
    * @brief Editor updater
    *
    * @param dt Time delta
-   * @param scene Scene
+   * @param state Workspace state
    */
-  void updateEditor(float dt, Scene &scene);
+  void updateEditor(float dt, WorkspaceState &scene);
 
   /**
    * @brief Simulation updater
    *
    * @param dt Time delta
-   * @param scene Scene
+   * @param state Workspace state
    */
-  void updateSimulation(float dt, Scene &scene);
+  void updateSimulation(float dt, WorkspaceState &scene);
 
 private:
-  std::function<void(float, Scene &)> mUpdater;
+  std::function<void(float, WorkspaceState &)> mUpdater;
 
   EditorCamera &mEditorCamera;
   CameraAspectRatioUpdater mCameraAspectRatioUpdater;
@@ -99,6 +90,8 @@ private:
   ScriptingSystem mScriptingSystem;
   PhysicsSystem mPhysicsSystem;
   AudioSystem<DefaultAudioBackend> mAudioSystem;
+
+  WorkspaceMode mMode = WorkspaceMode::Edit;
 };
 
 } // namespace liquid::editor

--- a/editor/src/liquidator/editor-scene/EditorManager.cpp
+++ b/editor/src/liquidator/editor-scene/EditorManager.cpp
@@ -38,15 +38,14 @@ void EditorManager::saveWorkspaceState(WorkspaceState &state,
   stream.close();
 }
 
-WorkspaceState
-EditorManager::loadWorkspaceState(const std::filesystem::path &path) {
-  WorkspaceState state{};
+void EditorManager::loadWorkspaceState(const std::filesystem::path &path,
+                                       WorkspaceState &state) {
   state.camera = mEditorCamera.getEntity();
 
   std::ifstream stream(path, std::ios::in);
 
   if (!stream.good()) {
-    return state;
+    return;
   }
 
   YAML::Node node;
@@ -55,7 +54,7 @@ EditorManager::loadWorkspaceState(const std::filesystem::path &path) {
     stream.close();
   } catch (std::exception &) {
     stream.close();
-    return state;
+    return;
   }
 
   if (node["camera"].IsMap()) {
@@ -114,8 +113,6 @@ EditorManager::loadWorkspaceState(const std::filesystem::path &path) {
     state.grid.x = static_cast<uint32_t>(gridLinesShown);
     state.grid.y = static_cast<uint32_t>(axisLinesShown);
   }
-
-  return state;
 }
 
 void EditorManager::createNewScene() {
@@ -138,27 +135,6 @@ void EditorManager::loadOrCreateScene() {
   if (!mEntityManager.loadScene()) {
     createNewScene();
   }
-}
-
-void EditorManager::moveCameraToEntity(WorkspaceState &state, Entity entity) {
-  if (!mEntityManager.getActiveEntityDatabase().has<WorldTransform>(entity)) {
-    return;
-  }
-
-  auto &transformComponent =
-      mEntityManager.getActiveEntityDatabase().get<WorldTransform>(entity);
-
-  const auto &translation =
-      glm::vec3(glm::column(transformComponent.worldTransform, 3));
-
-  static constexpr glm::vec3 DistanceFromCenter{0.0f, 0.0f, 10.0f};
-
-  auto &lookAt =
-      mEntityManager.getActiveEntityDatabase().get<CameraLookAt>(state.camera);
-
-  lookAt.up = EditorCamera::DefaultUp;
-  lookAt.center = translation;
-  lookAt.eye = translation - DistanceFromCenter;
 }
 
 bool EditorManager::hasSkybox() {

--- a/editor/src/liquidator/editor-scene/EditorManager.h
+++ b/editor/src/liquidator/editor-scene/EditorManager.h
@@ -47,9 +47,10 @@ public:
    * @brief Load workspace state from file
    *
    * @param path Path to workspace state file
-   * @return Workspace state
+   * @param state Workspace state
    */
-  WorkspaceState loadWorkspaceState(const std::filesystem::path &path);
+  void loadWorkspaceState(const std::filesystem::path &path,
+                          WorkspaceState &state);
 
   /**
    * @brief Get editor camera
@@ -67,14 +68,6 @@ public:
    * @brief Load or create scene
    */
   void loadOrCreateScene();
-
-  /**
-   * @brief Move camera to entity location
-   *
-   * @param state Workspace state
-   * @param entity Entity
-   */
-  void moveCameraToEntity(WorkspaceState &state, Entity entity);
 
   /**
    * @brief Check if skybox exists

--- a/editor/src/liquidator/editor-scene/EntityManager.h
+++ b/editor/src/liquidator/editor-scene/EntityManager.h
@@ -5,6 +5,7 @@
 #include "liquid/renderer/Renderer.h"
 #include "liquid/scene/SceneIO.h"
 
+#include "liquidator/state/WorkspaceState.h"
 #include "liquidator/asset/AssetManager.h"
 #include "EditorCamera.h"
 
@@ -22,9 +23,10 @@ public:
    * @brief Create entity manager
    *
    * @param assetManager Asset manager
+   * @param state Workspace state
    * @param scenePath Scene path
    */
-  EntityManager(AssetManager &assetManager,
+  EntityManager(AssetManager &assetManager, WorkspaceState &state,
                 const std::filesystem::path &scenePath);
 
   /**
@@ -180,19 +182,10 @@ public:
    * @return Active entity database
    */
   inline EntityDatabase &getActiveEntityDatabase() {
-    return mInSimulation ? mSimulationScene.entityDatabase
-                         : mScene.entityDatabase;
+    return mState.mode == WorkspaceMode::Simulation
+               ? mState.simulationScene.entityDatabase
+               : mState.scene.entityDatabase;
   }
-
-  /**
-   * @brief Use simulation database
-   */
-  void useSimulationDatabase();
-
-  /**
-   * @brief Use editing database
-   */
-  void useEditingDatabase();
 
   /**
    * @brief Check if using simulation database
@@ -200,7 +193,9 @@ public:
    * @retval true Using simulation databse
    * @retval false Using editing database
    */
-  inline bool isUsingSimulationDatabase() const { return mInSimulation; }
+  inline bool isUsingSimulationDatabase() const {
+    return mState.mode == WorkspaceMode::Simulation;
+  }
 
   /**
    * @brief Get active camera in simulation
@@ -229,7 +224,8 @@ public:
    * @return Active scene
    */
   inline Scene &getActiveScene() {
-    return mInSimulation ? mSimulationScene : mScene;
+    return mState.mode == WorkspaceMode::Simulation ? mState.simulationScene
+                                                    : mState.scene;
   }
 
   /**
@@ -247,12 +243,10 @@ private:
   LocalTransform getTransformFromCamera(Entity camera) const;
 
 private:
-  Scene mScene;
-  Scene mSimulationScene;
+  WorkspaceState &mState;
 
   AssetManager &mAssetManager;
   SceneIO mSceneIO;
-  bool mInSimulation = false;
   std::filesystem::path mScenePath;
 };
 

--- a/editor/src/liquidator/state/WorkspaceState.h
+++ b/editor/src/liquidator/state/WorkspaceState.h
@@ -1,14 +1,32 @@
 #pragma once
 
 #include "liquid/entity/Entity.h"
+#include "liquid/scene/Scene.h"
 #include "liquidator/core/TransformOperation.h"
 
 namespace liquid::editor {
+
+enum class WorkspaceMode { Edit, Simulation };
 
 /**
  * @brief State for editor workspace
  */
 struct WorkspaceState {
+  /**
+   * Workspace mode
+   */
+  WorkspaceMode mode = WorkspaceMode::Edit;
+
+  /**
+   * Scene
+   */
+  Scene scene;
+
+  /**
+   * Simulation scene
+   */
+  Scene simulationScene;
+
   /**
    * Active transform operation
    */

--- a/editor/src/liquidator/ui/EditorGridPanel.cpp
+++ b/editor/src/liquidator/ui/EditorGridPanel.cpp
@@ -4,9 +4,15 @@
 #include "liquid/imgui/Imgui.h"
 #include "Widgets.h"
 
+#include "liquidator/actions/SetGridDataActions.h"
+
 namespace liquid::editor {
 
-void EditorGridPanel::render(WorkspaceState &state) {
+static const std::vector<Action> GridActions{SetGridLinesAction,
+                                             SetGridAxisLinesAction};
+
+void EditorGridPanel::render(WorkspaceState &state,
+                             ActionExecutor &actionExecutor) {
   if (auto _ = widgets::MainMenuBar()) {
     if (ImGui::BeginMenu("Editor")) {
       ImGui::MenuItem("Grid", nullptr, &mOpen);
@@ -19,14 +25,11 @@ void EditorGridPanel::render(WorkspaceState &state) {
   }
 
   if (auto _ = widgets::FixedWindow("Editor Grid", mOpen)) {
-    bool showGridLines = state.grid.x == 1;
-    if (ImGui::Checkbox("Show grid lines", &showGridLines)) {
-      state.grid.x = static_cast<uint32_t>(showGridLines);
-    }
-
-    bool showAxisLines = state.grid.y == 1;
-    if (ImGui::Checkbox("Show axis lines", &showAxisLines)) {
-      state.grid.y = static_cast<uint32_t>(showAxisLines);
+    for (const auto &action : GridActions) {
+      bool enabled = action.predicate(state);
+      if (ImGui::Checkbox(String(action.name).c_str(), &enabled)) {
+        actionExecutor.execute(action, enabled);
+      }
     }
   }
 }

--- a/editor/src/liquidator/ui/EditorGridPanel.h
+++ b/editor/src/liquidator/ui/EditorGridPanel.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "liquidator/state/WorkspaceState.h"
+#include "liquidator/actions/ActionExecutor.h"
 
 namespace liquid::editor {
 
@@ -13,8 +14,9 @@ public:
    * @brief Render editor grid panel
    *
    * @param state Workspace state
+   * @param actionExecutor Action executor
    */
-  void render(WorkspaceState &state);
+  void render(WorkspaceState &state, ActionExecutor &actionExecutor);
 
 private:
   bool mOpen = false;

--- a/editor/src/liquidator/ui/MenuBar.cpp
+++ b/editor/src/liquidator/ui/MenuBar.cpp
@@ -7,7 +7,8 @@
 
 namespace liquid::editor {
 
-void MenuBar::render(WorkspaceState &state, EditorManager &editorManager,
+void MenuBar::render(WorkspaceState &state, ActionExecutor &actionExecutor,
+                     EditorManager &editorManager,
                      EntityManager &entityManager) {
   if (ImGui::BeginMenu("Project")) {
     if (ImGui::MenuItem("Export as game", nullptr)) {

--- a/editor/src/liquidator/ui/MenuBar.h
+++ b/editor/src/liquidator/ui/MenuBar.h
@@ -2,6 +2,7 @@
 
 #include "liquidator/editor-scene/EditorManager.h"
 #include "liquidator/editor-scene/EntityManager.h"
+#include "liquidator/actions/ActionExecutor.h"
 
 namespace liquid::editor {
 
@@ -14,10 +15,12 @@ public:
    * @brief Render menu bar
    *
    * @param state Workspace state
+   * @param actionExecutor Action executor
    * @param editorManager Editor manager
    * @param entityManager Entity manager
    */
-  static void render(WorkspaceState &state, EditorManager &editorManager,
+  static void render(WorkspaceState &state, ActionExecutor &actionExecutor,
+                     EditorManager &editorManager,
                      EntityManager &entityManager);
 };
 

--- a/editor/src/liquidator/ui/SceneHierarchyPanel.cpp
+++ b/editor/src/liquidator/ui/SceneHierarchyPanel.cpp
@@ -8,12 +8,15 @@
 #include "FontAwesome.h"
 #include "Theme.h"
 
+#include "liquidator/actions/MoveCameraToEntityAction.h"
+
 namespace liquid::editor {
 
 SceneHierarchyPanel::SceneHierarchyPanel(EntityManager &entityManager)
     : mEntityManager(entityManager) {}
 
 void SceneHierarchyPanel::render(WorkspaceState &state,
+                                 ActionExecutor &actionExecutor,
                                  EditorManager &editorManager) {
   static constexpr ImVec2 TreeNodeItemPadding{4.0f, 8.0f};
   static constexpr float TreeNodeIndentSpacing = 10.0f;
@@ -35,7 +38,7 @@ void SceneHierarchyPanel::render(WorkspaceState &state,
       }
 
       renderEntity(entity, ImGuiTreeNodeFlags_DefaultOpen, state,
-                   editorManager);
+                   actionExecutor, editorManager);
     }
   }
 }
@@ -76,6 +79,7 @@ static String getNodeName(const String &name, Entity entity,
 
 void SceneHierarchyPanel::renderEntity(Entity entity, int flags,
                                        WorkspaceState &state,
+                                       ActionExecutor &actionExecutor,
                                        EditorManager &editorManager) {
   auto &entityDatabase = mEntityManager.getActiveEntityDatabase();
   String name =
@@ -129,7 +133,7 @@ void SceneHierarchyPanel::renderEntity(Entity entity, int flags,
                              ImGui::GetStyle().ItemSpacing.x));
 
       if (ImGui::MenuItem("Go to view")) {
-        editorManager.moveCameraToEntity(state, entity);
+        actionExecutor.execute(MoveCameraToEntityAction, entity);
       }
 
       if (ImGui::MenuItem("Delete")) {
@@ -151,7 +155,7 @@ void SceneHierarchyPanel::renderEntity(Entity entity, int flags,
       for (auto childEntity : mEntityManager.getActiveEntityDatabase()
                                   .get<Children>(entity)
                                   .children) {
-        renderEntity(childEntity, 0, state, editorManager);
+        renderEntity(childEntity, 0, state, actionExecutor, editorManager);
       }
     }
 

--- a/editor/src/liquidator/ui/SceneHierarchyPanel.h
+++ b/editor/src/liquidator/ui/SceneHierarchyPanel.h
@@ -5,6 +5,7 @@
 #include "liquidator/editor-scene/EditorCamera.h"
 
 #include "liquidator/state/WorkspaceState.h"
+#include "liquidator/actions/ActionExecutor.h"
 
 namespace liquid::editor {
 
@@ -26,9 +27,11 @@ public:
    * @brief Render the UI
    *
    * @param state Workspace state
+   * @param actionExecutor Action executor
    * @param editorManager Editor manager
    */
-  void render(WorkspaceState &state, EditorManager &editorManager);
+  void render(WorkspaceState &state, ActionExecutor &actionExecutor,
+              EditorManager &editorManager);
 
 private:
   /**
@@ -37,9 +40,11 @@ private:
    * @param entity Entity
    * @param flags Flags
    * @param state Workspace state
+   * @param actionExecutor Action executor
    * @param editorManager Editor manager
    */
   void renderEntity(Entity entity, int flags, WorkspaceState &state,
+                    ActionExecutor &actionExecutor,
                     EditorManager &editorManager);
 
 private:

--- a/editor/src/liquidator/ui/TransformOperationControl.h
+++ b/editor/src/liquidator/ui/TransformOperationControl.h
@@ -2,6 +2,7 @@
 
 #include "liquidator/core/TransformOperation.h"
 #include "liquidator/state/WorkspaceState.h"
+#include "liquidator/actions/ActionExecutor.h"
 
 namespace liquid::editor {
 
@@ -17,14 +18,14 @@ public:
    * @brief Begin toolbar
    *
    * @param state Workspace state
+   * @param actionExecutor Action executor
    */
-  TransformOperationControl(WorkspaceState &state);
+  TransformOperationControl(WorkspaceState &state,
+                            ActionExecutor &actionExecutor);
 
 private:
-  void renderIcon(TransformOperation transformOperation, WorkspaceState &state);
-
-  static const char *
-  getTransformOperationIcon(TransformOperation transformOperation);
+  static constexpr size_t NumOperations = 3;
+  std::array<Action, NumOperations> mActions;
 };
 
 } // namespace liquid::editor

--- a/editor/src/liquidator/ui/UIRoot.cpp
+++ b/editor/src/liquidator/ui/UIRoot.cpp
@@ -5,9 +5,10 @@
 
 namespace liquid::editor {
 
-UIRoot::UIRoot(EntityManager &entityManager, AssetLoader &assetLoader)
-    : mAssetBrowser(assetLoader), mSceneHierarchyPanel(entityManager),
-      mEntityPanel(entityManager) {}
+UIRoot::UIRoot(ActionExecutor &actionExecutor, EntityManager &entityManager,
+               AssetLoader &assetLoader)
+    : mActionExecutor(actionExecutor), mAssetBrowser(assetLoader),
+      mSceneHierarchyPanel(entityManager), mEntityPanel(entityManager) {}
 
 void UIRoot::render(WorkspaceState &state, EditorManager &editorManager,
                     Renderer &renderer, AssetManager &assetManager,
@@ -15,7 +16,7 @@ void UIRoot::render(WorkspaceState &state, EditorManager &editorManager,
                     EntityManager &entityManager) {
   mLayout.setup();
 
-  mSceneHierarchyPanel.render(state, editorManager);
+  mSceneHierarchyPanel.render(state, mActionExecutor, editorManager);
 
   if (state.selectedEntity != Entity::Null) {
     mEntityPanel.render(editorManager, state.selectedEntity, renderer,
@@ -24,7 +25,7 @@ void UIRoot::render(WorkspaceState &state, EditorManager &editorManager,
 
   EnvironmentPanel::render(editorManager, assetManager);
 
-  mEditorCameraPanel.render(state);
+  mEditorCameraPanel.render(state, mActionExecutor);
   mAssetBrowser.render(assetManager, mIconRegistry, state, editorManager,
                        entityManager);
 }

--- a/editor/src/liquidator/ui/UIRoot.h
+++ b/editor/src/liquidator/ui/UIRoot.h
@@ -16,6 +16,7 @@
 #include "IconRegistry.h"
 #include "EnvironmentPanel.h"
 #include "SceneView.h"
+#include "liquidator/actions/ActionExecutor.h"
 
 namespace liquid::editor {
 
@@ -29,10 +30,12 @@ public:
   /**
    * @brief Create UI Root
    *
+   * @param actionExecutor Action executor
    * @param entityManager Entity manager
    * @param assetLoader Asset loader
    */
-  UIRoot(EntityManager &entityManager, AssetLoader &assetLoader);
+  UIRoot(ActionExecutor &actionExecutor, EntityManager &entityManager,
+         AssetLoader &assetLoader);
 
   /**
    * @brief Render UI Root
@@ -74,6 +77,7 @@ public:
   }
 
 private:
+  ActionExecutor mActionExecutor;
   MenuBar mMenuBar;
   SceneHierarchyPanel mSceneHierarchyPanel;
   EntityPanel mEntityPanel;

--- a/editor/tests/liquidator-tests/actions/ActionExecutor.test.cpp
+++ b/editor/tests/liquidator-tests/actions/ActionExecutor.test.cpp
@@ -1,0 +1,35 @@
+#include "liquid/core/Base.h"
+#include "liquidator/actions/ActionExecutor.h"
+
+#include "liquidator-tests/Testing.h"
+
+class ActionExecutorTest : public ::testing::Test {
+public:
+  liquid::editor::WorkspaceState state;
+  liquid::editor::ActionExecutor executor{state};
+};
+
+TEST_F(ActionExecutorTest, ExecuteFailsIfActionHasNoExecutor) {
+  liquid::editor::Action TestAction{"TestAction"};
+
+  EXPECT_DEATH(executor.execute(TestAction, liquid::String("Hello world")),
+               ".*");
+}
+
+TEST_F(ActionExecutorTest, ExecuteCallsActionExecutorWithStateAndData) {
+  state.mode = liquid::editor::WorkspaceMode::Simulation;
+
+  bool called = false;
+  liquid::editor::Action TestAction{
+      "TestAction", "",
+      [&called](liquid::editor::WorkspaceState &state, std::any data) mutable {
+        called = true;
+        EXPECT_EQ(std::any_cast<liquid::String>(data), "Hello world");
+        EXPECT_EQ(state.mode, liquid::editor::WorkspaceMode::Simulation);
+        return liquid::editor::ActionExecutorResult{};
+      }};
+
+  executor.execute(TestAction, liquid::String("Hello world"));
+
+  EXPECT_TRUE(called);
+}

--- a/editor/tests/liquidator-tests/actions/MoveCameraToEntityAction.test.cpp
+++ b/editor/tests/liquidator-tests/actions/MoveCameraToEntityAction.test.cpp
@@ -1,0 +1,50 @@
+#include "liquid/core/Base.h"
+#include "liquidator/actions/MoveCameraToEntityAction.h"
+
+#include "liquidator-tests/Testing.h"
+
+class MoveCameraToEntityActionTest : public ::testing::Test {
+public:
+  MoveCameraToEntityActionTest() {
+    state.scene.entityDatabase.reg<liquid::editor::CameraLookAt>();
+  }
+
+  liquid::editor::WorkspaceState state;
+};
+
+TEST_F(MoveCameraToEntityActionTest,
+       ExecuteFailsIfProvidedArgumentIsNotEntity) {
+  EXPECT_THROW(
+      liquid::editor::MoveCameraToEntityAction.onExecute(state, "test"),
+      std::bad_any_cast);
+}
+
+TEST_F(MoveCameraToEntityActionTest,
+       ExecuteFailsIfProvidedEntityDoesNotHaveWorldTransform) {
+  auto entity = state.scene.entityDatabase.create();
+  EXPECT_DEATH(
+      liquid::editor::MoveCameraToEntityAction.onExecute(state, entity), ".*");
+}
+
+TEST_F(MoveCameraToEntityActionTest,
+       ExecuteSetsCameraPositionToEntityPosition) {
+  state.camera = state.scene.entityDatabase.create();
+  state.scene.entityDatabase.set<liquid::editor::CameraLookAt>(state.camera,
+                                                               {});
+
+  glm::mat4 world{};
+  world[3] = glm::vec4{2.5f, 1.5f, 3.5f, -10.0f};
+
+  auto entity = state.scene.entityDatabase.create();
+  state.scene.entityDatabase.set<liquid::WorldTransform>(entity, {world});
+
+  liquid::editor::MoveCameraToEntityAction.onExecute(state, entity);
+
+  const auto &lookAt =
+      state.scene.entityDatabase.get<liquid::editor::CameraLookAt>(
+          state.camera);
+
+  EXPECT_EQ(lookAt.up, glm::vec3(0.0f, 1.0f, 0.0));
+  EXPECT_EQ(lookAt.center, glm::vec3(world[3]));
+  EXPECT_EQ(lookAt.eye, glm::vec3(world[3]) - glm::vec3(0.0f, 0.0f, 10.0f));
+}

--- a/editor/tests/liquidator-tests/actions/SetActiveTransformActions.test.cpp
+++ b/editor/tests/liquidator-tests/actions/SetActiveTransformActions.test.cpp
@@ -1,0 +1,84 @@
+#include "liquid/core/Base.h"
+#include "liquidator/actions/SetActiveTransformActions.h"
+
+#include "liquidator-tests/Testing.h"
+
+using TO = liquid::editor::TransformOperation;
+
+class SetActiveTransformActionsTestBase : public ::testing::Test {
+public:
+  liquid::editor::WorkspaceState state;
+};
+
+using SetActiveTransformToMoveActionTest = SetActiveTransformActionsTestBase;
+
+TEST_F(SetActiveTransformToMoveActionTest,
+       ExecutorChangesActiveTransformToMove) {
+  state.activeTransform = TO::Rotate;
+  EXPECT_EQ(state.activeTransform, TO::Rotate);
+
+  liquid::editor::SetActiveTransformToMoveAction.onExecute(state, {});
+
+  EXPECT_EQ(state.activeTransform, TO::Move);
+}
+
+TEST_F(SetActiveTransformToMoveActionTest,
+       PredicateReturnsFalseIfActiveTransformIsNotMove) {
+  state.activeTransform = TO::Rotate;
+  EXPECT_FALSE(liquid::editor::SetActiveTransformToMoveAction.predicate(state));
+}
+
+TEST_F(SetActiveTransformToMoveActionTest,
+       PredicateReturnsTrueIfActiveTransformIsMove) {
+  state.activeTransform = TO::Move;
+  EXPECT_TRUE(liquid::editor::SetActiveTransformToMoveAction.predicate(state));
+}
+
+using SetActiveTransformToRotateActionTest = SetActiveTransformActionsTestBase;
+
+TEST_F(SetActiveTransformToRotateActionTest,
+       ExecutorChangesActiveTransformToRotate) {
+  EXPECT_EQ(state.activeTransform, TO::Move);
+
+  liquid::editor::SetActiveTransformToRotateAction.onExecute(state, {});
+
+  EXPECT_EQ(state.activeTransform, TO::Rotate);
+}
+
+TEST_F(SetActiveTransformToRotateActionTest,
+       PredicateReturnsFalseIfActiveTransformIsNotRotate) {
+  state.activeTransform = TO::Move;
+  EXPECT_FALSE(
+      liquid::editor::SetActiveTransformToRotateAction.predicate(state));
+}
+
+TEST_F(SetActiveTransformToRotateActionTest,
+       PredicateReturnsTrueIfActiveTransformIsRotate) {
+  state.activeTransform = TO::Rotate;
+  EXPECT_TRUE(
+      liquid::editor::SetActiveTransformToRotateAction.predicate(state));
+}
+
+using SetActiveTransformToScaleActionTest = SetActiveTransformActionsTestBase;
+
+TEST_F(SetActiveTransformToScaleActionTest,
+       ExecutorChangesActiveTransformToScale) {
+  EXPECT_EQ(state.activeTransform, TO::Move);
+
+  liquid::editor::SetActiveTransformToScaleAction.onExecute(state, {});
+
+  EXPECT_EQ(state.activeTransform, TO::Scale);
+}
+
+TEST_F(SetActiveTransformToRotateActionTest,
+       PredicateReturnsFalseIfActiveTransformIsNotScale) {
+  state.activeTransform = TO::Move;
+  EXPECT_FALSE(
+      liquid::editor::SetActiveTransformToScaleAction.predicate(state));
+}
+
+TEST_F(SetActiveTransformToRotateActionTest,
+       PredicateReturnsTrueIfActiveTransformIsScale) {
+  state.activeTransform = TO::Scale;
+  EXPECT_TRUE(liquid::editor::SetActiveTransformToScaleAction.predicate(state));
+}

--- a/editor/tests/liquidator-tests/actions/SetGridDataActions.test.cpp
+++ b/editor/tests/liquidator-tests/actions/SetGridDataActions.test.cpp
@@ -1,0 +1,59 @@
+#include "liquid/core/Base.h"
+#include "liquidator/actions/SetGridDataActions.h"
+
+#include "liquidator-tests/Testing.h"
+
+class SetGridDataActionsTestBase : public ::testing::Test {
+public:
+  liquid::editor::WorkspaceState state{};
+};
+
+using SetGridAxisLines = SetGridDataActionsTestBase;
+
+TEST_F(SetGridAxisLines, ExecutorEnablesGridAxisLinesIfArgumentIsTrue) {
+  EXPECT_EQ(state.grid.y, 0);
+  liquid::editor::SetGridAxisLinesAction.onExecute(state, true);
+  EXPECT_EQ(state.grid.y, 1);
+}
+
+TEST_F(SetGridAxisLines, ExecutorDisablesGridAxisLinesIfArgumentIsFalse) {
+  state.grid.y = 1;
+  EXPECT_EQ(state.grid.y, 1);
+  liquid::editor::SetGridAxisLinesAction.onExecute(state, false);
+  EXPECT_EQ(state.grid.y, 0);
+}
+
+TEST_F(SetGridAxisLines, PredicateReturnsFalseIfAxisLinesAreDisabled) {
+  liquid::editor::SetGridAxisLinesAction.onExecute(state, false);
+  EXPECT_FALSE(liquid::editor::SetGridAxisLinesAction.predicate(state));
+}
+
+TEST_F(SetGridAxisLines, PredicateReturnsFalseIfAxisLinesAreEnabled) {
+  liquid::editor::SetGridAxisLinesAction.onExecute(state, true);
+  EXPECT_TRUE(liquid::editor::SetGridAxisLinesAction.predicate(state));
+}
+
+using SetGridines = SetGridDataActionsTestBase;
+
+TEST_F(SetGridAxisLines, ExecutorEnablesGridLinesIfArgumentIsTrue) {
+  EXPECT_EQ(state.grid.x, 0);
+  liquid::editor::SetGridLinesAction.onExecute(state, true);
+  EXPECT_EQ(state.grid.x, 1);
+}
+
+TEST_F(SetGridAxisLines, ExecutorDisablesGridLinesIfArgumentIsFalse) {
+  state.grid.x = 1;
+  EXPECT_EQ(state.grid.x, 1);
+  liquid::editor::SetGridLinesAction.onExecute(state, false);
+  EXPECT_EQ(state.grid.x, 0);
+}
+
+TEST_F(SetGridAxisLines, PredicateReturnsFalseIfGridLinesAreDisabled) {
+  liquid::editor::SetGridLinesAction.onExecute(state, false);
+  EXPECT_FALSE(liquid::editor::SetGridLinesAction.predicate(state));
+}
+
+TEST_F(SetGridAxisLines, PredicateReturnsFalseIfGridLinesAreEnabled) {
+  liquid::editor::SetGridLinesAction.onExecute(state, true);
+  EXPECT_TRUE(liquid::editor::SetGridLinesAction.predicate(state));
+}

--- a/editor/tests/liquidator-tests/actions/SimulationModeActions.test.cpp
+++ b/editor/tests/liquidator-tests/actions/SimulationModeActions.test.cpp
@@ -1,0 +1,73 @@
+#include "liquid/core/Base.h"
+#include "liquidator/actions/SimulationModeActions.h"
+
+#include "liquidator-tests/Testing.h"
+
+using WM = liquid::editor::WorkspaceMode;
+
+class SimulationModeActionsTestBase : public ::testing::Test {
+public:
+  liquid::editor::WorkspaceState state{};
+};
+
+using StartSimulationModeActionTest = SimulationModeActionsTestBase;
+
+TEST_F(StartSimulationModeActionTest, ExecutorSetsWorkspaceModeToSimulation) {
+  state.mode = WM::Edit;
+  EXPECT_EQ(state.mode, WM::Edit);
+  liquid::editor::StartSimulationModeAction.onExecute(state, {});
+  EXPECT_EQ(state.mode, WM::Simulation);
+}
+
+TEST_F(StartSimulationModeActionTest,
+       ExecutorDuplicatesSceneToSimulationScene) {
+  state.mode = WM::Edit;
+  state.scene.environment = liquid::Entity{12};
+  state.scene.activeCamera = liquid::Entity{14};
+  state.scene.dummyCamera = liquid::Entity{15};
+  auto entity = state.scene.entityDatabase.create();
+
+  EXPECT_EQ(state.simulationScene.environment, liquid::Entity::Null);
+  EXPECT_EQ(state.simulationScene.activeCamera, liquid::Entity::Null);
+  EXPECT_EQ(state.simulationScene.dummyCamera, liquid::Entity::Null);
+  EXPECT_FALSE(state.simulationScene.entityDatabase.exists(entity));
+
+  liquid::editor::StartSimulationModeAction.onExecute(state, {});
+
+  EXPECT_EQ(state.simulationScene.environment, state.scene.environment);
+  EXPECT_EQ(state.simulationScene.activeCamera, state.scene.activeCamera);
+  EXPECT_EQ(state.simulationScene.dummyCamera, state.scene.dummyCamera);
+  EXPECT_TRUE(state.simulationScene.entityDatabase.exists(entity));
+}
+
+TEST_F(StartSimulationModeActionTest,
+       PredicateReturnsTrueIfWorkspaceModeIsEdit) {
+  state.mode = WM::Edit;
+  EXPECT_TRUE(liquid::editor::StartSimulationModeAction.predicate(state));
+}
+
+TEST_F(StartSimulationModeActionTest,
+       PredicateReturnsFalseIfWorkspaceModeIsSimulation) {
+  state.mode = WM::Simulation;
+  EXPECT_FALSE(liquid::editor::StartSimulationModeAction.predicate(state));
+}
+
+using StopSimulationModeActionTest = SimulationModeActionsTestBase;
+
+TEST_F(StopSimulationModeActionTest, ExecutorSetsWorkspaceModeToSimulation) {
+  state.mode = WM::Simulation;
+  liquid::editor::StopSimulationModeAction.onExecute(state, {});
+  EXPECT_EQ(state.mode, WM::Edit);
+}
+
+TEST_F(StopSimulationModeActionTest,
+       PredicateReturnsTrueIfWorkspaceModeIsEdit) {
+  state.mode = WM::Simulation;
+  EXPECT_TRUE(liquid::editor::StopSimulationModeAction.predicate(state));
+}
+
+TEST_F(StopSimulationModeActionTest,
+       PredicateReturnsFalseIfWorkspaceModeIsSimulation) {
+  state.mode = WM::Edit;
+  EXPECT_FALSE(liquid::editor::StopSimulationModeAction.predicate(state));
+}


### PR DESCRIPTION
- Add action and action executor
- Convert grid data operations to actions
- Convert simulation mode operations to actions
- Convert active transform operations to actions
- Convert moving camera to entity to action
- Cleanup system state when simulation ends automatically
- Decouple scene from entity manager
- Add scenes to workspace state
- Add workspace mode