### PR TITLE
Enable multisampling

### DIFF
--- a/editor/src/liquidator/core/MousePickingGraph.cpp
+++ b/editor/src/liquidator/core/MousePickingGraph.cpp
@@ -54,7 +54,8 @@ MousePickingGraph::MousePickingGraph(
   mSkinnedEntitiesBuffer = renderStorage.createBuffer(defaultDesc);
 
   auto &pass = mRenderGraph.addGraphicsPass("MousePicking");
-  pass.write(depthBuffer, rhi::DepthStencilClear({1.0f, 0}));
+  pass.write(depthBuffer, AttachmentType::Depth,
+             rhi::DepthStencilClear({1.0f, 0}));
 
   // Normal meshes
   auto vPipeline = pass.addPipeline(rhi::GraphicsPipelineDescription{

--- a/editor/src/liquidator/screens/EditorScreen.cpp
+++ b/editor/src/liquidator/screens/EditorScreen.cpp
@@ -114,13 +114,16 @@ void EditorScreen::start(const Project &project) {
 
   auto scenePassGroup = renderer.getSceneRenderer().attach(graph);
   auto imguiPassGroup = renderer.getImguiRenderer().attach(graph);
-  imguiPassGroup.pass.read(scenePassGroup.sceneColor);
+  imguiPassGroup.pass.read(scenePassGroup.finalColor);
 
   {
-    static constexpr glm::vec4 BlueishClearValue{0.52f, 0.54f, 0.89f, 1.0f};
+    static constexpr glm::vec4 ClearColor{0.52f, 0.54f, 0.89f, 1.0f};
     auto &pass = editorRenderer.attach(graph);
-    pass.write(scenePassGroup.sceneColor, BlueishClearValue);
-    pass.write(scenePassGroup.depthBuffer, rhi::DepthStencilClear{1.0f, 0});
+    pass.write(scenePassGroup.sceneColor, AttachmentType::Color, ClearColor);
+    pass.write(scenePassGroup.depthBuffer, AttachmentType::Depth,
+               rhi::DepthStencilClear{1.0f, 0});
+    pass.write(scenePassGroup.sceneColorResolved, AttachmentType::Resolve,
+               ClearColor);
   }
 
   renderer.getSceneRenderer().attachText(graph, scenePassGroup);
@@ -189,7 +192,7 @@ void EditorScreen::start(const Project &project) {
     logViewer.render(systemLogStorage, userLogStorage);
 
     bool mouseClicked =
-        ui.renderSceneView(state, scenePassGroup.sceneColor, editorCamera);
+        ui.renderSceneView(state, scenePassGroup.finalColor, editorCamera);
 
     StatusBar::render(editorManager);
 

--- a/engine/rhi/core/include/liquid/rhi/PhysicalDeviceInformation.h
+++ b/engine/rhi/core/include/liquid/rhi/PhysicalDeviceInformation.h
@@ -30,6 +30,16 @@ public:
      * Minimum uniform buffer alignment offset
      */
     uint32_t minUniformBufferOffsetAlignment = 0;
+
+    /**
+     * Framebuffer color sample counts
+     */
+    uint32_t framebufferColorSampleCounts = 0;
+
+    /**
+     * Framebuffer depth sample counts
+     */
+    uint32_t framebufferDepthSampleCounts = 0;
   };
 
 public:

--- a/engine/rhi/core/include/liquid/rhi/PipelineDescription.h
+++ b/engine/rhi/core/include/liquid/rhi/PipelineDescription.h
@@ -277,6 +277,16 @@ struct PipelineColorBlend {
 };
 
 /**
+ * @brief Pipeline multisampling description
+ */
+struct PipelineMultisample {
+  /**
+   * Sample count
+   */
+  uint32_t sampleCount = 1;
+};
+
+/**
  * @brief Graphics pipeline description
  */
 struct GraphicsPipelineDescription {
@@ -309,6 +319,11 @@ struct GraphicsPipelineDescription {
    * Color blending
    */
   PipelineColorBlend colorBlend;
+
+  /**
+   * Multisampling
+   */
+  PipelineMultisample multisample;
 
   /**
    * Render pass

--- a/engine/rhi/core/include/liquid/rhi/RenderPassDescription.h
+++ b/engine/rhi/core/include/liquid/rhi/RenderPassDescription.h
@@ -67,9 +67,19 @@ struct RenderPassAttachmentDescription {
  */
 struct RenderPassDescription {
   /**
-   * Number of render pass attachments
+   * Color attachments
    */
-  std::vector<RenderPassAttachmentDescription> attachments;
+  std::vector<RenderPassAttachmentDescription> colorAttachments;
+
+  /**
+   * Depth attachment
+   */
+  std::optional<RenderPassAttachmentDescription> depthAttachment;
+
+  /**
+   * Resolve attachment
+   */
+  std::optional<RenderPassAttachmentDescription> resolveAttachment;
 
   /**
    * Pipeline bind point

--- a/engine/rhi/core/include/liquid/rhi/TextureDescription.h
+++ b/engine/rhi/core/include/liquid/rhi/TextureDescription.h
@@ -58,9 +58,14 @@ struct TextureDescription {
   uint32_t layers = 1;
 
   /**
-   * @brief Number of mip levels
+   * Number of mip levels
    */
   uint32_t levels = 1;
+
+  /**
+   * Number of samples
+   */
+  uint32_t samples = 1;
 };
 
 } // namespace liquid::rhi

--- a/engine/rhi/vulkan/include/liquid/rhi-vulkan/VulkanRenderPass.h
+++ b/engine/rhi/vulkan/include/liquid/rhi-vulkan/VulkanRenderPass.h
@@ -49,6 +49,18 @@ public:
   }
 
 private:
+  /**
+   * @brief Get Vulkan attachment description
+   *
+   * @param description Render pass attachment description
+   * @param registry Vulkan resource registry
+   * @return Vulkan attachment description
+   */
+  VkAttachmentDescription getVulkanAttachmentDescription(
+      const RenderPassAttachmentDescription &description,
+      const VulkanResourceRegistry &registry);
+
+private:
   VulkanDeviceObject &mDevice;
   VkRenderPass mRenderPass = VK_NULL_HANDLE;
   std::vector<VkClearValue> mClearValues;

--- a/engine/rhi/vulkan/src/VulkanPhysicalDevice.cpp
+++ b/engine/rhi/vulkan/src/VulkanPhysicalDevice.cpp
@@ -277,6 +277,10 @@ const PhysicalDeviceInformation VulkanPhysicalDevice::getDeviceInfo() const {
   PhysicalDeviceInformation::Limits deviceLimits{};
   deviceLimits.minUniformBufferOffsetAlignment =
       static_cast<uint32_t>(limits.minUniformBufferOffsetAlignment);
+  deviceLimits.framebufferColorSampleCounts =
+      static_cast<uint32_t>(limits.framebufferColorSampleCounts);
+  deviceLimits.framebufferDepthSampleCounts =
+      static_cast<uint32_t>(limits.framebufferDepthSampleCounts);
 
   return PhysicalDeviceInformation(mName, type, propertiesMap, limitsMap,
                                    deviceLimits);

--- a/engine/rhi/vulkan/src/VulkanPipeline.cpp
+++ b/engine/rhi/vulkan/src/VulkanPipeline.cpp
@@ -80,7 +80,8 @@ VulkanPipeline::VulkanPipeline(const GraphicsPipelineDescription &description,
   multisampling.sType =
       VK_STRUCTURE_TYPE_PIPELINE_MULTISAMPLE_STATE_CREATE_INFO;
   multisampling.sampleShadingEnable = VK_FALSE;
-  multisampling.rasterizationSamples = VK_SAMPLE_COUNT_1_BIT;
+  multisampling.rasterizationSamples =
+      static_cast<VkSampleCountFlagBits>(description.multisample.sampleCount);
   multisampling.minSampleShading = 1.0f;          // Optional
   multisampling.pSampleMask = nullptr;            // Optional
   multisampling.alphaToCoverageEnable = VK_FALSE; // Optional

--- a/engine/rhi/vulkan/src/VulkanTexture.cpp
+++ b/engine/rhi/vulkan/src/VulkanTexture.cpp
@@ -89,9 +89,10 @@ VulkanTexture::VulkanTexture(const TextureDescription &description,
   imageCreateInfo.extent = extent;
   imageCreateInfo.mipLevels = description.levels;
   imageCreateInfo.arrayLayers = description.layers;
-  imageCreateInfo.samples = VK_SAMPLE_COUNT_1_BIT;
   imageCreateInfo.tiling = VK_IMAGE_TILING_OPTIMAL;
   imageCreateInfo.usage = usageFlags;
+  imageCreateInfo.samples =
+      static_cast<VkSampleCountFlagBits>(description.samples);
 
   VmaAllocationCreateInfo allocationCreateInfo{};
   allocationCreateInfo.usage = VMA_MEMORY_USAGE_AUTO;

--- a/engine/src/liquid/imgui/ImguiRenderer.cpp
+++ b/engine/src/liquid/imgui/ImguiRenderer.cpp
@@ -85,7 +85,7 @@ ImguiRenderPassData ImguiRenderer::attach(RenderGraph &graph) {
       mRenderStorage.createFramebufferRelativeTexture(imguiDesc, false);
 
   auto &pass = graph.addGraphicsPass("imgui");
-  pass.write(imgui, mClearColor);
+  pass.write(imgui, AttachmentType::Color, mClearColor);
 
   auto pipeline = pass.addPipeline(rhi::GraphicsPipelineDescription{
       mShaderLibrary.getShader("__engine.imgui.default.vertex"),

--- a/engine/src/liquid/renderer/Presenter.cpp
+++ b/engine/src/liquid/renderer/Presenter.cpp
@@ -41,7 +41,7 @@ void Presenter::updateFramebuffers(const rhi::Swapchain &swapchain) {
 
   rhi::RenderPassDescription renderPassDescription{};
   renderPassDescription.bindPoint = rhi::PipelineBindPoint::Graphics;
-  renderPassDescription.attachments.push_back(attachment);
+  renderPassDescription.colorAttachments.push_back(attachment);
 
   if (mPresentPass != rhi::RenderPassHandle::Invalid) {
     mDevice->destroyRenderPass(mPresentPass);

--- a/engine/src/liquid/renderer/RenderGraph.cpp
+++ b/engine/src/liquid/renderer/RenderGraph.cpp
@@ -217,15 +217,13 @@ void RenderGraph::compile(rhi::RenderDevice *device) {
       rhi::Access srcAccess{rhi::Access::None};
       rhi::Access dstAccess{rhi::Access::None};
 
-      auto &texture = device->getTextureDescription(output.texture);
-      if ((texture.usage & rhi::TextureUsage::Color) ==
-          rhi::TextureUsage::Color) {
+      if (attachment.type == AttachmentType::Color ||
+          attachment.type == AttachmentType::Resolve) {
         output.dstLayout = rhi::ImageLayout::ColorAttachmentOptimal;
         stage = StageColor;
         srcAccess = rhi::Access::ColorAttachmentWrite;
         dstAccess = srcAccess | rhi::Access::ColorAttachmentRead;
-      } else if ((texture.usage & rhi::TextureUsage::Depth) ==
-                 rhi::TextureUsage::Depth) {
+      } else if (attachment.type == AttachmentType::Depth) {
         output.dstLayout = rhi::ImageLayout::DepthStencilAttachmentOptimal;
         stage = StageFragmentTest;
         srcAccess = rhi::Access::DepthStencilAttachmentWrite;

--- a/engine/src/liquid/renderer/RenderGraphPass.cpp
+++ b/engine/src/liquid/renderer/RenderGraphPass.cpp
@@ -6,10 +6,10 @@ namespace liquid {
 RenderGraphPass::RenderGraphPass(StringView name, RenderGraphPassType type)
     : mName(name), mType(type) {}
 
-void RenderGraphPass::write(rhi::TextureHandle handle,
+void RenderGraphPass::write(rhi::TextureHandle handle, AttachmentType type,
                             const rhi::AttachmentClearValue &clearValue) {
   mTextureOutputs.push_back({handle});
-  mAttachments.push_back({clearValue});
+  mAttachments.push_back({type, clearValue});
 }
 
 void RenderGraphPass::read(rhi::TextureHandle handle) {

--- a/engine/src/liquid/renderer/RenderGraphPass.h
+++ b/engine/src/liquid/renderer/RenderGraphPass.h
@@ -13,10 +13,17 @@ namespace liquid {
 class RenderGraph;
 class RenderGraphEvaluator;
 
+enum class AttachmentType { Color, Depth, Resolve };
+
 /**
  * @brief Render graph attachment data
  */
 struct AttachmentData {
+  /**
+   * Attachment type
+   */
+  AttachmentType type = AttachmentType::Color;
+
   /**
    * Clear value
    */
@@ -168,9 +175,10 @@ public:
    * @brief Set output texture
    *
    * @param handle Texture handle
+   * @param type Attachment type
    * @param clearValue Clear value
    */
-  void write(rhi::TextureHandle handle,
+  void write(rhi::TextureHandle handle, AttachmentType type,
              const rhi::AttachmentClearValue &clearValue);
 
   /**

--- a/engine/src/liquid/renderer/SceneRenderer.h
+++ b/engine/src/liquid/renderer/SceneRenderer.h
@@ -18,6 +18,16 @@ struct SceneRenderPassData {
   rhi::TextureHandle sceneColor;
 
   /**
+   * Scene color resolved
+   */
+  rhi::TextureHandle sceneColorResolved;
+
+  /**
+   * Final color texture
+   */
+  rhi::TextureHandle finalColor;
+
+  /**
    * Scene depth buffer
    */
   rhi::TextureHandle depthBuffer;
@@ -122,6 +132,13 @@ private:
    */
   void generateBrdfLut();
 
+  /**
+   * @brief Get framebuffer samples
+   *
+   * @return Framebuffer samples
+   */
+  inline uint32_t getFramebufferSamples() const { return mMaxSampleCounts; }
+
 private:
   glm::vec4 mClearColor{DefaultClearColor};
   ShaderLibrary &mShaderLibrary;
@@ -129,6 +146,8 @@ private:
   rhi::RenderDevice *mDevice;
   RenderStorage &mRenderStorage;
   std::array<SceneRendererFrameData, rhi::RenderDevice::NumFrames> mFrameData;
+
+  uint32_t mMaxSampleCounts = 1;
 };
 
 } // namespace liquid

--- a/engine/tests/liquid-tests/renderer/RenderGraph.test.cpp
+++ b/engine/tests/liquid-tests/renderer/RenderGraph.test.cpp
@@ -88,43 +88,44 @@ TEST_F(RenderGraphTest, TopologicallySortRenderGraph) {
   {
     auto &pass = graph.addGraphicsPass("A");
     pass.write(buffers.at("a-b"), liquid::rhi::BufferUsage::Storage);
-    pass.write(textures.at("a-d"), glm::vec4());
+    pass.write(textures.at("a-d"), liquid::AttachmentType::Color, glm::vec4());
   }
 
   {
     auto &pass = graph.addGraphicsPass("B");
     pass.read(buffers.at("a-b"), liquid::rhi::BufferUsage::Vertex);
     pass.read(buffers.at("d-b"), liquid::rhi::BufferUsage::Index);
-    pass.write(textures.at("b-c"), glm::vec4());
-    pass.write(textures.at("b-g"), glm::vec4());
+    pass.write(textures.at("b-c"), liquid::AttachmentType::Color, glm::vec4());
+    pass.write(textures.at("b-g"), liquid::AttachmentType::Depth, glm::vec4());
   }
 
   {
     auto &pass = graph.addGraphicsPass("C");
     pass.read(textures.at("b-c"));
     pass.read(textures.at("h-c"));
-    pass.write(textures.at("c-e"), glm::vec4());
+    pass.write(textures.at("c-e"), liquid::AttachmentType::Color, glm::vec4());
   }
 
   {
     auto &pass = graph.addGraphicsPass("D");
     pass.read(textures.at("a-d"));
     pass.write(buffers.at("d-b"), liquid::rhi::BufferUsage::Uniform);
-    pass.write(textures.at("d-e"), glm::vec4());
-    pass.write(textures.at("d-g"), glm::vec4());
+    pass.write(textures.at("d-e"), liquid::AttachmentType::Color, glm::vec4());
+    pass.write(textures.at("d-g"), liquid::AttachmentType::Color, glm::vec4());
   }
 
   {
     auto &pass = graph.addGraphicsPass("E");
     pass.read(textures.at("d-e"));
     pass.read(textures.at("c-e"));
-    pass.write(textures.at("e-f"), glm::vec4());
+    pass.write(textures.at("e-f"), liquid::AttachmentType::Color, glm::vec4());
   }
 
   {
     auto &pass = graph.addGraphicsPass("F");
     pass.read(textures.at("e-f"));
-    pass.write(textures.at("f-g"), glm::vec4());
+    pass.write(textures.at("f-g"), liquid::AttachmentType::Resolve,
+               glm::vec4());
   }
 
   {
@@ -132,12 +133,13 @@ TEST_F(RenderGraphTest, TopologicallySortRenderGraph) {
     pass.read(textures.at("f-g"));
     pass.read(textures.at("d-g"));
     pass.read(textures.at("b-g"));
-    pass.write(textures.at("final-color"), glm::vec4());
+    pass.write(textures.at("final-color"), liquid::AttachmentType::Color,
+               glm::vec4());
   }
 
   {
     auto &pass = graph.addGraphicsPass("H");
-    pass.write(textures.at("h-c"), glm::vec4());
+    pass.write(textures.at("h-c"), liquid::AttachmentType::Depth, glm::vec4());
   }
 
   graph.compile(&device);
@@ -164,9 +166,12 @@ TEST_F(RenderGraphTest, TopologicallySortRenderGraph) {
 TEST_F(RenderGraphTest, SetsPassAttachmentOperations) {
   auto handle = device.createTexture({});
 
-  graph.addGraphicsPass("A").write(handle, glm::vec4());
-  graph.addGraphicsPass("B").write(handle, glm::vec4());
-  graph.addGraphicsPass("C").write(handle, glm::vec4());
+  graph.addGraphicsPass("A").write(handle, liquid::AttachmentType::Color,
+                                   glm::vec4());
+  graph.addGraphicsPass("B").write(handle, liquid::AttachmentType::Color,
+                                   glm::vec4());
+  graph.addGraphicsPass("C").write(handle, liquid::AttachmentType::Color,
+                                   glm::vec4());
 
   graph.compile(&device);
 
@@ -199,14 +204,14 @@ TEST_F(RenderGraphTest, SetsOutputImageLayouts) {
 
   {
     auto &pass = graph.addGraphicsPass("A");
-    pass.write(colorTexture, glm::vec4{});
-    pass.write(depthTexture, glm::vec4{});
+    pass.write(colorTexture, liquid::AttachmentType::Color, glm::vec4{});
+    pass.write(depthTexture, liquid::AttachmentType::Depth, glm::vec4{});
   }
 
   {
     auto &pass = graph.addGraphicsPass("B");
-    pass.write(depthTexture, {});
-    pass.write(colorTexture, {});
+    pass.write(depthTexture, liquid::AttachmentType::Depth, {});
+    pass.write(colorTexture, liquid::AttachmentType::Color, {});
   }
 
   graph.compile(&device);
@@ -243,8 +248,8 @@ TEST_F(RenderGraphTest, SetsInputImageLayouts) {
 
   {
     auto &pass = graph.addGraphicsPass("A");
-    pass.write(colorTexture, glm::vec4{});
-    pass.write(depthTexture, glm::vec4{});
+    pass.write(colorTexture, liquid::AttachmentType::Color, glm::vec4{});
+    pass.write(depthTexture, liquid::AttachmentType::Depth, glm::vec4{});
   }
 
   {
@@ -274,7 +279,7 @@ TEST_F(RenderGraphTest, SetsPassBarrierForColorWrite) {
 
   {
     auto &pass = graph.addGraphicsPass("A");
-    pass.write(colorTexture, glm::vec4{});
+    pass.write(colorTexture, liquid::AttachmentType::Color, glm::vec4{});
   }
 
   graph.compile(&device);
@@ -303,7 +308,7 @@ TEST_F(RenderGraphTest, SetsPassBarrierForDepthWrite) {
 
   {
     auto &pass = graph.addGraphicsPass("A");
-    pass.write(depthTexture, glm::vec4{});
+    pass.write(depthTexture, liquid::AttachmentType::Depth, glm::vec4{});
   }
 
   graph.compile(&device);
@@ -338,8 +343,8 @@ TEST_F(RenderGraphTest, SetsPassBarriersForAllTextureWrites) {
 
   {
     auto &pass = graph.addGraphicsPass("A");
-    pass.write(colorTexture, glm::vec4{});
-    pass.write(depthTexture, glm::vec4{});
+    pass.write(colorTexture, liquid::AttachmentType::Color, glm::vec4{});
+    pass.write(depthTexture, liquid::AttachmentType::Depth, glm::vec4{});
   }
 
   graph.compile(&device);
@@ -377,7 +382,7 @@ TEST_F(RenderGraphTest, SetsPassBarrierForColorRead) {
 
   {
     auto &pass = graph.addGraphicsPass("A");
-    pass.write(colorTexture, glm::vec4{});
+    pass.write(colorTexture, liquid::AttachmentType::Color, glm::vec4{});
   }
 
   {
@@ -430,7 +435,7 @@ TEST_F(RenderGraphTest, SetsPassBarrierForDepthTextureRead) {
 
   {
     auto &pass = graph.addGraphicsPass("A");
-    pass.write(depthTexture, glm::vec4{});
+    pass.write(depthTexture, liquid::AttachmentType::Depth, glm::vec4{});
   }
 
   {
@@ -488,8 +493,8 @@ TEST_F(RenderGraphTest, SetsPassBarrierForBothColorAndDepthTextureReads) {
 
   {
     auto &pass = graph.addGraphicsPass("A");
-    pass.write(colorTexture, glm::vec4{});
-    pass.write(depthTexture, glm::vec4{});
+    pass.write(colorTexture, liquid::AttachmentType::Color, glm::vec4{});
+    pass.write(depthTexture, liquid::AttachmentType::Depth, glm::vec4{});
   }
 
   {
@@ -985,8 +990,8 @@ TEST_F(RenderGraphTest, MergesInputAndOutputBarriers) {
 
   {
     auto &pass = graph.addGraphicsPass("A");
-    pass.write(colorTexture1, glm::vec4{});
-    pass.write(depthTexture1, glm::vec4{});
+    pass.write(colorTexture1, liquid::AttachmentType::Color, glm::vec4{});
+    pass.write(depthTexture1, liquid::AttachmentType::Depth, glm::vec4{});
   }
 
   {
@@ -994,8 +999,8 @@ TEST_F(RenderGraphTest, MergesInputAndOutputBarriers) {
     pass.read(colorTexture1);
     pass.read(depthTexture1);
 
-    pass.write(depthTexture2, {});
-    pass.write(colorTexture2, {});
+    pass.write(depthTexture2, liquid::AttachmentType::Depth, {});
+    pass.write(colorTexture2, liquid::AttachmentType::Color, {});
   }
 
   graph.compile(&device);
@@ -1087,7 +1092,8 @@ TEST_F(RenderGraphDeathTest, FailsIfPassReadsFromNonWrittenTexture) {
 TEST_F(RenderGraphTest, CompilationRemovesLonelyNodes) {
   liquid::rhi::TextureHandle handle = device.createTexture({});
 
-  graph.addGraphicsPass("A").write(handle, glm::vec4());
+  graph.addGraphicsPass("A").write(handle, liquid::AttachmentType::Color,
+                                   glm::vec4());
   graph.addGraphicsPass("B");
   graph.addGraphicsPass("C");
   graph.addGraphicsPass("E").read(handle);
@@ -1101,7 +1107,8 @@ TEST_F(RenderGraphTest, CompilationRemovesLonelyNodes) {
 TEST_F(RenderGraphTest, RecompilationRecreatesCompiledPassesList) {
   liquid::rhi::TextureHandle handle = device.createTexture({});
 
-  graph.addGraphicsPass("A").write(handle, glm::vec4());
+  graph.addGraphicsPass("A").write(handle, liquid::AttachmentType::Color,
+                                   glm::vec4());
   graph.addGraphicsPass("E").read(handle);
 
   graph.compile(&device);
@@ -1116,7 +1123,8 @@ TEST_F(RenderGraphTest, RecompilationRecreatesCompiledPassesList) {
 TEST_F(RenderGraphDeathTest, CompilationFailsIfMultipleNodesHaveTheSameName) {
   liquid::rhi::TextureHandle handle{2};
 
-  graph.addGraphicsPass("A").write(handle, glm::vec4());
+  graph.addGraphicsPass("A").write(handle, liquid::AttachmentType::Color,
+                                   glm::vec4());
   graph.addGraphicsPass("B");
   graph.addGraphicsPass("A");
   graph.addGraphicsPass("E");

--- a/engine/tests/liquid-tests/renderer/RenderGraphPass.test.cpp
+++ b/engine/tests/liquid-tests/renderer/RenderGraphPass.test.cpp
@@ -24,7 +24,7 @@ TEST_F(RenderGraphPassTest, SetsNameAndTypeOnConstruct) {
 TEST_F(RenderGraphPassTest, AddsTextureHandleToOutputOnWrite) {
   liquid::rhi::TextureHandle handle{2};
 
-  graphicsPass.write(handle, glm::vec4());
+  graphicsPass.write(handle, liquid::AttachmentType::Color, glm::vec4());
   EXPECT_EQ(graphicsPass.getTextureOutputs().size(), 1);
   EXPECT_EQ(graphicsPass.getTextureOutputs().at(0).texture, handle);
 }
@@ -32,7 +32,7 @@ TEST_F(RenderGraphPassTest, AddsTextureHandleToOutputOnWrite) {
 TEST_F(RenderGraphPassTest, AddsClearValueToAttachmentDataOnWrite) {
   liquid::rhi::TextureHandle handle{2};
 
-  graphicsPass.write(handle, glm::vec4(2.0f));
+  graphicsPass.write(handle, liquid::AttachmentType::Color, glm::vec4(2.0f));
   EXPECT_EQ(graphicsPass.getAttachments().size(), 1);
   EXPECT_EQ(std::get<glm::vec4>(graphicsPass.getAttachments().at(0).clearValue),
             glm::vec4(2.0f));

--- a/runtime/src/runtime/Runtime.cpp
+++ b/runtime/src/runtime/Runtime.cpp
@@ -49,11 +49,7 @@ void Runtime::start() {
 
   liquid::RenderGraph graph("Main");
 
-  static constexpr glm::vec4 BlueishClearValue{0.52f, 0.54f, 0.89f, 1.0f};
-
   liquid::Presenter presenter(renderer.getShaderLibrary(), device);
-
-  renderer.getSceneRenderer().setClearColor(BlueishClearValue);
 
   auto passData = renderer.getSceneRenderer().attach(graph);
   renderer.getSceneRenderer().attachText(graph, passData);
@@ -110,7 +106,7 @@ void Runtime::start() {
 
       renderer.render(graph, renderFrame.commandList, renderFrame.frameIndex);
 
-      presenter.present(renderFrame.commandList, passData.sceneColor,
+      presenter.present(renderFrame.commandList, passData.finalColor,
                         renderFrame.swapchainImageIndex);
 
       renderer.getRenderDevice()->endFrame(renderFrame);


### PR DESCRIPTION
- Expose maxiumum supported samples for framebuffers from device
- Add render pass attachment type
- Pass the attachment type for all attachments
- Add resolve attachment to render pass
- Add samples field to texture description
- Add multisampling field to pipeline
- Automatically deduce the number of samples for pipelines during render graph evaluation