### PR TITLE
Process actions at the beginning of frame

### DIFF
--- a/editor/src/liquidator/actions/ActionCreator.h
+++ b/editor/src/liquidator/actions/ActionCreator.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include "liquidator/actions/Action.h"
+
+namespace liquid::editor {
+
+/**
+ * @brief Action creator
+ */
+class ActionCreator {
+public:
+  /**
+   * @brief Create action
+   *
+   * @return Action
+   */
+  virtual std::unique_ptr<Action> create() = 0;
+};
+
+} // namespace liquid::editor

--- a/editor/src/liquidator/actions/ActionExecutor.cpp
+++ b/editor/src/liquidator/actions/ActionExecutor.cpp
@@ -7,7 +7,13 @@ ActionExecutor::ActionExecutor(WorkspaceState &state, Path scenePath)
     : mState(state), mScenePath(scenePath),
       mSceneIO(state.assetRegistry, state.scene) {}
 
-void ActionExecutor::execute(const std::unique_ptr<Action> &action) {
+void ActionExecutor::process() {
+  if (!mActionToProcess) {
+    return;
+  }
+
+  auto action = std::move(mActionToProcess);
+
   if (!action->predicate(mState)) {
     return;
   }
@@ -34,6 +40,10 @@ void ActionExecutor::execute(const std::unique_ptr<Action> &action) {
     mSceneIO.saveStartingCamera(mScenePath);
     mSceneIO.saveEnvironment(mScenePath);
   }
+}
+
+void ActionExecutor::execute(std::unique_ptr<Action> action) {
+  mActionToProcess = std::move(action);
 }
 
 } // namespace liquid::editor

--- a/editor/src/liquidator/actions/ActionExecutor.h
+++ b/editor/src/liquidator/actions/ActionExecutor.h
@@ -19,11 +19,27 @@ public:
   ActionExecutor(WorkspaceState &state, Path scenePath);
 
   /**
+   * @brief Process actions
+   */
+  void process();
+
+  /**
    * @brief Execute action
    *
    * @param action Action
    */
-  void execute(const std::unique_ptr<Action> &action);
+  void execute(std::unique_ptr<Action> action);
+
+  /**
+   * @brief Execute action
+   *
+   * @tparam TAction Action type
+   * @tparam ...TArgs Action type arguments
+   * @param ...args Action arguments
+   */
+  template <typename TAction, typename... TArgs> void execute(TArgs &&...args) {
+    execute(std::make_unique<TAction>(std::forward<TArgs>(args)...));
+  }
 
   /**
    * @brief Get scene IO
@@ -36,6 +52,8 @@ private:
   WorkspaceState &mState;
   SceneIO mSceneIO;
   Path mScenePath;
+
+  std::unique_ptr<Action> mActionToProcess;
 };
 
 } // namespace liquid::editor

--- a/editor/src/liquidator/actions/TypedActionCreator.h
+++ b/editor/src/liquidator/actions/TypedActionCreator.h
@@ -1,0 +1,63 @@
+#pragma once
+
+#include "ActionCreator.h"
+
+namespace liquid::editor {
+
+/**
+ * @brief Typed action creator implementation
+ *
+ * @tparam TAction Action type
+ * @tparam ...TArgs Action parameters type
+ */
+template <class TAction, class... TArgs>
+class TypedActionCreatorImpl : public ActionCreator {
+public:
+  /**
+   * @brief Create action creator
+   *
+   * @param ...args Action parameters
+   */
+  TypedActionCreatorImpl(TArgs &&...args) : mArgs(args...) {}
+
+  /**
+   * @brief Create action
+   *
+   * @return Action
+   */
+  std::unique_ptr<Action> create() override {
+    auto args = mArgs;
+
+    // Pass tuple as action constructor arguments
+    TAction *action = std::apply(
+        [](auto... args) { return new TAction(std::forward<TArgs>(args)...); },
+        args);
+
+    return std::unique_ptr<Action>(action);
+  }
+
+private:
+  std::tuple<TArgs...> mArgs;
+};
+
+/**
+ * @brief Typed action creator
+ */
+class TypedActionCreator {
+public:
+  /**
+   * @brief Create typed action creator
+   *
+   * @tparam TAction Action type
+   * @tparam ...TArgs Action parameters type
+   * @param ...args Action parameters
+   * @return Typed action creator
+   */
+  template <class TAction, class... TArgs>
+  static TypedActionCreatorImpl<TAction, TArgs...> *create(TArgs &&...args) {
+    return new TypedActionCreatorImpl<TAction, TArgs...>(
+        std::forward<TArgs>(args)...);
+  }
+};
+
+} // namespace liquid::editor

