### PR TITLE
Remove camera entity from editor camera

### DIFF
--- a/editor/src/liquidator/actions/SimulationModeActions.cpp
+++ b/editor/src/liquidator/actions/SimulationModeActions.cpp
@@ -12,9 +12,12 @@ ActionExecutorResult StartSimulationMode::onExecute(WorkspaceState &state) {
 
   if (state.scene.entityDatabase.has<Camera>(state.scene.activeCamera)) {
     state.simulationScene.activeCamera = state.scene.activeCamera;
+    state.activeCamera = state.scene.activeCamera;
   } else {
     state.simulationScene.activeCamera = state.scene.dummyCamera;
+    state.activeCamera = state.scene.dummyCamera;
   }
+
   return ActionExecutorResult{};
 }
 
@@ -24,6 +27,7 @@ bool StartSimulationMode::predicate(WorkspaceState &state) {
 
 ActionExecutorResult StopSimulationMode::onExecute(WorkspaceState &state) {
   state.mode = WorkspaceMode::Edit;
+  state.activeCamera = state.camera;
   return ActionExecutorResult{};
 }
 

--- a/editor/src/liquidator/core/EditorSimulator.cpp
+++ b/editor/src/liquidator/core/EditorSimulator.cpp
@@ -52,7 +52,7 @@ void EditorSimulator::updateEditor(float dt, WorkspaceState &state) {
   mEntityDeleter.update(state.scene);
 
   mCameraAspectRatioUpdater.update(entityDatabase);
-  mEditorCamera.update();
+  mEditorCamera.update(state);
 
   mSkeletonUpdater.update(entityDatabase);
   mSceneUpdater.update(entityDatabase);

--- a/editor/src/liquidator/editor-scene/EditorCamera.h
+++ b/editor/src/liquidator/editor-scene/EditorCamera.h
@@ -5,6 +5,7 @@
 #include "liquid/entity/EntityDatabase.h"
 #include "liquid/events/EventSystem.h"
 #include "liquidator/core/CameraLookAt.h"
+#include "liquidator/state/WorkspaceState.h"
 
 namespace liquid::editor {
 
@@ -20,7 +21,13 @@ public:
   /**
    * Current camera input state
    */
-  enum class InputState { None = 0, Pan = 1, Rotate = 2, Zoom = 3 };
+  enum class InputState {
+    None = 0,
+    Pan = 1,
+    Rotate = 2,
+    Zoom = 3,
+    ZoomWheel = 4
+  };
 
   /**
    * Zoom speed when scrolling
@@ -61,12 +68,10 @@ public:
   /**
    * @brief Create editor camera
    *
-   * @param entityDatabase Entity database
    * @param eventSystem Event system
    * @param window Window
    */
-  EditorCamera(EntityDatabase &entityDatabase, EventSystem &eventSystem,
-               Window &window);
+  EditorCamera(EventSystem &eventSystem, Window &window);
 
   EditorCamera(const EditorCamera &) = delete;
   EditorCamera &operator=(const EditorCamera &) = delete;
@@ -81,18 +86,11 @@ public:
   ~EditorCamera();
 
   /**
-   * @brief Get aspect ratio
-   *
-   * @return Aspect ratio
-   */
-  inline float getAspectRatio() const {
-    return getPerspectiveLens().aspectRatio;
-  }
-
-  /**
    * @brief Update camera
+   *
+   * @param state Workspace state
    */
-  void update();
+  void update(WorkspaceState &state);
 
   /**
    * @brief Set viewport
@@ -134,56 +132,48 @@ public:
   inline const InputState &getInputState() const { return mInputState; }
 
   /**
-   * @brief Get camera entity
+   * @brief Create default camera
    *
+   * @param entityDatabase Entity database
    * @return Camera entity
    */
-  inline Entity getEntity() { return mCameraEntity; }
+  Entity createDefaultCamera(EntityDatabase &entityDatabase);
 
 private:
   /**
-   * @brief Reset camera to defaults
-   */
-  void reset();
-
-  /**
-   * @brief Get perspective lens
-   *
-   * @return Perspective lens
-   */
-  inline PerspectiveLens &getPerspectiveLens() {
-    return mEntityDatabase.get<PerspectiveLens>(mCameraEntity);
-  }
-
-  /**
-   * @brief Get perspective lens
-   *
-   * @return Perspective lens
-   */
-  inline const PerspectiveLens &getPerspectiveLens() const {
-    return mEntityDatabase.get<PerspectiveLens>(mCameraEntity);
-  }
-
-  /**
    * @brief Pan camera using mouse movement
+   *
+   * @param lookAt Camera look at
    */
-  void pan();
+  void pan(CameraLookAt &lookAt);
 
   /**
    * @brief Rotate camera using mouse movement
+   *
+   * @param lookAt Camera look at
    */
-  void rotate();
+  void rotate(CameraLookAt &lookAt);
 
   /**
    * @brief Zoom camera using mouse movement
+   *
+   * @param lookAt Camera look at
    */
-  void zoom();
+  void zoom(CameraLookAt &lookAt);
+
+  /**
+   * @brief Zoom camera using mouse wheel
+   *
+   * @param lookAt Camera look at
+   */
+  void zoomWheel(CameraLookAt &lookAt);
 
 private:
   float mX = 0.0f;
   float mY = 0.0f;
   float mWidth = 0.0f;
   float mHeight = 0.0f;
+  float mWheelOffset = 0.0f;
   bool mCaptureMouse = false;
 
   InputState mInputState = InputState::None;
@@ -195,9 +185,7 @@ private:
   EventObserverId mMouseScrollHandler = 0;
 
   Window &mWindow;
-  EntityDatabase &mEntityDatabase;
   EventSystem &mEventSystem;
-  Entity mCameraEntity = Entity::Null;
 };
 
 } // namespace liquid::editor

--- a/editor/src/liquidator/editor-scene/EditorManager.cpp
+++ b/editor/src/liquidator/editor-scene/EditorManager.cpp
@@ -3,13 +3,11 @@
 #include "liquid/platform-tools/NativeFileDialog.h"
 
 #include "EditorManager.h"
+#include "EditorCamera.h"
 
 #include <glm/gtc/matrix_access.hpp>
 
 namespace liquid::editor {
-
-EditorManager::EditorManager(EditorCamera &editorCamera, const Project &project)
-    : mEditorCamera(editorCamera), mProject(project) {}
 
 void EditorManager::saveWorkspaceState(WorkspaceState &state,
                                        const std::filesystem::path &path) {
@@ -37,8 +35,6 @@ void EditorManager::saveWorkspaceState(WorkspaceState &state,
 
 void EditorManager::loadWorkspaceState(const std::filesystem::path &path,
                                        WorkspaceState &state) {
-  state.camera = mEditorCamera.getEntity();
-
   std::ifstream stream(path, std::ios::in);
 
   if (!stream.good()) {

--- a/editor/src/liquidator/editor-scene/EditorManager.h
+++ b/editor/src/liquidator/editor-scene/EditorManager.h
@@ -3,42 +3,23 @@
 #include "liquidator/project/Project.h"
 #include "liquidator/state/WorkspaceState.h"
 
-#include "EditorCamera.h"
-
 namespace liquid::editor {
-
-enum class EnvironmentLightingSource { None = 0, Skybox = 1 };
 
 /**
  * @brief Editor manager
  *
- * Manages, saves, and loads the
- * scene with editor settings
+ * Saves an loads workspace state
  */
 class EditorManager {
 public:
-  /**
-   * @brief Create editor manager
-   *
-   * @param editorCamera Editor camera
-   * @param project Project
-   */
-  EditorManager(EditorCamera &editorCamera, const Project &project);
-
-  EditorManager(const EditorManager &) = delete;
-  EditorManager(EditorManager &&) = delete;
-  EditorManager &operator=(const EditorManager &) = delete;
-  EditorManager &operator=(EditorManager &&) = delete;
-  ~EditorManager() = default;
-
   /**
    * @brief Save workspace state to a file
    *
    * @param state Workspace state
    * @param path Path to workspace state file
    */
-  void saveWorkspaceState(WorkspaceState &state,
-                          const std::filesystem::path &path);
+  static void saveWorkspaceState(WorkspaceState &state,
+                                 const std::filesystem::path &path);
 
   /**
    * @brief Load workspace state from file
@@ -46,20 +27,8 @@ public:
    * @param path Path to workspace state file
    * @param state Workspace state
    */
-  void loadWorkspaceState(const std::filesystem::path &path,
-                          WorkspaceState &state);
-
-  /**
-   * @brief Get editor camera
-   *
-   * @return Editor camera
-   */
-  inline EditorCamera &getEditorCamera() { return mEditorCamera; }
-
-private:
-  EditorCamera &mEditorCamera;
-  std::filesystem::path mScenePath;
-  Project mProject;
+  static void loadWorkspaceState(const std::filesystem::path &path,
+                                 WorkspaceState &state);
 };
 
 } // namespace liquid::editor

--- a/editor/src/liquidator/state/WorkspaceState.h
+++ b/editor/src/liquidator/state/WorkspaceState.h
@@ -50,6 +50,15 @@ struct WorkspaceState {
   Entity camera{Entity::Null};
 
   /**
+   * Active camera
+   *
+   * This camera is passed to the renderer
+   * and can point to either workspace camera,
+   * scene's active camera, or any other camera.
+   */
+  Entity activeCamera{Entity::Null};
+
+  /**
    * Selected entity
    */
   Entity selectedEntity{Entity::Null};

--- a/editor/src/liquidator/ui/StatusBar.cpp
+++ b/editor/src/liquidator/ui/StatusBar.cpp
@@ -5,11 +5,11 @@
 
 namespace liquid::editor {
 
-void StatusBar::render(EditorManager &editorManager) {
+void StatusBar::render(EditorCamera &editorCamera) {
   const ImGuiViewport *viewport = ImGui::GetMainViewport();
 
   String state = "";
-  switch (editorManager.getEditorCamera().getInputState()) {
+  switch (editorCamera.getInputState()) {
   case EditorCamera::InputState::Pan:
     state = "Panning";
     break;
@@ -17,6 +17,7 @@ void StatusBar::render(EditorManager &editorManager) {
     state = "Rotating";
     break;
   case EditorCamera::InputState::Zoom:
+  case EditorCamera::InputState::ZoomWheel:
     state = "Zooming";
     break;
   default:

--- a/editor/src/liquidator/ui/StatusBar.h
+++ b/editor/src/liquidator/ui/StatusBar.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "liquidator/editor-scene/EditorManager.h"
+#include "liquidator/editor-scene/EditorCamera.h"
 
 namespace liquid::editor {
 
@@ -12,9 +12,9 @@ public:
   /**
    * @brief Render status bar
    *
-   * @param editorManager Editor manager
+   * @param editorCamera Editor camera
    */
-  static void render(EditorManager &editorManager);
+  static void render(EditorCamera &editorCamera);
 };
 
 } // namespace liquid::editor

--- a/editor/src/liquidator/ui/UIRoot.cpp
+++ b/editor/src/liquidator/ui/UIRoot.cpp
@@ -38,8 +38,7 @@ UIRoot::UIRoot(ActionExecutor &actionExecutor, AssetLoader &assetLoader)
                fa::ExpandAlt, ToolbarItemType::Toggleable);
 }
 
-void UIRoot::render(WorkspaceState &state, EditorManager &editorManager,
-                    AssetManager &assetManager) {
+void UIRoot::render(WorkspaceState &state, AssetManager &assetManager) {
   mMainMenu.render(mActionExecutor);
   mToolbar.render(state, mActionExecutor);
   mLayout.setup();

--- a/editor/src/liquidator/ui/UIRoot.h
+++ b/editor/src/liquidator/ui/UIRoot.h
@@ -44,11 +44,9 @@ public:
    * Renders all components inside the root
    *
    * @param state Workspace state
-   * @param editorManager Editor manager
    * @param assetManager Asset manager
    */
-  void render(WorkspaceState &state, EditorManager &editorManager,
-              AssetManager &assetManager);
+  void render(WorkspaceState &state, AssetManager &assetManager);
 
   /**
    * @brief Render scene view

--- a/editor/tests/liquidator-tests/actions/SimulationModeActions.test.cpp
+++ b/editor/tests/liquidator-tests/actions/SimulationModeActions.test.cpp
@@ -38,6 +38,7 @@ TEST_F(StartSimulationModeActionTest,
   EXPECT_EQ(state.simulationScene.environment, state.scene.environment);
   EXPECT_EQ(state.simulationScene.activeCamera, state.scene.activeCamera);
   EXPECT_EQ(state.simulationScene.dummyCamera, state.scene.dummyCamera);
+  EXPECT_EQ(state.activeCamera, state.scene.activeCamera);
   EXPECT_TRUE(state.simulationScene.entityDatabase.exists(entity));
 }
 
@@ -63,6 +64,7 @@ TEST_F(StartSimulationModeActionTest,
   EXPECT_EQ(state.simulationScene.environment, state.scene.environment);
   EXPECT_EQ(state.simulationScene.activeCamera, state.scene.dummyCamera);
   EXPECT_EQ(state.simulationScene.dummyCamera, state.scene.dummyCamera);
+  EXPECT_EQ(state.activeCamera, state.scene.dummyCamera);
   EXPECT_TRUE(state.simulationScene.entityDatabase.exists(entity));
 }
 
@@ -86,10 +88,12 @@ using StopSimulationModeActionTest = ActionTestBase;
 
 TEST_F(StopSimulationModeActionTest, ExecutorSetsWorkspaceModeToSimulation) {
   state.mode = WM::Simulation;
+  state.camera = state.scene.entityDatabase.create();
 
   liquid::editor::StopSimulationMode action;
   action.onExecute(state);
   EXPECT_EQ(state.mode, WM::Edit);
+  EXPECT_EQ(state.activeCamera, state.camera);
 }
 
 TEST_F(StopSimulationModeActionTest,


### PR DESCRIPTION
- Only keep local, window specific state from editor camera
- Add active camera to workspace state
- Change active camera based when triggering simulation mode actions
- Remove editor camera from editor manager
- Remove editor manager from all components