### PR TITLE
Fix camera in editor

### DIFF
--- a/editor/assets/shaders/collidable-shape.vert
+++ b/editor/assets/shaders/collidable-shape.vert
@@ -19,6 +19,8 @@ layout(set = 1, binding = 0) uniform DrawParameters {
   uint collidableParams;
   uint camera;
   uint gridData;
+  uint pad0;
+  uint pad1;
 }
 uDrawParams;
 

--- a/editor/assets/shaders/editor-grid.frag
+++ b/editor/assets/shaders/editor-grid.frag
@@ -16,9 +16,11 @@ layout(set = 1, binding = 0) uniform DrawParameters {
   uint gizmoTransforms;
   uint skeletonTransforms;
   uint debugSkeletons;
-  uint collidbaleParams;
+  uint collidableParams;
   uint camera;
   uint gridData;
+  uint pad0;
+  uint pad1;
 }
 uDrawParams;
 

--- a/editor/assets/shaders/object-icons.frag
+++ b/editor/assets/shaders/object-icons.frag
@@ -8,13 +8,15 @@ layout(location = 0) out vec4 outColor;
 
 layout(set = 1, binding = 0) uniform sampler2D uGlobalTextures[];
 
-layout(set = 2, binding = 0) uniform DrawParameters {
+layout(set = 1, binding = 0) uniform DrawParameters {
   uint gizmoTransforms;
   uint skeletonTransforms;
   uint debugSkeletons;
-  uint collidbaleParams;
+  uint collidableParams;
   uint camera;
   uint gridData;
+  uint pad0;
+  uint pad1;
 }
 uDrawParams;
 

--- a/editor/assets/shaders/object-icons.vert
+++ b/editor/assets/shaders/object-icons.vert
@@ -14,6 +14,8 @@ layout(set = 2, binding = 0) uniform DrawParameters {
   uint collidbaleParams;
   uint camera;
   uint gridData;
+  uint pad0;
+  uint pad1;
 }
 uDrawParams;
 

--- a/editor/assets/shaders/skeleton-lines.vert
+++ b/editor/assets/shaders/skeleton-lines.vert
@@ -28,9 +28,11 @@ layout(set = 1, binding = 0) uniform DrawParameters {
   uint gizmoTransforms;
   uint skeletonTransforms;
   uint debugSkeletons;
-  uint collidbaleParams;
+  uint collidableParams;
   uint camera;
   uint gridData;
+  uint pad0;
+  uint pad1;
 }
 uDrawParams;
 

--- a/editor/src/liquidator/actions/SimulationModeActions.cpp
+++ b/editor/src/liquidator/actions/SimulationModeActions.cpp
@@ -8,9 +8,14 @@ StartSimulationModeAction::onExecute(WorkspaceState &state) {
   state.mode = WorkspaceMode::Simulation;
   state.simulationScene.entityDatabase.destroy();
   state.scene.entityDatabase.duplicate(state.simulationScene.entityDatabase);
-  state.simulationScene.activeCamera = state.scene.activeCamera;
   state.simulationScene.dummyCamera = state.scene.dummyCamera;
   state.simulationScene.environment = state.scene.environment;
+
+  if (state.scene.entityDatabase.has<Camera>(state.scene.activeCamera)) {
+    state.simulationScene.activeCamera = state.scene.activeCamera;
+  } else {
+    state.simulationScene.activeCamera = state.scene.dummyCamera;
+  }
   return ActionExecutorResult{};
 }
 

--- a/editor/src/liquidator/core/EditorRenderer.cpp
+++ b/editor/src/liquidator/core/EditorRenderer.cpp
@@ -193,7 +193,7 @@ RenderGraphPass &EditorRenderer::attach(RenderGraph &graph) {
 
         commandList.draw(4, 0, count, previousInstance);
 
-        previousInstance = count;
+        previousInstance += count;
       }
     }
   });

--- a/editor/src/liquidator/core/EditorRendererFrameData.cpp
+++ b/editor/src/liquidator/core/EditorRendererFrameData.cpp
@@ -62,6 +62,8 @@ EditorRendererFrameData::EditorRendererFrameData(RenderStorage &renderStorage,
     rhi::BufferHandle collidbaleParams;
     rhi::BufferHandle camera;
     rhi::BufferHandle gridData;
+    uint32_t pad0;
+    uint32_t pad1;
   };
 
   mBindlessParams.addRange(EditorDrawParams{

--- a/editor/tests/liquidator-tests/actions/SimulationModeActions.test.cpp
+++ b/editor/tests/liquidator-tests/actions/SimulationModeActions.test.cpp
@@ -18,9 +18,12 @@ TEST_F(StartSimulationModeActionTest, ExecutorSetsWorkspaceModeToSimulation) {
 
 TEST_F(StartSimulationModeActionTest,
        ExecutorDuplicatesSceneToSimulationScene) {
+  auto activeCamera = state.scene.entityDatabase.create();
+  state.scene.entityDatabase.set<liquid::Camera>(activeCamera, {});
+
   state.mode = WM::Edit;
   state.scene.environment = liquid::Entity{12};
-  state.scene.activeCamera = liquid::Entity{14};
+  state.scene.activeCamera = activeCamera;
   state.scene.dummyCamera = liquid::Entity{15};
   auto entity = state.scene.entityDatabase.create();
 
@@ -34,6 +37,31 @@ TEST_F(StartSimulationModeActionTest,
 
   EXPECT_EQ(state.simulationScene.environment, state.scene.environment);
   EXPECT_EQ(state.simulationScene.activeCamera, state.scene.activeCamera);
+  EXPECT_EQ(state.simulationScene.dummyCamera, state.scene.dummyCamera);
+  EXPECT_TRUE(state.simulationScene.entityDatabase.exists(entity));
+}
+
+TEST_F(StartSimulationModeActionTest,
+       ExecutorSetsDummyCameraAsSceneCameraIfSceneHasNoActiveCamera) {
+  auto dummyCamera = state.scene.entityDatabase.create();
+  state.scene.entityDatabase.set<liquid::Camera>(dummyCamera, {});
+
+  state.mode = WM::Edit;
+  state.scene.environment = liquid::Entity{12};
+  state.scene.activeCamera = liquid::Entity{14};
+  state.scene.dummyCamera = dummyCamera;
+  auto entity = state.scene.entityDatabase.create();
+
+  EXPECT_EQ(state.simulationScene.environment, liquid::Entity::Null);
+  EXPECT_EQ(state.simulationScene.activeCamera, liquid::Entity::Null);
+  EXPECT_EQ(state.simulationScene.dummyCamera, liquid::Entity::Null);
+  EXPECT_FALSE(state.simulationScene.entityDatabase.exists(entity));
+
+  liquid::editor::StartSimulationModeAction action;
+  action.onExecute(state);
+
+  EXPECT_EQ(state.simulationScene.environment, state.scene.environment);
+  EXPECT_EQ(state.simulationScene.activeCamera, state.scene.dummyCamera);
   EXPECT_EQ(state.simulationScene.dummyCamera, state.scene.dummyCamera);
   EXPECT_TRUE(state.simulationScene.entityDatabase.exists(entity));
 }


### PR DESCRIPTION
- Add padding to editor renderer bindless params
- Fix camera gizmo positions
- When scene has no camera, use the dummy camera as simulation mode camera