### PR TITLE
Add entity remove observers

### DIFF
--- a/editor/src/liquidator/core/EditorSimulator.h
+++ b/editor/src/liquidator/core/EditorSimulator.h
@@ -63,6 +63,13 @@ private:
   void cleanupSimulationDatabase(EntityDatabase &simulationDatabase);
 
   /**
+   * @brief Observe changes for simulation database
+   *
+   * @param simulationDatabase Simulation database
+   */
+  void observeChanges(EntityDatabase &simulationDatabase);
+
+  /**
    * @brief Editor updater
    *
    * @param dt Time delta

--- a/editor/src/liquidator/ui/EntityPanel.cpp
+++ b/editor/src/liquidator/ui/EntityPanel.cpp
@@ -808,38 +808,6 @@ void EntityPanel::renderRigidBody(Scene &scene,
 
       mRigidBody.reset();
     }
-
-    if (rigidBody.actor) {
-      rigidBody.actor->getLinearVelocity();
-      if (auto table = widgets::Table("TableRigidBodyDetails", 2)) {
-        auto *actor = rigidBody.actor;
-
-        const auto &pose = actor->getGlobalPose();
-        const auto &cmass = actor->getCMassLocalPose();
-        const auto &invInertia = actor->getMassSpaceInvInertiaTensor();
-        const auto &linearVelocity = actor->getLinearVelocity();
-        const auto &angularVelocity = actor->getAngularVelocity();
-
-        table.row("Pose position", glm::vec3(pose.p.x, pose.p.y, pose.p.y));
-        table.row("Pose rotation",
-                  glm::quat(cmass.q.w, cmass.q.x, cmass.q.y, cmass.q.z));
-        table.row("CMass position", glm::vec3(cmass.p.x, cmass.p.y, cmass.p.y));
-        table.row("CMass rotation",
-                  glm::quat(cmass.q.w, cmass.q.x, cmass.q.y, cmass.q.z));
-        table.row("Inverse inertia tensor position",
-                  glm::vec3(invInertia.x, invInertia.y, invInertia.y));
-        table.row("Linear damping",
-                  static_cast<float>(actor->getLinearDamping()));
-        table.row("Angular damping",
-                  static_cast<float>(actor->getAngularDamping()));
-        table.row(
-            "Linear velocity",
-            glm::vec3(linearVelocity.x, linearVelocity.y, linearVelocity.z));
-        table.row(
-            "Angular velocity",
-            glm::vec3(angularVelocity.x, angularVelocity.y, angularVelocity.z));
-      }
-    }
   }
 }
 

--- a/editor/src/liquidator/ui/UIRoot.cpp
+++ b/editor/src/liquidator/ui/UIRoot.cpp
@@ -28,6 +28,8 @@ UIRoot::UIRoot(ActionExecutor &actionExecutor, AssetLoader &assetLoader)
 
   mToolbar.add(new StartSimulationMode, "Play", fa::Play,
                ToolbarItemType::HideWhenInactive);
+  mToolbar.add(new StopSimulationMode, "Stop", fa::Stop,
+               ToolbarItemType::HideWhenInactive);
   mToolbar.add(new SetActiveTransform(TransformOperation::Move), "Move",
                fa::Arrows, ToolbarItemType::Toggleable);
   mToolbar.add(new SetActiveTransform(TransformOperation::Rotate), "Rotate",

--- a/engine/src/liquid/core/EntityDeleter.cpp
+++ b/engine/src/liquid/core/EntityDeleter.cpp
@@ -19,6 +19,9 @@ void EntityDeleter::update(Scene &scene) {
   auto activeCamera = scene.activeCamera;
 
   auto count = entityDatabase.getEntityCountForComponent<Delete>();
+  if (count == 0) {
+    return;
+  }
 
   std::vector<Entity> deleteList;
   deleteList.reserve(count);

--- a/engine/src/liquid/entity/EntityDatabase.cpp
+++ b/engine/src/liquid/entity/EntityDatabase.cpp
@@ -29,6 +29,7 @@ EntityDatabase::EntityDatabase() {
   reg<SkeletonDebug>();
   reg<RigidBody>();
   reg<Collidable>();
+  reg<PhysxInstance>();
   reg<Force>();
   reg<Torque>();
   reg<RigidBodyClear>();

--- a/engine/src/liquid/entity/EntityDatabase.h
+++ b/engine/src/liquid/entity/EntityDatabase.h
@@ -30,6 +30,7 @@
 #include "liquid/physics/Force.h"
 #include "liquid/physics/Torque.h"
 #include "liquid/physics/RigidBodyClear.h"
+#include "liquid/physics/PhysxInstance.h"
 #include "liquid/scripting/Script.h"
 #include "liquid/text/Text.h"
 
@@ -50,5 +51,8 @@ public:
    */
   EntityDatabase();
 };
