### PR TITLE
Remove engine log container from editor

### DIFF
--- a/editor/src/liquidator/ui/AssetBrowser.cpp
+++ b/editor/src/liquidator/ui/AssetBrowser.cpp
@@ -1,4 +1,5 @@
 #include "liquid/core/Base.h"
+#include "liquid/core/Engine.h"
 #include "liquid/imgui/ImguiUtils.h"
 #include "AssetBrowser.h"
 
@@ -321,6 +322,8 @@ void AssetBrowser::handleAssetImport() {
     mStatusDialog.setMessages({res.getError()});
     mStatusDialog.show();
 
+    Engine::getUserLogger().error() << res.getError();
+
     return;
   }
 
@@ -328,6 +331,10 @@ void AssetBrowser::handleAssetImport() {
     mStatusDialog.setTitle("Import successful with warnings");
     mStatusDialog.setMessages(res.getWarnings());
     mStatusDialog.show();
+
+    for (const auto &warning : res.getWarnings()) {
+      Engine::getUserLogger().warning() << warning;
+    }
   }
 
   reload();

--- a/editor/src/liquidator/ui/LogViewer.cpp
+++ b/editor/src/liquidator/ui/LogViewer.cpp
@@ -6,16 +6,11 @@
 
 namespace liquid::editor {
 
-void LogViewer::render(LogMemoryStorage &systemLogs,
-                       LogMemoryStorage &userLogs) {
+void LogViewer::render(LogMemoryStorage &userLogs) {
   auto flags = ImGuiWindowFlags_HorizontalScrollbar |
                ImGuiWindowFlags_AlwaysUseWindowPadding;
 
   if (auto _ = widgets::Window("Logs")) {
-    const float FirstHalf = ImGui::GetContentRegionAvail().x / 2.0f;
-
-    renderLogContainer("System Logs", systemLogs, mSystemLogSize, FirstHalf);
-    ImGui::SameLine();
     renderLogContainer("User logs", userLogs, mUserLogSize,
                        ImGui::GetContentRegionAvail().x);
   }

--- a/editor/src/liquidator/ui/LogViewer.h
+++ b/editor/src/liquidator/ui/LogViewer.h
@@ -12,10 +12,9 @@ public:
   /**
    * @brief Render log viewer
    *
-   * @param systemLogs System logs
    * @param userLogs User logs
    */
-  void render(LogMemoryStorage &systemLogs, LogMemoryStorage &userLogs);
+  void render(LogMemoryStorage &userLogs);
 
 private:
   /**
@@ -30,7 +29,6 @@ private:
                           size_t &logSize, float width);
 
 private:
-  size_t mSystemLogSize = 0;
   size_t mUserLogSize = 0;
 };
 

--- a/engine/src/liquid/scripting/LuaHeaders.h
+++ b/engine/src/liquid/scripting/LuaHeaders.h
@@ -1,0 +1,9 @@
+#pragma once
+
+#include "liquid/core/Engine.h"
+
+extern "C" {
+#include <lua.h>
+#include <lualib.h>
+#include <lauxlib.h>
+}

--- a/engine/src/liquid/scripting/LuaInterpreter.cpp
+++ b/engine/src/liquid/scripting/LuaInterpreter.cpp
@@ -1,14 +1,9 @@
 #include "liquid/core/Base.h"
 #include "liquid/core/Engine.h"
 
+#include "LuaHeaders.h"
 #include "LuaInterpreter.h"
 #include "LuaScope.h"
-
-extern "C" {
-#include <lua.h>
-#include <lualib.h>
-#include <lauxlib.h>
-}
 
 namespace liquid {
 

--- a/engine/src/liquid/scripting/LuaScope.cpp
+++ b/engine/src/liquid/scripting/LuaScope.cpp
@@ -1,12 +1,7 @@
 #include "liquid/core/Base.h"
 #include "liquid/core/Engine.h"
+#include "LuaHeaders.h"
 #include "LuaScope.h"
-
-extern "C" {
-#include <lua.h>
-#include <lualib.h>
-#include <lauxlib.h>
-}
 
 namespace liquid {
 

--- a/engine/src/liquid/scripting/LuaTable.cpp
+++ b/engine/src/liquid/scripting/LuaTable.cpp
@@ -1,11 +1,6 @@
 #include "liquid/core/Base.h"
+#include "LuaHeaders.h"
 #include "LuaTable.h"
-
-extern "C" {
-#include <lua.h>
-#include <lualib.h>
-#include <lauxlib.h>
-}
 
 namespace liquid {
 

--- a/engine/tests/liquid-tests/scripting/LuaInterpreter.test.cpp
+++ b/engine/tests/liquid-tests/scripting/LuaInterpreter.test.cpp
@@ -1,12 +1,8 @@
 #include "liquid/core/Base.h"
+#include "liquid/scripting/LuaHeaders.h"
 #include "liquid/scripting/LuaInterpreter.h"
 
 #include "liquid-tests/Testing.h"
-
-extern "C" {
-#include <lua.h>
-#include <lauxlib.h>
-}
 
 inline std::vector<uint8_t> readFileIntoBuffer(const liquid::Path &fileName) {
   std::ifstream file(fileName);


### PR DESCRIPTION
- Remove engine log container and transport
- Only show user logger in editor
- Encapsulate lua headers in a single file
- Show asset errors and warnings in user log