--- a/editor/src/liquidator/screens/EditorScreen.cpp
+++ b/editor/src/liquidator/screens/EditorScreen.cpp
@@ -181,11 +181,13 @@ void EditorScreen::start(const Project &project) {
 
   mWindow.maximize();
 
-  mainLoop.setUpdateFn([&state, &simulator, this](float dt) mutable {
-    mEventSystem.poll();
-    simulator.update(dt, state);
-    return true;
-  });
+  mainLoop.setUpdateFn(
+      [&state, &actionExecutor, &simulator, this](float dt) mutable {
+        actionExecutor.process();
+        mEventSystem.poll();
+        simulator.update(dt, state);
+        return true;
+      });
 
   LogViewer logViewer;
   mainLoop.setRenderFn([&renderer, &editorCamera, &assetManager, &graph,

--- a/editor/src/liquidator/ui/AssetBrowser.cpp
+++ b/editor/src/liquidator/ui/AssetBrowser.cpp
@@ -239,8 +239,8 @@ void AssetBrowser::render(AssetManager &assetManager,
               mCurrentDirectory = entry.path;
               mDirectoryChanged = true;
             } else if (entry.assetType == AssetType::Prefab) {
-              actionExecutor.execute(std::make_unique<SpawnPrefabAtView>(
-                  static_cast<PrefabAssetHandle>(entry.asset), state.camera));
+              actionExecutor.execute<SpawnPrefabAtView>(
+                  static_cast<PrefabAssetHandle>(entry.asset), state.camera);
             } else if (entry.assetType == AssetType::Material) {
               mMaterialViewer.open(
                   static_cast<MaterialAssetHandle>(entry.asset));

--- a/editor/src/liquidator/ui/EditorGridPanel.cpp
+++ b/editor/src/liquidator/ui/EditorGridPanel.cpp
@@ -25,14 +25,14 @@ void EditorGridPanel::render(WorkspaceState &state,
     {
       bool enabled = SetGridLines::isShown(state);
       if (ImGui::Checkbox("Show grid lines", &enabled)) {
-        actionExecutor.execute(std::make_unique<SetGridLines>(enabled));
+        actionExecutor.execute<SetGridLines>(enabled);
       }
     }
 
     {
       bool enabled = SetGridAxisLines::isShown(state);
       if (ImGui::Checkbox("Show axis lines", &enabled)) {
-        actionExecutor.execute(std::make_unique<SetGridAxisLines>(enabled));
+        actionExecutor.execute<SetGridAxisLines>(enabled);
       }
     }
   }

--- a/editor/src/liquidator/ui/EntityPanel.h
+++ b/editor/src/liquidator/ui/EntityPanel.h
@@ -194,9 +194,8 @@ private:
   Entity mSelectedEntity = Entity::Null;
   bool mIsNameActivated = false;
 
-  Name mName;
-
 private:
+  std::optional<Name> mName;
   std::optional<RigidBody> mRigidBody;
   std::optional<LocalTransform> mLocalTransform;
   std::optional<Text> mText;

--- a/editor/src/liquidator/ui/EnvironmentPanel.cpp
+++ b/editor/src/liquidator/ui/EnvironmentPanel.cpp
@@ -42,7 +42,7 @@ static void dndEnvironmentAsset(widgets::Section &section,
     if (auto *payload = ImGui::AcceptDragDropPayload(
             getAssetTypeString(AssetType::Environment).c_str())) {
       auto asset = *static_cast<EnvironmentAssetHandle *>(payload->Data);
-      actionExecutor.execute(std::make_unique<SceneSetSkyboxTexture>(asset));
+      actionExecutor.execute<SceneSetSkyboxTexture>(asset);
     }
   }
 }
@@ -70,13 +70,13 @@ void EnvironmentPanel::renderSkyboxSection(Scene &scene,
     ImGui::Text("Type");
     if (ImGui::BeginCombo("###SkyboxType", getSkyboxTypeLabel(scene).c_str())) {
       if (ImGui::Selectable("None")) {
-        actionExecutor.execute(std::make_unique<SceneRemoveSkybox>());
+        actionExecutor.execute<SceneRemoveSkybox>();
       } else if (ImGui::Selectable("Color")) {
-        actionExecutor.execute(std::make_unique<SceneSetSkyboxColor>(
-            glm::vec4{0.0f, 0.0f, 0.0f, 1.0f}));
+        actionExecutor.execute<SceneSetSkyboxColor>(
+            glm::vec4{0.0f, 0.0f, 0.0f, 1.0f});
       } else if (ImGui::Selectable("Texture")) {
-        actionExecutor.execute(std::make_unique<SceneSetSkyboxTexture>(
-            EnvironmentAssetHandle::Invalid));
+        actionExecutor.execute<SceneSetSkyboxTexture>(
+            EnvironmentAssetHandle::Invalid);
       }
 
       ImGui::EndCombo();
@@ -96,7 +96,7 @@ void EnvironmentPanel::renderSkyboxSection(Scene &scene,
       widgets::InputColor("Color", color);
 
       if (ImGui::IsItemDeactivatedAfterEdit()) {
-        actionExecutor.execute(std::make_unique<SceneSetSkyboxColor>(color));
+        actionExecutor.execute<SceneSetSkyboxColor>(color);
       }
     } else if (skybox.type == EnvironmentSkyboxType::Texture) {
       if (environments.hasAsset(skybox.texture)) {
@@ -108,8 +108,8 @@ void EnvironmentPanel::renderSkyboxSection(Scene &scene,
         dndEnvironmentAsset(section, actionExecutor);
 
         if (ImGui::Button(fa::Times)) {
-          actionExecutor.execute(std::make_unique<SceneSetSkyboxTexture>(
-              EnvironmentAssetHandle::Invalid));
+          actionExecutor.execute<SceneSetSkyboxTexture>(
+              EnvironmentAssetHandle::Invalid);
         }
 
       } else {
@@ -136,12 +136,11 @@ void EnvironmentPanel::renderLightingSection(Scene &scene,
     ImGui::Text("Source");
     if (ImGui::BeginCombo("###LightingSource", sourceName.c_str())) {
       if (ImGui::Selectable("None")) {
-        actionExecutor.execute(std::make_unique<SceneRemoveLighting>());
+        actionExecutor.execute<SceneRemoveLighting>();
       }
 
       if (ImGui::Selectable("Use skybox")) {
-        actionExecutor.execute(
-            std::make_unique<SceneSetSkyboxLightingSource>());
+        actionExecutor.execute<SceneSetSkyboxLightingSource>();
       }
 
       ImGui::EndCombo();

--- a/editor/src/liquidator/ui/MainMenu.cpp
+++ b/editor/src/liquidator/ui/MainMenu.cpp
@@ -5,9 +5,10 @@
 
 namespace liquid::editor {
 
-MainMenuItem::MainMenuItem(MainMenuItem *parent, String label, Action *action,
-                           Shortcut shortcut)
-    : mParent(parent), mLabel(label), mAction(action), mShortcut(shortcut) {}
+MainMenuItem::MainMenuItem(MainMenuItem *parent, String label,
+                           ActionCreator *actionCreator, Shortcut shortcut)
+    : mParent(parent), mLabel(label), mActionCreator(actionCreator),
+      mShortcut(shortcut) {}
 
 MainMenuItem &MainMenuItem::begin(String label) {
   mChildren.push_back({this, label, {}, Shortcut{}});
@@ -17,19 +18,18 @@ MainMenuItem &MainMenuItem::begin(String label) {
 
 MainMenuItem &MainMenuItem::end() { return mParent ? *mParent : *this; }
 
-MainMenuItem &MainMenuItem::add(String label, Action *action,
+MainMenuItem &MainMenuItem::add(String label, ActionCreator *actionCreator,
                                 Shortcut shortcut) {
-  mChildren.push_back({this, label, action, shortcut});
+  mChildren.push_back({this, label, actionCreator, shortcut});
 
   return *this;
 }
 
 void MainMenuItem::render(ActionExecutor &actionExecutor) const {
   if (mChildren.empty()) {
-
     if (ImGui::MenuItem(mLabel.c_str(),
                         mShortcut ? mShortcut.toString().c_str() : nullptr)) {
-      actionExecutor.execute(mAction);
+      actionExecutor.execute(mActionCreator->create());
     }
     return;
   }

--- a/editor/src/liquidator/ui/MainMenu.h
+++ b/editor/src/liquidator/ui/MainMenu.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "liquidator/actions/ActionExecutor.h"
+#include "liquidator/actions/ActionCreator.h"
 #include "Shortcut.h"
 
 namespace liquid::editor {
@@ -18,10 +19,10 @@ public:
    *
    * @param parent Parent menu item
    * @param label Menu item label
-   * @param action Menu item action
+   * @param actionCreator Menu item action creator
    * @param shortcut Shortcut
    */
-  MainMenuItem(MainMenuItem *parent, String label, Action *action,
+  MainMenuItem(MainMenuItem *parent, String label, ActionCreator *actionCreator,
                Shortcut shortcut);
 
   /**
@@ -43,11 +44,12 @@ public:
    * @brief Add actionable menu item
    *
    * @param label Menu item label
-   * @param action Menu item action
+   * @param actionCreator Menu item action creator
    * @param shortcut Shortcut
    * @return This menu item
    */
-  MainMenuItem &add(String label, Action *action, Shortcut shortcut = {});
+  MainMenuItem &add(String label, ActionCreator *actionCreator,
+                    Shortcut shortcut = {});
 
   /**
    * @brief Get children
@@ -66,7 +68,7 @@ public:
   void render(ActionExecutor &actionExecutor) const;
 
 private:
-  std::unique_ptr<Action> mAction;
+  std::unique_ptr<ActionCreator> mActionCreator;
   String mLabel;
   Shortcut mShortcut;
   std::vector<MainMenuItem> mChildren;

--- a/editor/src/liquidator/ui/SceneHierarchyPanel.cpp
+++ b/editor/src/liquidator/ui/SceneHierarchyPanel.cpp
@@ -138,7 +138,7 @@ void SceneHierarchyPanel::renderEntity(Entity entity, int flags,
                              ImGui::GetStyle().ItemSpacing.x));
 
       if (ImGui::MenuItem("Go to view")) {
-        actionExecutor.execute(std::make_unique<MoveCameraToEntity>(entity));
+        actionExecutor.execute<MoveCameraToEntity>(entity);
       }
 
       if (ImGui::MenuItem("Delete")) {
@@ -147,7 +147,7 @@ void SceneHierarchyPanel::renderEntity(Entity entity, int flags,
     }
     confirmDeleteSceneNode.render();
     if (confirmDeleteSceneNode.isConfirmed()) {
-      actionExecutor.execute(std::make_unique<DeleteEntity>(entity));
+      actionExecutor.execute<DeleteEntity>(entity);
     }
   }
 

--- a/editor/src/liquidator/ui/ShortcutsManager.cpp
+++ b/editor/src/liquidator/ui/ShortcutsManager.cpp
@@ -3,9 +3,9 @@
 
 namespace liquid::editor {
 
-void ShortcutsManager::add(Shortcut shortcut, Action *action) {
+void ShortcutsManager::add(Shortcut shortcut, ActionCreator *actionCreator) {
   mShortcuts.push_back(shortcut);
-  mActions.push_back(std::unique_ptr<Action>(action));
+  mActionCreators.push_back(std::unique_ptr<ActionCreator>(actionCreator));
 }
 
 void ShortcutsManager::process(int key, int mods,
@@ -14,7 +14,7 @@ void ShortcutsManager::process(int key, int mods,
     const auto &shortcut = mShortcuts.at(i);
 
     if (shortcut == Shortcut(key, mods)) {
-      actionExecutor.execute(mActions.at(i));
+      actionExecutor.execute(mActionCreators.at(i)->create());
       return;
     }
   }

--- a/editor/src/liquidator/ui/ShortcutsManager.h
+++ b/editor/src/liquidator/ui/ShortcutsManager.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "liquidator/actions/Action.h"
+#include "liquidator/actions/ActionCreator.h"
 #include "liquidator/actions/ActionExecutor.h"
 #include "Shortcut.h"
 
@@ -15,9 +15,9 @@ public:
    * @brief Add shortcut
    *
    * @param shortcut Shortcut
-   * @param action Action
+   * @param actionCreator Action creator
    */
-  void add(Shortcut shortcut, Action *action);
+  void add(Shortcut shortcut, ActionCreator *actionCreator);
 
   /**
    * @brief Process input
@@ -30,7 +30,7 @@ public:
 
 private:
   std::vector<Shortcut> mShortcuts;
-  std::vector<std::unique_ptr<Action>> mActions;
+  std::vector<std::unique_ptr<ActionCreator>> mActionCreators;
 };
 
 } // namespace liquid::editor

--- a/editor/src/liquidator/ui/Toolbar.cpp
+++ b/editor/src/liquidator/ui/Toolbar.cpp
@@ -16,7 +16,7 @@ void Toolbar::render(WorkspaceState &state, ActionExecutor &actionExecutor) {
                        ImGuiWindowFlags_NoSavedSettings |
                        ImGuiWindowFlags_NoDocking)) {
 
-    for (const auto &item : mItems) {
+    for (auto &item : mItems) {
       if (item.type == ToolbarItemType::HideWhenInactive &&
           !item.action->predicate(state)) {
         continue;
@@ -34,7 +34,9 @@ void Toolbar::render(WorkspaceState &state, ActionExecutor &actionExecutor) {
       }
 
       if (ImGui::Button(item.icon.c_str())) {
-        actionExecutor.execute(item.action);
+        actionExecutor.execute(std::move(item.action));
+
+        item.action = item.actionCreator->create();
       }
 
       ImGui::SameLine();
@@ -45,10 +47,11 @@ void Toolbar::render(WorkspaceState &state, ActionExecutor &actionExecutor) {
   ImGui::PopStyleVar();
 }
 
-void Toolbar::add(Action *action, String label, String icon,
+void Toolbar::add(ActionCreator *actionCreator, String label, String icon,
                   ToolbarItemType type) {
-  mItems.push_back(
-      {std::move(std::unique_ptr<Action>(action)), label, icon, type});
+  auto ptr = actionCreator->create();
+  mItems.push_back({std::unique_ptr<ActionCreator>(actionCreator),
+                    std::move(ptr), label, icon, type});
 }
 
 } // namespace liquid::editor

--- a/editor/src/liquidator/ui/Toolbar.h
+++ b/editor/src/liquidator/ui/Toolbar.h
@@ -2,6 +2,7 @@
 
 #include "liquidator/state/WorkspaceState.h"
 #include "liquidator/actions/ActionExecutor.h"
+#include "liquidator/actions/ActionCreator.h"
 
 namespace liquid::editor {
 
@@ -16,6 +17,7 @@ enum class ToolbarItemType { Toggleable, HideWhenInactive };
 class Toolbar {
 private:
   struct ToolbarItem {
+    std::unique_ptr<ActionCreator> actionCreator;
     std::unique_ptr<Action> action;
     String label;
     String icon;
@@ -38,14 +40,15 @@ public:
   void render(WorkspaceState &state, ActionExecutor &actionExecutor);
 
   /**
-   * @brief Add action
+   * @brief Add toolbar item
    *
-   * @param action Action
+   * @param actionCreator Action creator
    * @param label Button label
    * @param icon Button icon
    * @param type Item type
    */
-  void add(Action *action, String label, String icon, ToolbarItemType type);
+  void add(ActionCreator *actionCreator, String label, String icon,
+           ToolbarItemType type);
 
 private:
   std::vector<ToolbarItem> mItems;

--- a/editor/src/liquidator/ui/UIRoot.cpp
+++ b/editor/src/liquidator/ui/UIRoot.cpp
@@ -6,6 +6,7 @@
 #include "liquidator/actions/SpawnEntityActions.h"
 #include "liquidator/actions/ProjectActions.h"
 #include "liquidator/actions/DeleteEntityAction.h"
+#include "liquidator/actions/TypedActionCreator.h"
 
 #include "UIRoot.h"
 #include "ImGuizmo.h"
@@ -16,26 +17,30 @@ UIRoot::UIRoot(ActionExecutor &actionExecutor, AssetLoader &assetLoader)
     : mActionExecutor(actionExecutor), mAssetBrowser(assetLoader) {
 
   mShortcutsManager.add(Shortcut().control().key('N'),
-                        new SpawnEmptyEntityAtView);
+                        TypedActionCreator::create<SpawnEmptyEntityAtView>());
 
   mMainMenu.begin("Project")
-      .add("Export as game", new ExportAsGame)
+      .add("Export as game", TypedActionCreator::create<ExportAsGame>())
       .end()
       .begin("Objects")
-      .add("Create empty object", new SpawnEmptyEntityAtView,
+      .add("Create empty object",
+           TypedActionCreator::create<SpawnEmptyEntityAtView>(),
            Shortcut().control().key('N'))
       .end();
 
-  mToolbar.add(new StartSimulationMode, "Play", fa::Play,
-               ToolbarItemType::HideWhenInactive);
-  mToolbar.add(new StopSimulationMode, "Stop", fa::Stop,
-               ToolbarItemType::HideWhenInactive);
-  mToolbar.add(new SetActiveTransform(TransformOperation::Move), "Move",
-               fa::Arrows, ToolbarItemType::Toggleable);
-  mToolbar.add(new SetActiveTransform(TransformOperation::Rotate), "Rotate",
-               fa::Rotate, ToolbarItemType::Toggleable);
-  mToolbar.add(new SetActiveTransform(TransformOperation::Scale), "Scale",
-               fa::ExpandAlt, ToolbarItemType::Toggleable);
+  mToolbar.add(TypedActionCreator::create<StartSimulationMode>(), "Play",
+               fa::Play, ToolbarItemType::HideWhenInactive);
+  mToolbar.add(TypedActionCreator::create<StopSimulationMode>(), "Stop",
+               fa::Stop, ToolbarItemType::HideWhenInactive);
+  mToolbar.add(
+      TypedActionCreator::create<SetActiveTransform>(TransformOperation::Move),
+      "Move", fa::Arrows, ToolbarItemType::Toggleable);
+  mToolbar.add(TypedActionCreator ::create<SetActiveTransform>(
+                   TransformOperation::Rotate),
+               "Rotate", fa::Rotate, ToolbarItemType::Toggleable);
+  mToolbar.add(
+      TypedActionCreator::create<SetActiveTransform>(TransformOperation::Scale),
+      "Scale", fa::ExpandAlt, ToolbarItemType::Toggleable);
 }
 
 void UIRoot::render(WorkspaceState &state, AssetManager &assetManager) {

--- a/editor/src/liquidator/ui/UIRoot.h
+++ b/editor/src/liquidator/ui/UIRoot.h
@@ -91,7 +91,7 @@ public:
   void processShortcuts(EventSystem &eventSystem);
 
 private:
-  ActionExecutor mActionExecutor;
+  ActionExecutor &mActionExecutor;
   SceneHierarchyPanel mSceneHierarchyPanel;
   EntityPanel mEntityPanel;
   EnvironmentPanel mEnvironmentPanel;


### PR DESCRIPTION
- Add action creator
- Use action creator in main menu, shortcuts, and toolbar
- Store currently added action in action executor
- Execute the action at the beginning of next frame
- Add new function to record action in a simpler way
- Fix name component update in entity panel