+
+template <class TComponent>
+using EntityDatabaseObserver = EntityStorageSparseSetObserver<TComponent>;
 
 } // namespace liquid

--- a/engine/src/liquid/entity/EntityStorageSparseSetObserver.h
+++ b/engine/src/liquid/entity/EntityStorageSparseSetObserver.h
@@ -1,0 +1,122 @@
+#pragma once
+
+#include "EntityStorageSparseSetComponentPool.h"
+
+namespace liquid {
+
+/**
+ * @brief Observer for sparse set based entity storage
+ *
+ * @tparam TComponentTypes Component types
+ */
+template <class TComponent> class EntityStorageSparseSetObserver {
+public:
+  /**
+   * @brief Observer iterator
+   */
+  class Iterator {
+  public:
+    /**
+     * @brief Create iterator
+     *
+     * @param index Index
+     * @param pool Picked pools
+     */
+    Iterator(size_t index, EntityStorageSparseSetComponentPool *pool)
+        : mIndex(index), mPool(pool) {}
+
+    /**
+     * @brief Increment iterator
+     *
+     * @return This iterator
+     */
+    Iterator &operator++() {
+      mIndex++;
+      return *this;
+    }
+
+    /**
+     * @brief Check if iterators are equal
+     *
+     * @param rhs Other iterator
+     * @retval true Iterators are equal
+     * @retval false Iterators are not equal
+     */
+    bool operator==(Iterator &rhs) { return mIndex == rhs.mIndex; }
+
+    /**
+     * @brief Check if iterators are not equal
+     *
+     * @param rhs Other iterator
+     * @retval true Iterators are not equal
+     * @retval false Iterators are equal
+     */
+    bool operator!=(Iterator &rhs) { return mIndex != rhs.mIndex; }
+
+    /**
+     * @brief Get value
+     *
+     * @return Tuple with first item as entity and rest as components
+     */
+    std::tuple<Entity, TComponent> operator*() {
+      return {mPool->entities.at(mIndex),
+              std::any_cast<TComponent>(mPool->components.at(mIndex))};
+    }
+
+  private:
+    size_t mIndex = 0;
+    EntityStorageSparseSetComponentPool *mPool;
+  };
+
+public:
+  /**
+   * @brief Create observer
+   */
+  EntityStorageSparseSetObserver() = default;
+
+  /**
+   * @brief Create observer
+   *
+   * @param pool Component pool
+   */
+  EntityStorageSparseSetObserver(EntityStorageSparseSetComponentPool *pool)
+      : mPool(pool) {}
+
+  /**
+   * @brief Get begin iterator
+   *
+   * @return Begin iterator
+   */
+  Iterator begin() {
+    LIQUID_ASSERT(mPool != nullptr, "Observer is not initialized");
+
+    return Iterator(0, mPool);
+  }
+
+  /**
+   * @brief Get end iterator
+   *
+   * @return End iterator
+   */
+  Iterator end() { return Iterator(mPool->entities.size(), mPool); }
+
+  /**
+   * @brief Get number of observed components
+   *
+   * @return Number of observed components
+   */
+  inline size_t size() { return mPool->entities.size(); }
+
+  /**
+   * @brief Clear observed items
+   */
+  void clear() {
+    mPool->entities.clear();
+    mPool->components.clear();
+  }
+
+private:
+  EntityStorageSparseSetComponentPool *mPool = nullptr;
+};
+
+} // namespace liquid

--- a/engine/src/liquid/events/EventPool.h
+++ b/engine/src/liquid/events/EventPool.h
@@ -67,6 +67,18 @@ public:
   }
 
   /**
+   * @brief Check if observer exists
+   *
+   * @param type Event type
+   * @param observerId Observer Id
+   * @retval true Observer exists
+   * @retval Observer does not exist
+   */
+  bool hasObserver(TEvent type, EventObserverId observerId) {
+    return mObservers.at(type).contains(observerId);
+  }
+
+  /**
    * @brief Dispatch event
    *
    * @param type Event type

--- a/engine/src/liquid/events/EventSystem.h
+++ b/engine/src/liquid/events/EventSystem.h
@@ -56,7 +56,7 @@ public:
   }
 
   /**
-   * @brief Remove collision event observer
+   * @brief Remove event observer
    *
    * @tparam TEvent Event type enum
    * @param type Event type
@@ -66,6 +66,21 @@ public:
   inline void removeObserver(TEvent type, EventObserverId id) {
     using CurrentPool = GetEventPool<TEvent>;
     std::get<CurrentPool>(mPools).removeObserver(type, id);
+  }
+
+  /**
+   * @brief Check if observer exists
+   *
+   * @tparam TEvent Event type enum
+   * @param type Event type
+   * @param id Observer Id
+   * @retval true Observer exists
+   * @retval false Observer does not exist
+   */
+  template <class TEvent>
+  inline bool hasObserver(TEvent type, EventObserverId id) {
+    using CurrentPool = GetEventPool<TEvent>;
+    return std::get<CurrentPool>(mPools).hasObserver(type, id);
   }
 
   /**

--- a/engine/src/liquid/physics/Collidable.h
+++ b/engine/src/liquid/physics/Collidable.h
@@ -1,9 +1,5 @@
 #pragma once
 
-#include <PxConfig.h>
-#include <PxShape.h>
-#include <PxMaterial.h>
-
 #include "PhysicsObjects.h"
 
 namespace liquid {
@@ -21,21 +17,6 @@ struct Collidable {
    * Physics material description
    */
   PhysicsMaterialDesc materialDesc;
-
-  /**
-   * PhysX shape
-   */
-  physx::PxShape *shape = nullptr;
-
-  /**
-   * PhysX material
-   */
-  physx::PxMaterial *material = nullptr;
-
-  /**
-   * PhysX rigid body
-   */
-  physx::PxRigidStatic *rigidStatic = nullptr;
 };
 
 } // namespace liquid

--- a/engine/src/liquid/physics/PhysicsSystem.h
+++ b/engine/src/liquid/physics/PhysicsSystem.h
@@ -48,6 +48,13 @@ public:
    */
   void cleanup(EntityDatabase &entityDatabase);
 
+  /**
+   * @brief Observer changes in entities
+   *
+   * @param entityDatabase Entity database
+   */
+  void observeChanges(EntityDatabase &entityDatabase);
+
 private:
   /**
    * @brief Synchronize physics components
@@ -66,6 +73,8 @@ private:
 private:
   PhysicsSystemImpl *mImpl = nullptr;
   EventSystem &mEventSystem;
+
+  EntityDatabaseObserver<PhysxInstance> mPhysxInstanceRemoveObserver;
 };
 
 } // namespace liquid

--- a/engine/src/liquid/physics/PhysxInstance.h
+++ b/engine/src/liquid/physics/PhysxInstance.h
@@ -1,0 +1,34 @@
+#pragma once
+
+#include <PxConfig.h>
+#include <PxShape.h>
+#include <PxMaterial.h>
+
+namespace liquid {
+
+/**
+ * @brief PhysX instance component
+ */
+struct PhysxInstance {
+  /**
+   * Dynamic rigid body actor
+   */
+  physx::PxRigidDynamic *rigidDynamic = nullptr;
+
+  /**
+   * Static rigid body actor
+   */
+  physx::PxRigidStatic *rigidStatic = nullptr;
+
+  /**
+   * Collidable shape
+   */
+  physx::PxShape *shape = nullptr;
+
+  /**
+   * Material
+   */
+  physx::PxMaterial *material = nullptr;
+};
+
+} // namespace liquid

--- a/engine/src/liquid/physics/RigidBody.h
+++ b/engine/src/liquid/physics/RigidBody.h
@@ -1,8 +1,5 @@
 #pragma once
 
-#include <PxConfig.h>
-#include <PxRigidDynamic.h>
-
 #include "PhysicsObjects.h"
 
 namespace liquid {
@@ -15,11 +12,6 @@ struct RigidBody {
    * Dynamic rigid body description
    */
   PhysicsDynamicRigidBodyDesc dynamicDesc;
-
-  /**
-   * PhysX Rigid body actor
-   */
-  physx::PxRigidDynamic *actor = nullptr;
 };
 
 } // namespace liquid

--- a/engine/src/liquid/scripting/LuaScope.h
+++ b/engine/src/liquid/scripting/LuaScope.h
@@ -193,6 +193,14 @@ public:
    */
   void stackDump();
 
+  /**
+   * @brief Check if scope exists
+   *
+   * @retval true Scope exists
+   * @retval false Scope does not exist
+   */
+  operator bool() { return mScope != nullptr; }
+
 private:
   /**
    * @brief Get table field

--- a/engine/src/liquid/scripting/ScriptingSystem.h
+++ b/engine/src/liquid/scripting/ScriptingSystem.h
@@ -53,6 +53,13 @@ public:
    */
   void cleanup(EntityDatabase &entityDatabase);
 
+  /**
+   * @brief Observer changes in entities
+   *
+   * @param entityDatabase Entity database
+   */
+  void observeChanges(EntityDatabase &entityDatabase);
+
 private:
   /**
    * @brief Destroy scripting data
@@ -73,6 +80,8 @@ private:
   EventSystem &mEventSystem;
   AssetRegistry &mAssetRegistry;
   LuaInterpreter mLuaInterpreter;
+
+  EntityDatabaseObserver<Script> mScriptRemoveObserver;
 };
 
 } // namespace liquid

--- a/runtime/src/runtime/Runtime.cpp
+++ b/runtime/src/runtime/Runtime.cpp
@@ -64,6 +64,10 @@ void Runtime::start() {
   liquid::AudioSystem audioSystem(assetCache.getRegistry());
   liquid::EntityDeleter entityDeleter;
 
+  audioSystem.observeChanges(scene.entityDatabase);
+  scriptingSystem.observeChanges(scene.entityDatabase);
+  physicsSystem.observeChanges(scene.entityDatabase);
+
   graph.setFramebufferExtent(window.getFramebufferSize());
   window.addResizeHandler([&graph, &renderer](auto width, auto height) {
     graph.setFramebufferExtent({width, height});
@@ -79,6 +83,7 @@ void Runtime::start() {
     eventSystem.poll();
     auto &entityDatabase = scene.entityDatabase;
 
+    entityDeleter.update(scene);
     cameraAspectRatioUpdater.update(entityDatabase);
     scriptingSystem.start(entityDatabase);
     scriptingSystem.update(dt, entityDatabase);
@@ -87,7 +92,6 @@ void Runtime::start() {
     sceneUpdater.update(entityDatabase);
     physicsSystem.update(dt, entityDatabase);
     audioSystem.output(entityDatabase);
-    entityDeleter.update(scene);
 
     return true;
   });


### PR DESCRIPTION
- Add remove observers to entity database
- Each observer stores its own copy of components
- Use remove observers to cleanup resources in scripting system
- Use remove observers to cleanup resources in physics system
- Use remove observers to cleanup resources in audio system
- Split physics component from PhysX instance