### PR TITLE
Use buffer device address to access buffers

### DIFF
--- a/editor/assets/shaders/bindless-editor.glsl
+++ b/editor/assets/shaders/bindless-editor.glsl
@@ -1,3 +1,4 @@
 #include "../../../engine/assets/shaders/bindless/base.glsl"
 #include "../../../engine/assets/shaders/bindless/transform.glsl"
 #include "../../../engine/assets/shaders/bindless/camera.glsl"
+#include "../../../engine/assets/shaders/bindless/mesh.glsl"

--- a/editor/assets/shaders/collidable-shape.vert
+++ b/editor/assets/shaders/collidable-shape.vert
@@ -4,25 +4,25 @@ layout(location = 0) in vec3 inPosition;
 
 #include "bindless-editor.glsl"
 
-RegisterUniform(CollidableParamsUniform, {
+Buffer(64) CollidableParams {
   mat4 worldTransform;
   uvec4 type;
   vec4 params;
-});
-#define GetCollidableParams()                                                  \
-  GetBindlessResource(CollidableParamsUniform, uDrawParams.collidableParams)
+};
 
-layout(set = 1, binding = 0) uniform DrawParameters {
-  uint gizmoTransforms;
-  uint skeletonTransforms;
-  uint debugSkeletons;
-  uint collidableParams;
-  uint camera;
-  uint gridData;
-  uint pad0;
-  uint pad1;
+layout(set = 0, binding = 0) uniform DrawParameters {
+  Empty gizmoTransforms;
+  Empty skeletonTransforms;
+  Empty debugSkeletons;
+  CollidableParams collidableParams;
+  Camera camera;
+  Empty gridData;
+  Empty pad0;
+  Empty pad1;
 }
 uDrawParams;
+
+#define GetCollidableParams() uDrawParams.collidableParams
 
 void main() {
   vec3 finalPosition = inPosition;

--- a/editor/assets/shaders/editor-grid.frag
+++ b/editor/assets/shaders/editor-grid.frag
@@ -9,18 +9,19 @@ layout(location = 0) out vec4 outColor;
 
 #include "bindless-editor.glsl"
 
-RegisterUniform(GridData, { uvec4 gridLines; });
-#define getGridData() GetBindlessResource(GridData, uDrawParams.gridData)
+Buffer(16) GridData { uvec4 gridLines; };
 
-layout(set = 1, binding = 0) uniform DrawParameters {
-  uint gizmoTransforms;
-  uint skeletonTransforms;
-  uint debugSkeletons;
-  uint collidableParams;
-  uint camera;
-  uint gridData;
-  uint pad0;
-  uint pad1;
+#define getGridData() uDrawParams.gridData
+
+layout(set = 0, binding = 0) uniform DrawParameters {
+  Empty gizmoTransforms;
+  Empty skeletonTransforms;
+  Empty debugSkeletons;
+  Empty collidableParams;
+  Empty camera;
+  GridData gridData;
+  Empty pad0;
+  Empty pad1;
 }
 uDrawParams;
 

--- a/editor/assets/shaders/editor-grid.vert
+++ b/editor/assets/shaders/editor-grid.vert
@@ -7,13 +7,13 @@ layout(location = 2) out mat4 outViewProj;
 
 #include "bindless-editor.glsl"
 
-layout(set = 1, binding = 0) uniform DrawParameters {
-  uint gizmoTransforms;
-  uint skeletonTransforms;
-  uint debugSkeletons;
-  uint collidbaleParams;
-  uint camera;
-  uint gridData;
+layout(set = 0, binding = 0) uniform DrawParameters {
+  Empty gizmoTransforms;
+  Empty skeletonTransforms;
+  Empty debugSkeletons;
+  Empty collidableParams;
+  Camera camera;
+  Empty gridData;
 }
 uDrawParams;
 

--- a/editor/assets/shaders/mouse-picking-skinned.vert
+++ b/editor/assets/shaders/mouse-picking-skinned.vert
@@ -7,21 +7,19 @@ layout(location = 7) in vec4 inWeights;
 
 layout(location = 0) out uint outEntity;
 
-#include "../../../engine/assets/shaders/bindless/base.glsl"
-#include "../../../engine/assets/shaders/bindless/mesh.glsl"
-#include "../../../engine/assets/shaders/bindless/camera.glsl"
+#include "bindless-editor.glsl"
 
-RegisterBuffer(scalar, readonly, EntityData, { uint entities[]; });
+Buffer(16) EntityData { uint entities[]; };
 
-layout(set = 1, binding = 0) uniform DrawParams {
-  uint meshTransforms;
-  uint skinnedMeshTransforms;
-  uint skeletons;
-  uint camera;
-  uint entities;
-  uint selectedEntity;
-  uint pad0;
-  uint pad1;
+layout(set = 0, binding = 0) uniform DrawParams {
+  TransformsArray meshTransforms;
+  TransformsArray skinnedMeshTransforms;
+  SkeletonsArray skeletons;
+  Camera camera;
+  EntityData entities;
+  Empty selectedEntity;
+  Empty pad0;
+  Empty pad1;
 }
 uDrawParams;
 
@@ -39,6 +37,5 @@ void main() {
       getCamera().viewProj * modelMatrix * skinMatrix * vec4(inPosition, 1.0f);
 
   gl_Position = worldPosition;
-  outEntity = GetBindlessResource(EntityData, uDrawParams.entities)
-                  .entities[gl_InstanceIndex];
+  outEntity = uDrawParams.entities.entities[gl_InstanceIndex];
 }

--- a/editor/assets/shaders/mouse-picking.frag
+++ b/editor/assets/shaders/mouse-picking.frag
@@ -3,23 +3,20 @@
 
 layout(location = 0) in flat uint outEntity;
 
-layout(set = 1, binding = 0) uniform DrawParams {
-  uint meshTransforms;
-  uint skinnedMeshTransforms;
-  uint skeletons;
-  uint camera;
-  uint entities;
-  uint selectedEntity;
-  uint pad0;
-  uint pad1;
+#include "bindless-editor.glsl"
+
+Buffer(16) SelectedEntity { uint selectedEntity; };
+
+layout(set = 0, binding = 0) uniform DrawParams {
+  Empty meshTransforms;
+  Empty skinnedMeshTransforms;
+  Empty skeletons;
+  Empty camera;
+  Empty entities;
+  SelectedEntity selectedEntity;
+  Empty pad0;
+  Empty pad1;
 }
 uDrawParams;
 
-#include "../../../engine/assets/shaders/bindless/base.glsl"
-
-RegisterBuffer(scalar, writeonly, SelectedEntityData, { uint selectedEntity; });
-
-void main() {
-  GetBindlessResource(SelectedEntityData, uDrawParams.selectedEntity)
-      .selectedEntity = outEntity;
-}
+void main() { uDrawParams.selectedEntity.selectedEntity = outEntity; }

--- a/editor/assets/shaders/mouse-picking.vert
+++ b/editor/assets/shaders/mouse-picking.vert
@@ -5,23 +5,21 @@ layout(location = 0) in vec3 inPosition;
 
 layout(location = 0) out uint outEntity;
 
-#include "../../../engine/assets/shaders/bindless/base.glsl"
-#include "../../../engine/assets/shaders/bindless/mesh.glsl"
-#include "../../../engine/assets/shaders/bindless/camera.glsl"
+#include "bindless-editor.glsl"
 
-layout(set = 1, binding = 0) uniform DrawParams {
-  uint meshTransforms;
-  uint skinnedMeshTransforms;
-  uint skeletons;
-  uint camera;
-  uint entities;
-  uint selectedEntity;
-  uint pad0;
-  uint pad1;
+Buffer(16) EntitiesArray { uint entities[]; };
+
+layout(set = 0, binding = 0) uniform DrawParams {
+  TransformsArray meshTransforms;
+  TransformsArray skinnedMeshTransforms;
+  SkeletonsArray skeletons;
+  Camera camera;
+  EntitiesArray entities;
+  Empty selectedEntity;
+  Empty pad0;
+  Empty pad1;
 }
 uDrawParams;
-
-RegisterBuffer(scalar, readonly, EntityData, { uint entities[]; });
 
 void main() {
   mat4 modelMatrix = getMeshTransform(gl_InstanceIndex).modelMatrix;
@@ -30,6 +28,5 @@ void main() {
       getCamera().viewProj * modelMatrix * vec4(inPosition, 1.0f);
 
   gl_Position = worldPosition;
-  outEntity = GetBindlessResource(EntityData, uDrawParams.entities)
-                  .entities[gl_InstanceIndex];
+  outEntity = uDrawParams.entities.entities[gl_InstanceIndex];
 }

--- a/editor/assets/shaders/object-icons.frag
+++ b/editor/assets/shaders/object-icons.frag
@@ -6,17 +6,17 @@ layout(location = 0) out vec4 outColor;
 
 #include "bindless-editor.glsl"
 
-layout(set = 1, binding = 0) uniform sampler2D uGlobalTextures[];
+layout(set = 0, binding = 0) uniform sampler2D uGlobalTextures[];
 
 layout(set = 1, binding = 0) uniform DrawParameters {
-  uint gizmoTransforms;
-  uint skeletonTransforms;
-  uint debugSkeletons;
-  uint collidableParams;
-  uint camera;
-  uint gridData;
-  uint pad0;
-  uint pad1;
+  Empty gizmoTransforms;
+  Empty skeletonTransforms;
+  Empty debugSkeletons;
+  Empty collidableParams;
+  Empty camera;
+  Empty gridData;
+  Empty pad0;
+  Empty pad1;
 }
 uDrawParams;
 

--- a/editor/assets/shaders/object-icons.vert
+++ b/editor/assets/shaders/object-icons.vert
@@ -4,20 +4,19 @@ layout(location = 0) out vec2 outTexCoord;
 
 #include "bindless-editor.glsl"
 
-#define getGizmoTransform(index)                                               \
-  GetBindlessResource(TransformData, uDrawParams.gizmoTransforms).items[index]
-
-layout(set = 2, binding = 0) uniform DrawParameters {
-  uint gizmoTransforms;
-  uint skeletonTransforms;
-  uint debugSkeletons;
-  uint collidbaleParams;
-  uint camera;
-  uint gridData;
-  uint pad0;
-  uint pad1;
+layout(set = 1, binding = 0) uniform DrawParameters {
+  TransformsArray gizmoTransforms;
+  Empty skeletonTransforms;
+  Empty debugSkeletons;
+  Empty collidbaleParams;
+  Camera camera;
+  Empty gridData;
+  Empty pad0;
+  Empty pad1;
 }
 uDrawParams;
+
+#define getGizmoTransform(index) uDrawParams.gizmoTransforms.items[index]
 
 const vec2 positions[4] =
     vec2[](vec2(-1, -1), vec2(+1, -1), vec2(-1, +1), vec2(+1, +1));

--- a/editor/assets/shaders/outline-geometry.vert
+++ b/editor/assets/shaders/outline-geometry.vert
@@ -6,20 +6,19 @@ layout(location = 7) in vec4 inWeights;
 
 #include "bindless-editor.glsl"
 
-#define getOutlineTransform(index)                                             \
-  GetBindlessResource(TransformData, uDrawParams.outlineTransforms).items[index]
-
-layout(set = 1, binding = 0) uniform DrawParameters {
-  uint gizmoTransforms;
-  uint skeletonTransforms;
-  uint debugSkeletons;
-  uint collidableParams;
-  uint camera;
-  uint gridData;
-  uint outlineTransforms;
-  uint outlineSkeletons;
+layout(set = 0, binding = 0) uniform DrawParameters {
+  Empty gizmoTransforms;
+  Empty skeletonTransforms;
+  Empty debugSkeletons;
+  Empty collidableParams;
+  Camera camera;
+  Empty gridData;
+  TransformsArray outlineTransforms;
+  Empty outlineSkeletons;
 }
 uDrawParams;
+
+#define getOutlineTransform(index) uDrawParams.outlineTransforms.items[index]
 
 /**
  * @brief Push constant for color

--- a/editor/assets/shaders/outline-skinned-geometry.vert
+++ b/editor/assets/shaders/outline-skinned-geometry.vert
@@ -5,25 +5,22 @@ layout(location = 6) in uvec4 inJoints;
 layout(location = 7) in vec4 inWeights;
 
 #include "bindless-editor.glsl"
-#include "../../../engine/assets/shaders/bindless/mesh.glsl"
 
-#define getOutlineTransform(index)                                             \
-  GetBindlessResource(TransformData, uDrawParams.outlineTransforms).items[index]
-
-#define getOutlineSkeleton(index)                                              \
-  GetBindlessResource(SkeletonData, uDrawParams.outlineSkeletons).items[index]
-
-layout(set = 1, binding = 0) uniform DrawParameters {
-  uint gizmoTransforms;
-  uint skeletonTransforms;
-  uint debugSkeletons;
-  uint collidableParams;
-  uint camera;
-  uint gridData;
-  uint outlineTransforms;
-  uint outlineSkeletons;
+layout(set = 0, binding = 0) uniform DrawParameters {
+  Empty gizmoTransforms;
+  Empty skeletonTransforms;
+  Empty debugSkeletons;
+  Empty collidableParams;
+  Camera camera;
+  Empty gridData;
+  TransformsArray outlineTransforms;
+  SkeletonsArray outlineSkeletons;
 }
 uDrawParams;
+
+#define getOutlineTransform(index) uDrawParams.outlineTransforms.items[index]
+
+#define getOutlineSkeleton(index) uDrawParams.outlineSkeletons.items[index]
 
 /**
  * @brief Push constant for color

--- a/editor/assets/shaders/skeleton-lines.vert
+++ b/editor/assets/shaders/skeleton-lines.vert
@@ -13,28 +13,23 @@ struct DebugSkeletonItem {
   mat4 bones[64];
 };
 
-RegisterBuffer(std430, readonly, DebugSkeletonData,
-               { DebugSkeletonItem items[]; });
+Buffer(64) DebugSkeletonsArray { DebugSkeletonItem items[]; };
 
-#define GetDebugSkeleton(index)                                                \
-  GetBindlessResource(DebugSkeletonData, uDrawParams.debugSkeletons)           \
-      .items[index]
-
-#define getSkeletonTransform(index)                                            \
-  GetBindlessResource(TransformData, uDrawParams.skeletonTransforms)           \
-      .items[index]
-
-layout(set = 1, binding = 0) uniform DrawParameters {
-  uint gizmoTransforms;
-  uint skeletonTransforms;
-  uint debugSkeletons;
-  uint collidableParams;
-  uint camera;
-  uint gridData;
-  uint pad0;
-  uint pad1;
+layout(set = 0, binding = 0) uniform DrawParameters {
+  Empty gizmoTransforms;
+  TransformsArray skeletonTransforms;
+  DebugSkeletonsArray debugSkeletons;
+  Empty collidableParams;
+  Camera camera;
+  Empty gridData;
+  Empty pad0;
+  Empty pad1;
 }
 uDrawParams;
+
+#define GetDebugSkeleton(index) uDrawParams.debugSkeletons.items[index]
+
+#define getSkeletonTransform(index) uDrawParams.skeletonTransforms.items[index]
 
 void main() {
   gl_Position = getCamera().viewProj *

--- a/editor/src/liquidator/core/EditorRenderer.cpp
+++ b/editor/src/liquidator/core/EditorRenderer.cpp
@@ -127,10 +127,8 @@ void EditorRenderer::attach(RenderGraph &graph,
         LIQUID_PROFILE_EVENT("EditorPass::CollidableShapes");
 
         commandList.bindPipeline(collidableShapePipeline);
-        commandList.bindDescriptor(collidableShapePipeline, 0,
-                                   mRenderStorage.getGlobalBuffersDescriptor());
         commandList.bindDescriptor(
-            collidableShapePipeline, 1,
+            collidableShapePipeline, 0,
             frameData.getBindlessParams().getDescriptor(), offsets);
 
         auto type = frameData.getCollidableShapeType();
@@ -152,10 +150,8 @@ void EditorRenderer::attach(RenderGraph &graph,
         LIQUID_PROFILE_EVENT("EditorPass::EditorGrid");
 
         commandList.bindPipeline(editorGridPipeline);
-        commandList.bindDescriptor(editorGridPipeline, 0,
-                                   mRenderStorage.getGlobalBuffersDescriptor());
         commandList.bindDescriptor(
-            editorGridPipeline, 1,
+            editorGridPipeline, 0,
             frameData.getBindlessParams().getDescriptor(), offsets);
 
         static constexpr uint32_t GridPlaneNumVertices = 6;
@@ -167,10 +163,8 @@ void EditorRenderer::attach(RenderGraph &graph,
         LIQUID_PROFILE_EVENT("EditorPass::SkeletonBones");
 
         commandList.bindPipeline(skeletonLinesPipeline);
-        commandList.bindDescriptor(skeletonLinesPipeline, 0,
-                                   mRenderStorage.getGlobalBuffersDescriptor());
         commandList.bindDescriptor(
-            skeletonLinesPipeline, 1,
+            skeletonLinesPipeline, 0,
             frameData.getBindlessParams().getDescriptor(), offsets);
 
         const auto &numBones = frameData.getBoneCounts();
@@ -185,13 +179,11 @@ void EditorRenderer::attach(RenderGraph &graph,
         LIQUID_PROFILE_EVENT("EditorPass::ObjectGizmos");
 
         commandList.bindPipeline(objectIconsPipeline);
-        commandList.bindDescriptor(objectIconsPipeline, 0,
-                                   mRenderStorage.getGlobalBuffersDescriptor());
         commandList.bindDescriptor(
-            objectIconsPipeline, 1,
+            objectIconsPipeline, 0,
             mRenderStorage.getGlobalTexturesDescriptor());
         commandList.bindDescriptor(
-            objectIconsPipeline, 2,
+            objectIconsPipeline, 1,
             frameData.getBindlessParams().getDescriptor(), offsets);
 
         uint32_t previousInstance = 0;
@@ -445,10 +437,8 @@ void EditorRenderer::renderOutlines(rhi::RenderCommandList &commandList,
   std::array<uint32_t, 1> offsets{0};
 
   commandList.bindPipeline(pipeline);
-  commandList.bindDescriptor(pipeline, 0,
-                             mRenderStorage.getGlobalBuffersDescriptor());
   commandList.bindDescriptor(
-      pipeline, 1, frameData.getBindlessParams().getDescriptor(), offsets);
+      pipeline, 0, frameData.getBindlessParams().getDescriptor(), offsets);
 
   struct PushConstants {
     glm::vec4 color;

--- a/editor/src/liquidator/core/EditorRendererFrameData.cpp
+++ b/editor/src/liquidator/core/EditorRendererFrameData.cpp
@@ -67,22 +67,23 @@ EditorRendererFrameData::EditorRendererFrameData(RenderStorage &renderStorage,
   mOutlineTransformsBuffer = renderStorage.createBuffer(defaultDesc);
 
   struct EditorDrawParams {
-    rhi::BufferHandle gizmoTransforms;
-    rhi::BufferHandle skeletonTransforms;
-    rhi::BufferHandle debugSkeletons;
-    rhi::BufferHandle collidableParams;
-    rhi::BufferHandle camera;
-    rhi::BufferHandle gridData;
-    rhi::BufferHandle outlineTransforms;
-    rhi::BufferHandle outlineSkeletons;
+    rhi::DeviceAddress gizmoTransforms;
+    rhi::DeviceAddress skeletonTransforms;
+    rhi::DeviceAddress debugSkeletons;
+    rhi::DeviceAddress collidableParams;
+    rhi::DeviceAddress camera;
+    rhi::DeviceAddress gridData;
+    rhi::DeviceAddress outlineTransforms;
+    rhi::DeviceAddress outlineSkeletons;
   };
 
   mBindlessParams.addRange(EditorDrawParams{
-      mGizmoTransformsBuffer.getHandle(), mSkeletonTransformsBuffer.getHandle(),
-      mSkeletonBoneTransformsBuffer.getHandle(),
-      mCollidableEntityBuffer.getHandle(), mCameraBuffer.getHandle(),
-      mEditorGridBuffer.getHandle(), mOutlineTransformsBuffer.getHandle(),
-      mOutlineSkeletonsBuffer.getHandle()});
+      mGizmoTransformsBuffer.getAddress(),
+      mSkeletonTransformsBuffer.getAddress(),
+      mSkeletonBoneTransformsBuffer.getAddress(),
+      mCollidableEntityBuffer.getAddress(), mCameraBuffer.getAddress(),
+      mEditorGridBuffer.getAddress(), mOutlineTransformsBuffer.getAddress(),
+      mOutlineSkeletonsBuffer.getAddress()});
 
   mBindlessParams.build(renderStorage.getDevice());
 }

--- a/editor/src/liquidator/core/MousePickingGraph.cpp
+++ b/editor/src/liquidator/core/MousePickingGraph.cpp
@@ -85,14 +85,14 @@ MousePickingGraph::MousePickingGraph(
   pass.addPipeline(skinnedPipeline);
 
   struct MousePickingDrawParams {
-    rhi::BufferHandle meshTransforms;
-    rhi::BufferHandle skinnedMeshTransforms;
-    rhi::BufferHandle skeletons;
-    rhi::BufferHandle camera;
-    rhi::BufferHandle entities;
-    rhi::BufferHandle selectedEntity;
-    uint32_t pad0;
-    uint32_t pad1;
+    rhi::DeviceAddress meshTransforms;
+    rhi::DeviceAddress skinnedMeshTransforms;
+    rhi::DeviceAddress skeletons;
+    rhi::DeviceAddress camera;
+    rhi::DeviceAddress entities;
+    rhi::DeviceAddress selectedEntity;
+    rhi::DeviceAddress pad0;
+    rhi::DeviceAddress pad1;
   };
 
   size_t offset = 0;
@@ -102,7 +102,7 @@ MousePickingGraph::MousePickingGraph(
         frameData.getMeshTransformsBuffer(),
         frameData.getSkinnedMeshTransformsBuffer(),
         frameData.getSkeletonsBuffer(), frameData.getCameraBuffer(),
-        mEntitiesBuffer.getHandle(), mSelectedEntityBuffer.getHandle()});
+        mEntitiesBuffer.getAddress(), mSelectedEntityBuffer.getAddress()});
   }
 
   pass.setExecutor([this, pipeline, skinnedPipeline, offset,
@@ -117,10 +117,8 @@ MousePickingGraph::MousePickingGraph(
     {
       commandList.bindPipeline(pipeline);
 
-      commandList.bindDescriptor(pipeline, 0,
-                                 renderStorage.getGlobalBuffersDescriptor());
       commandList.bindDescriptor(
-          pipeline, 1, mBindlessParams.at(frameIndex).getDescriptor(), offsets);
+          pipeline, 0, mBindlessParams.at(frameIndex).getDescriptor(), offsets);
 
       uint32_t instanceStart = 0;
       for (auto &[handle, meshData] : frameData.getMeshGroups()) {
@@ -152,8 +150,6 @@ MousePickingGraph::MousePickingGraph(
       commandList.bindPipeline(skinnedPipeline);
 
       commandList.bindDescriptor(skinnedPipeline, 0,
-                                 renderStorage.getGlobalBuffersDescriptor());
-      commandList.bindDescriptor(skinnedPipeline, 1,
                                  mBindlessParams.at(frameIndex).getDescriptor(),
                                  offsets);
 

--- a/engine/assets/shaders/bindless/base.glsl
+++ b/engine/assets/shaders/bindless/base.glsl
@@ -1,57 +1,11 @@
-#extension GL_EXT_nonuniform_qualifier : enable
+#extension GL_EXT_nonuniform_qualifier : require
+#extension GL_EXT_buffer_reference : require
 
 #define Bindless 1
 #define BindlessDescriptorSet 0
-#define BindlessStorageBinding 0
-#define BindlessUniformBinding 1
+#define BindlessTexturesBinding 0
 
-/**
- * @brief Get variable name of a layout
- *
- * @param Name Layout name
- */
-#define GetLayoutVariableName(Name) u##Name##Register
+#define Buffer(alignment)                                                      \
+  layout(buffer_reference, std430, buffer_reference_align = alignment) buffer
 
-/**
- * @brief Register storage buffer
- *
- * @param Layout Layout type (e.g std430)
- * @param BufferAccess Buffer access type (e.g readonly)
- * @param Name Layout name
- * @param Struct Structure
- */
-#define RegisterBuffer(Layout, BufferAccess, Name, Struct)                     \
-  layout(Layout, set = BindlessDescriptorSet,                                  \
-         binding = BindlessStorageBinding) BufferAccess buffer Name Struct     \
-  GetLayoutVariableName(Name)[]
-
-/**
- * @brief Register uniform buffer
- *
- * @param Name Layout name
- * @param Struct Structure
- */
-#define RegisterUniform(Name, Struct)                                          \
-  layout(set = BindlessDescriptorSet, binding = BindlessUniformBinding)        \
-      uniform Name Struct                                                      \
-      GetLayoutVariableName(Name)[]
-
-/**
- * @brief Get bindless resource by index
- *
- * @param Name Layout name
- * @param Index Resource index
- */
-#define GetBindlessResource(Name, Index) GetLayoutVariableName(Name)[Index]
-
-layout(set = BindlessDescriptorSet,
-       binding = BindlessStorageBinding) readonly buffer DummyGlobalData {
-  uint ignore;
-}
-uGlobalBuffers[];
-
-layout(set = BindlessDescriptorSet,
-       binding = BindlessUniformBinding) uniform DummyUniformData {
-  uint ignore;
-}
-uGlobalUniforms[];
+Buffer(16) Empty { uint pad0; };

--- a/engine/assets/shaders/bindless/camera.glsl
+++ b/engine/assets/shaders/bindless/camera.glsl
@@ -1,10 +1,7 @@
-struct CameraData {
+Buffer(64) Camera {
   mat4 proj;
   mat4 view;
   mat4 viewProj;
 };
 
-RegisterUniform(CameraUniform, { CameraData camera; });
-
-#define getCamera()                                                            \
-  GetBindlessResource(CameraUniform, uDrawParams.camera).camera
+#define getCamera() uDrawParams.camera

--- a/engine/assets/shaders/bindless/lights.glsl
+++ b/engine/assets/shaders/bindless/lights.glsl
@@ -18,12 +18,9 @@ struct DirectionalLightItem {
   uvec4 shadowData;
 };
 
-RegisterBuffer(std430, readonly, DirectionalLightData,
-               { DirectionalLightItem items[]; });
+Buffer(16) DirectionalLightsArray { DirectionalLightItem items[]; };
 
-#define getDirectionalLight(index)                                             \
-  GetBindlessResource(DirectionalLightData, uDrawParams.directionalLights)     \
-      .items[index]
+#define getDirectionalLight(index) uDrawParams.directionalLights.items[index]
 
 /**
  * @brief Point light item
@@ -45,7 +42,6 @@ struct PointLightItem {
   vec4 color;
 };
 
-RegisterBuffer(std430, readonly, PointLightData, { PointLightItem items[]; });
+Buffer(16) PointLightsArray { PointLightItem items[]; };
 
-#define getPointLight(index)                                                   \
-  GetBindlessResource(PointLightData, uDrawParams.pointLights).items[index]
+#define getPointLight(index) uDrawParams.pointLights.items[index]

--- a/engine/assets/shaders/bindless/mesh.glsl
+++ b/engine/assets/shaders/bindless/mesh.glsl
@@ -1,23 +1,7 @@
 #include "transform.glsl"
+#include "skeleton.glsl"
 
-/**
- * @brief Single skeleton joints
- */
-struct SkeletonItem {
-  /**
-   * Joints for skeleton
-   */
-  mat4 joints[32];
-};
-
-RegisterBuffer(std430, readonly, SkeletonData, { SkeletonItem items[]; });
-
-#define getMeshTransform(index)                                                \
-  GetBindlessResource(TransformData, uDrawParams.meshTransforms).items[index]
+#define getMeshTransform(index) uDrawParams.meshTransforms.items[index]
 
 #define getSkinnedMeshTransform(index)                                         \
-  GetBindlessResource(TransformData, uDrawParams.skinnedMeshTransforms)        \
-      .items[index]
-
-#define getSkeleton(index)                                                     \
-  GetBindlessResource(SkeletonData, uDrawParams.skeletons).items[index]
+  uDrawParams.skinnedMeshTransforms.items[index]

--- a/engine/assets/shaders/bindless/scene.glsl
+++ b/engine/assets/shaders/bindless/scene.glsl
@@ -1,4 +1,4 @@
-struct SceneData {
+Buffer(16) Scene {
   uvec4 data;
 
   uvec4 textures;
@@ -6,6 +6,4 @@ struct SceneData {
   vec4 color;
 };
 
-RegisterUniform(SceneUniform, { SceneData scene; });
-
-#define getScene() GetBindlessResource(SceneUniform, uDrawParams.scene).scene
+#define getScene() uDrawParams.scene

--- a/engine/assets/shaders/bindless/shadows.glsl
+++ b/engine/assets/shaders/bindless/shadows.glsl
@@ -13,7 +13,6 @@ struct ShadowMapItem {
   vec4 shadowData;
 };
 
-RegisterBuffer(std430, readonly, ShadowMapData, { ShadowMapItem items[]; });
+Buffer(64) ShadowMapsArray { ShadowMapItem items[]; };
 
-#define getShadowMap(index)                                                    \
-  GetBindlessResource(ShadowMapData, uDrawParams.shadows).items[index]
+#define getShadowMap(index) uDrawParams.shadows.items[index]

--- a/engine/assets/shaders/bindless/skeleton.glsl
+++ b/engine/assets/shaders/bindless/skeleton.glsl
@@ -1,0 +1,13 @@
+/**
+ * @brief Single skeleton joints
+ */
+struct SkeletonItem {
+  /**
+   * Joints for skeleton
+   */
+  mat4 joints[32];
+};
+
+Buffer(64) SkeletonsArray { SkeletonItem items[]; };
+
+#define getSkeleton(index) uDrawParams.skeletons.items[index]

--- a/engine/assets/shaders/bindless/text.glsl
+++ b/engine/assets/shaders/bindless/text.glsl
@@ -15,10 +15,8 @@ struct GlyphItem {
   vec4 planeBounds;
 };
 
-RegisterBuffer(std430, readonly, GlyphData, { GlyphItem items[]; });
+Buffer(16) GlyphsArray { GlyphItem items[]; };
 
-#define getTextTransform(index)                                                \
-  GetBindlessResource(TransformData, uDrawParams.textTransforms).items[index]
+#define getTextTransform(index) uDrawParams.textTransforms.items[index]
 
-#define getGlyph(index)                                                        \
-  GetBindlessResource(GlyphData, uDrawParams.glyphs).items[index]
+#define getGlyph(index) uDrawParams.glyphs.items[index]

--- a/engine/assets/shaders/bindless/transform.glsl
+++ b/engine/assets/shaders/bindless/transform.glsl
@@ -11,6 +11,6 @@ struct TransformItem {
   mat4 modelMatrix;
 };
 
-RegisterBuffer(std430, readonly, TransformData, { TransformItem items[]; });
+Buffer(64) TransformsArray { TransformItem items[]; };
 
 #endif

--- a/engine/assets/shaders/geometry-skinned.vert
+++ b/engine/assets/shaders/geometry-skinned.vert
@@ -17,15 +17,15 @@ layout(location = 3) out mat3 outTBN;
 #include "bindless/mesh.glsl"
 #include "bindless/camera.glsl"
 
-layout(set = 3, binding = 0) uniform DrawParams {
-  uint meshTransforms;
-  uint skinnedMeshTransforms;
-  uint skeletons;
-  uint camera;
-  uint scene;
-  uint lights;
-  uint shadows;
-  uint pad0;
+layout(set = 2, binding = 0) uniform DrawParameters {
+  TransformsArray meshTransforms;
+  TransformsArray skinnedMeshTransforms;
+  SkeletonsArray skeletons;
+  Camera camera;
+  Empty scene;
+  Empty directionalLights;
+  Empty pointLights;
+  Empty shadows;
 }
 uDrawParams;
 

--- a/engine/assets/shaders/geometry.vert
+++ b/engine/assets/shaders/geometry.vert
@@ -15,15 +15,15 @@ layout(location = 3) out mat3 outTBN;
 #include "bindless/mesh.glsl"
 #include "bindless/camera.glsl"
 
-layout(set = 3, binding = 0) uniform DrawParams {
-  uint meshTransforms;
-  uint skinnedMeshTransforms;
-  uint skeletons;
-  uint camera;
-  uint scene;
-  uint lights;
-  uint shadows;
-  uint pad0;
+layout(set = 2, binding = 0) uniform DrawParameters {
+  TransformsArray meshTransforms;
+  TransformsArray skinnedMeshTransforms;
+  SkeletonsArray skeletons;
+  Camera camera;
+  Empty scene;
+  Empty directionalLights;
+  Empty pointLights;
+  Empty shadows;
 }
 uDrawParams;
 

--- a/engine/assets/shaders/pbr.frag
+++ b/engine/assets/shaders/pbr.frag
@@ -14,23 +14,11 @@ layout(location = 0) out vec4 outColor;
 #include "bindless/shadows.glsl"
 #include "bindless/lights.glsl"
 
-layout(set = 3, binding = 0) uniform DrawParams {
-  uint meshTransforms;
-  uint skinnedMeshTransforms;
-  uint skeletons;
-  uint camera;
-  uint scene;
-  uint directionalLights;
-  uint pointLights;
-  uint shadows;
-}
-uDrawParams;
+layout(set = 0, binding = 0) uniform sampler2D uGlobalTextures[];
+layout(set = 0, binding = 0) uniform sampler2DArray uTextures2DArray[];
+layout(set = 0, binding = 0) uniform samplerCube uTexturesCube[];
 
-layout(set = 1, binding = 0) uniform sampler2D uGlobalTextures[];
-layout(set = 1, binding = 0) uniform sampler2DArray uTextures2DArray[];
-layout(set = 1, binding = 0) uniform samplerCube uTexturesCube[];
-
-layout(std140, set = 2, binding = 0) uniform MaterialDataRaw {
+layout(std140, set = 1, binding = 0) uniform MaterialDataRaw {
   uint baseColorTexture[1];
   int baseColorTextureCoord[1];
   vec4 baseColorFactor;
@@ -49,6 +37,18 @@ layout(std140, set = 2, binding = 0) uniform MaterialDataRaw {
   vec3 emissiveFactor;
 }
 uMaterialDataRaw;
+
+layout(set = 2, binding = 0) uniform DrawParameters {
+  Empty meshTransforms;
+  Empty skinnedMeshTransforms;
+  Empty skeletons;
+  Camera camera;
+  Scene scene;
+  DirectionalLightsArray directionalLights;
+  PointLightsArray pointLights;
+  ShadowMapsArray shadows;
+}
+uDrawParams;
 
 /**
  * @brief PBR Material data
@@ -327,8 +327,9 @@ getDirectionalLightSurfaceCalculations(DirectionalLightItem light, vec3 n,
 
 float calculateShadowFactorFromMap(vec3 shadowCoords, vec2 offset,
                                    uint cascadeIndex) {
+  uint index = getScene().textures.w;
   float closestDepth =
-      texture(uTextures2DArray[getScene().textures.w],
+      texture(uTextures2DArray[index],
               vec3(shadowCoords.x + offset.x, 1.0 - shadowCoords.y + offset.y,
                    cascadeIndex))
           .r;

--- a/engine/assets/shaders/shadowmap-skinned.vert
+++ b/engine/assets/shaders/shadowmap-skinned.vert
@@ -10,11 +10,11 @@ layout(location = 7) in vec4 inWeights;
 #include "bindless/mesh.glsl"
 #include "bindless/shadows.glsl"
 
-layout(set = 1, binding = 0) uniform DrawParams {
-  uint meshTransforms;
-  uint skinnedMeshTransforms;
-  uint skeletons;
-  uint shadows;
+layout(set = 0, binding = 0) uniform DrawParameters {
+  TransformsArray meshTransforms;
+  TransformsArray skinnedMeshTransforms;
+  SkeletonsArray skeletons;
+  ShadowMapsArray shadows;
 }
 uDrawParams;
 

--- a/engine/assets/shaders/shadowmap.vert
+++ b/engine/assets/shaders/shadowmap.vert
@@ -8,11 +8,11 @@ layout(location = 0) in vec3 inPosition;
 #include "bindless/mesh.glsl"
 #include "bindless/shadows.glsl"
 
-layout(set = 1, binding = 0) uniform DrawParams {
-  uint meshTransforms;
-  uint skinnedMeshTransforms;
-  uint skeletons;
-  uint shadows;
+layout(set = 0, binding = 0) uniform DrawParameters {
+  TransformsArray meshTransforms;
+  TransformsArray skinnedMeshTransforms;
+  SkeletonsArray skeletons;
+  ShadowMapsArray shadows;
 }
 uDrawParams;
 

--- a/engine/assets/shaders/skybox.frag
+++ b/engine/assets/shaders/skybox.frag
@@ -3,25 +3,16 @@
 #extension GL_EXT_nonuniform_qualifier : enable
 
 layout(location = 0) in vec3 inTexCoord;
-
 layout(location = 0) out vec4 outColor;
-
-layout(set = 2, binding = 0) uniform DrawParams {
-  uint camera;
-  uint skybox;
-  uint pad0;
-  uint pad1;
-}
-uDrawParams;
 
 #include "bindless/base.glsl"
 
-layout(set = 1, binding = 0) uniform samplerCube uGlobalTextures[];
+layout(set = 0, binding = 0) uniform samplerCube uGlobalTextures[];
 
 /**
- * @brief Skybox data
+ * @brief Skybox
  */
-struct SkyboxData {
+Buffer(16) Skybox {
   /**
    * Data
    *
@@ -35,18 +26,21 @@ struct SkyboxData {
   vec4 color;
 };
 
-RegisterUniform(SkyboxUniform, { SkyboxData skybox; });
+layout(set = 1, binding = 0) uniform DrawParams {
+  Empty camera;
+  Skybox skybox;
+}
+uDrawParams;
 
-#define getSkyboxData()                                                        \
-  GetBindlessResource(SkyboxUniform, uDrawParams.skybox).skybox
+#define getSkybox() uDrawParams.skybox
 
 void main() {
-  if (getSkyboxData().data.x > 0) {
+  if (getSkybox().data.x > 0) {
     vec3 color =
-        textureLod(uGlobalTextures[getSkyboxData().data.x], inTexCoord, 0).xyz;
+        textureLod(uGlobalTextures[getSkybox().data.x], inTexCoord, 0).xyz;
 
     outColor = vec4(pow(color, vec3(1.0 / 2.2)), 1.0);
   } else {
-    outColor = vec4(getSkyboxData().color.xyz, 1.0);
+    outColor = vec4(getSkybox().color.xyz, 1.0);
   }
 }

--- a/engine/assets/shaders/skybox.vert
+++ b/engine/assets/shaders/skybox.vert
@@ -8,11 +8,9 @@ layout(location = 0) out vec3 outTexCoord;
 #include "bindless/base.glsl"
 #include "bindless/camera.glsl"
 
-layout(set = 2, binding = 0) uniform DrawParams {
-  uint camera;
-  uint skybox;
-  uint pad0;
-  uint pad1;
+layout(set = 1, binding = 0) uniform DrawParameters {
+  Camera camera;
+  Empty skybox;
 }
 uDrawParams;
 

--- a/engine/assets/shaders/text.frag
+++ b/engine/assets/shaders/text.frag
@@ -7,7 +7,7 @@ layout(location = 0) out vec4 outColor;
 
 #include "bindless/base.glsl"
 
-layout(set = 1, binding = 0) uniform sampler2D uGlobalTextures[];
+layout(set = 0, binding = 0) uniform sampler2D uGlobalTextures[];
 
 layout(push_constant) uniform PushConstants { uvec4 text; }
 pcTextParams;

--- a/engine/assets/shaders/text.vert
+++ b/engine/assets/shaders/text.vert
@@ -7,11 +7,11 @@ layout(location = 0) out vec2 outTexCoord;
 #include "bindless/camera.glsl"
 #include "bindless/text.glsl"
 
-layout(set = 2, binding = 0) uniform DrawParams {
-  uint textTransforms;
-  uint camera;
-  uint glyphs;
-  uint pad0;
+layout(set = 1, binding = 0) uniform DrawParameters {
+  TransformsArray textTransforms;
+  Camera camera;
+  GlyphsArray glyphs;
+  Empty pad0;
 }
 uDrawParams;
 

--- a/engine/rhi/core/include/liquid/rhi/Buffer.h
+++ b/engine/rhi/core/include/liquid/rhi/Buffer.h
@@ -1,10 +1,9 @@
 #pragma once
 
 #include "liquid/rhi/RenderHandle.h"
+#include "liquid/rhi/NativeBuffer.h"
 
 namespace liquid::rhi {
-
-class NativeBuffer;
 
 /**
  * @brief Hardware buffer
@@ -57,6 +56,15 @@ public:
    * @param size New size
    */
   void resize(size_t size);
+
+  /**
+   * @brief Get device address
+   *
+   * @return Device address
+   */
+  inline DeviceAddress getAddress() const {
+    return mNativeBuffer->getAddress();
+  }
 
   /**
    * @brief Get buffer handle

--- a/engine/rhi/core/include/liquid/rhi/DeviceAddress.h
+++ b/engine/rhi/core/include/liquid/rhi/DeviceAddress.h
@@ -1,0 +1,7 @@
+#pragma once
+
+namespace liquid::rhi {
+
+enum class DeviceAddress : uint64_t { Null = 0 };
+
+}

--- a/engine/rhi/core/include/liquid/rhi/NativeBuffer.h
+++ b/engine/rhi/core/include/liquid/rhi/NativeBuffer.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "liquid/rhi/DeviceAddress.h"
+
 namespace liquid::rhi {
 
 /**
@@ -34,6 +36,13 @@ public:
    * @param size New size
    */
   virtual void resize(size_t size) = 0;
+
+  /**
+   * @brief Get buffer device address
+   *
+   * @return Device address
+   */
+  virtual DeviceAddress getAddress() = 0;
 };
 
 } // namespace liquid::rhi

--- a/engine/rhi/mock/include/liquid/rhi-mock/MockBuffer.h
+++ b/engine/rhi/mock/include/liquid/rhi-mock/MockBuffer.h
@@ -37,6 +37,13 @@ public:
   void resize(size_t size) override;
 
   /**
+   * @brief Get buffer device address
+   *
+   * @return Device address
+   */
+  rhi::DeviceAddress getAddress() override;
+
+  /**
    * @brief Get buffer description
    *
    * @return Buffer description

--- a/engine/rhi/mock/src/MockBuffer.cpp
+++ b/engine/rhi/mock/src/MockBuffer.cpp
@@ -18,4 +18,8 @@ void MockBuffer::unmap() {
 
 void MockBuffer::resize(size_t size) { mData.resize(size); }
 
+rhi::DeviceAddress MockBuffer::getAddress() {
+  return rhi::DeviceAddress{reinterpret_cast<uint64_t>(this)};
+}
+
 } // namespace liquid::rhi

--- a/engine/rhi/vulkan/include/liquid/rhi-vulkan/VulkanBuffer.h
+++ b/engine/rhi/vulkan/include/liquid/rhi-vulkan/VulkanBuffer.h
@@ -18,9 +18,10 @@ public:
    *
    * @param description Buffer description
    * @param allocator Vulkan allocator
+   * @param device Vulkan device object
    */
   VulkanBuffer(const BufferDescription &description,
-               VulkanResourceAllocator &allocator);
+               VulkanResourceAllocator &allocator, VulkanDeviceObject &device);
 
   /**
    * @brief Destroy buffer
@@ -37,12 +38,12 @@ public:
    *
    * @return Mapped data
    */
-  void *map();
+  void *map() override;
 
   /**
    * @brief Unmap buffer
    */
-  void unmap();
+  void unmap() override;
 
   /**
    * @brief Resize buffer
@@ -53,7 +54,14 @@ public:
    *
    * @param size New size
    */
-  void resize(size_t size);
+  void resize(size_t size) override;
+
+  /**
+   * @brief Get device address
+   *
+   * @return Buffer device address
+   */
+  DeviceAddress getAddress() override;
 
   /**
    * @brief Get Vulkan buffer
@@ -93,6 +101,7 @@ private:
 
 private:
   VulkanResourceAllocator &mAllocator;
+  VulkanDeviceObject &mDevice;
 
   VkBuffer mBuffer = VK_NULL_HANDLE;
   VmaAllocation mAllocation = VK_NULL_HANDLE;

--- a/engine/rhi/vulkan/include/liquid/rhi-vulkan/VulkanPhysicalDevice.h
+++ b/engine/rhi/vulkan/include/liquid/rhi-vulkan/VulkanPhysicalDevice.h
@@ -32,12 +32,10 @@ public:
    *
    * @param device Vulkan Physical Device handle
    * @param properties Physical Device properties
-   * @param features Physical Device features
    * @param queueFamilyIndices Queue Family Indices
    */
   VulkanPhysicalDevice(const VkPhysicalDevice &device,
                        const VkPhysicalDeviceProperties &properties,
-                       const VkPhysicalDeviceFeatures &features,
                        const VulkanQueueFamily &queueFamilyIndices);
 
   /**
@@ -54,15 +52,6 @@ public:
    * @return Physical device name
    */
   inline const String &getName() const { return mName; }
-
-  /**
-   * @brief Get device features
-   *
-   * @return Device features
-   */
-  inline const VkPhysicalDeviceFeatures &getFeatures() const {
-    return mFeatures;
-  }
 
   /**
    * @brief Get queue family indices
@@ -131,7 +120,6 @@ public:
 private:
   VulkanQueueFamily mQueueFamilyIndices;
   VkPhysicalDeviceProperties mProperties{};
-  VkPhysicalDeviceFeatures mFeatures{};
 
   String mName;
 

--- a/engine/rhi/vulkan/src/VulkanPhysicalDevice.cpp
+++ b/engine/rhi/vulkan/src/VulkanPhysicalDevice.cpp
@@ -16,13 +16,10 @@ VulkanPhysicalDevice::getPhysicalDevices(VkInstance instance,
     VkPhysicalDeviceProperties deviceProperties;
     vkGetPhysicalDeviceProperties(physicalDevice, &deviceProperties);
 
-    VkPhysicalDeviceFeatures deviceFeatures;
-    vkGetPhysicalDeviceFeatures(physicalDevice, &deviceFeatures);
-
     VulkanQueueFamily queueFamilyIndices(physicalDevice, surface);
 
     devices.push_back(VulkanPhysicalDevice(physicalDevice, deviceProperties,
-                                           deviceFeatures, queueFamilyIndices));
+                                           queueFamilyIndices));
   }
 
   return devices;
@@ -31,9 +28,8 @@ VulkanPhysicalDevice::getPhysicalDevices(VkInstance instance,
 VulkanPhysicalDevice::VulkanPhysicalDevice(
     const VkPhysicalDevice &device,
     const VkPhysicalDeviceProperties &properties,
-    const VkPhysicalDeviceFeatures &features,
     const VulkanQueueFamily &queueFamilyIndices)
-    : mDevice(device), mProperties(properties), mFeatures(features),
+    : mDevice(device), mProperties(properties),
       mQueueFamilyIndices(queueFamilyIndices) {
   mName = String((const char *)mProperties.deviceName);
 }

--- a/engine/rhi/vulkan/src/VulkanRenderDevice.cpp
+++ b/engine/rhi/vulkan/src/VulkanRenderDevice.cpp
@@ -139,7 +139,7 @@ void VulkanRenderDevice::recreateSwapchain() {
 
 Buffer VulkanRenderDevice::createBuffer(const BufferDescription &description) {
   auto handle = mRegistry.setBuffer(
-      std::make_unique<VulkanBuffer>(description, mAllocator));
+      std::make_unique<VulkanBuffer>(description, mAllocator, mDevice));
 
   return Buffer{handle, mRegistry.getBuffers().at(handle).get()};
 }

--- a/engine/rhi/vulkan/src/VulkanResourceAllocator.cpp
+++ b/engine/rhi/vulkan/src/VulkanResourceAllocator.cpp
@@ -48,6 +48,7 @@ VulkanResourceAllocator::VulkanResourceAllocator(
   createInfo.physicalDevice = physicalDevice;
   createInfo.device = device;
   createInfo.pVulkanFunctions = &vulkanFns;
+  createInfo.flags = VMA_ALLOCATOR_CREATE_BUFFER_DEVICE_ADDRESS_BIT;
 
   checkForVulkanError(vmaCreateAllocator(&createInfo, &mAllocator),
                       "Failed to create VMA allocator");

--- a/engine/src/liquid/renderer/BindlessDrawParameters.cpp
+++ b/engine/src/liquid/renderer/BindlessDrawParameters.cpp
@@ -9,6 +9,8 @@ void BindlessDrawParameters::build(rhi::RenderDevice *device) {
     maxSize = std::max(range.size, maxSize);
   }
 
+  maxSize = padSizeToMinimumUniformAlignment(maxSize);
+
   // Create buffer
   {
     rhi::BufferDescription description{};

--- a/engine/src/liquid/renderer/RenderStorage.cpp
+++ b/engine/src/liquid/renderer/RenderStorage.cpp
@@ -24,29 +24,6 @@ RenderStorage::RenderStorage(rhi::RenderDevice *device) : mDevice(device) {
     mGlobalTexturesDescriptor = mDevice->createDescriptor(layout);
   }
 
-  {
-    rhi::DescriptorLayoutBindingDescription binding0{};
-    binding0.binding = 0;
-    binding0.type = rhi::DescriptorLayoutBindingType::Dynamic;
-    binding0.name = "uGlobalBuffers";
-    binding0.descriptorCount = MaxBuffers;
-    binding0.descriptorType = rhi::DescriptorType::StorageBuffer;
-    binding0.shaderStage = rhi::ShaderStage::All;
-
-    rhi::DescriptorLayoutBindingDescription binding1{};
-    binding1.binding = 1;
-    binding1.type = rhi::DescriptorLayoutBindingType::Dynamic;
-    binding1.name = "uGlobalUniforms";
-    binding1.descriptorCount = MaxBuffers;
-    binding1.descriptorType = rhi::DescriptorType::UniformBuffer;
-    binding1.shaderStage = rhi::ShaderStage::All;
-
-    rhi::DescriptorLayoutDescription description{{binding0, binding1}};
-    auto layout = mDevice->createDescriptorLayout(description);
-
-    mGlobalBuffersDescriptor = mDevice->createDescriptor(layout);
-  }
-
   // Material descriptor layout
   {
     rhi::DescriptorLayoutBindingDescription binding{};
@@ -150,20 +127,7 @@ rhi::FramebufferHandle RenderStorage::getNewFramebufferHandle() {
 
 rhi::Buffer
 RenderStorage::createBuffer(const liquid::rhi::BufferDescription &description) {
-  auto buffer = mDevice->createBuffer(description);
-
-  std::array<rhi::BufferHandle, 1> buffers{buffer.getHandle()};
-  if (description.usage == rhi::BufferUsage::Storage) {
-    mGlobalBuffersDescriptor.write(0, buffers,
-                                   rhi::DescriptorType::StorageBuffer,
-                                   rhi::castHandleToUint(buffer.getHandle()));
-  } else if (description.usage == rhi::BufferUsage::Uniform) {
-    mGlobalBuffersDescriptor.write(1, buffers,
-                                   rhi::DescriptorType::UniformBuffer,
-                                   rhi::castHandleToUint(buffer.getHandle()));
-  }
-
-  return buffer;
+  return mDevice->createBuffer(description);
 }
 
 rhi::Descriptor RenderStorage::createMaterialDescriptor(rhi::Buffer buffer) {

--- a/engine/src/liquid/renderer/RenderStorage.h
+++ b/engine/src/liquid/renderer/RenderStorage.h
@@ -129,15 +129,6 @@ public:
   }
 
   /**
-   * @brief Get global buffers descriptor
-   *
-   * @return Global buffers descriptor
-   */
-  inline const rhi::Descriptor &getGlobalBuffersDescriptor() const {
-    return mGlobalBuffersDescriptor;
-  }
-
-  /**
    * @brief Create material descriptor
    *
    * @param buffer Material buffer
@@ -226,7 +217,6 @@ private:
   rhi::DescriptorLayoutHandle mMaterialDescriptorLayout{0};
 
   rhi::Descriptor mGlobalTexturesDescriptor;
-  rhi::Descriptor mGlobalBuffersDescriptor;
 
   size_t mResizeListener = 0;
 

--- a/engine/src/liquid/renderer/SceneRendererFrameData.h
+++ b/engine/src/liquid/renderer/SceneRendererFrameData.h
@@ -438,8 +438,8 @@ public:
    *
    * @return Mesh transforms buffer
    */
-  inline rhi::BufferHandle getMeshTransformsBuffer() const {
-    return mMeshTransformsBuffer.getHandle();
+  inline rhi::DeviceAddress getMeshTransformsBuffer() const {
+    return mMeshTransformsBuffer.getAddress();
   }
 
   /**
@@ -447,8 +447,8 @@ public:
    *
    * @return Skinned mesh transforms buffer
    */
-  inline rhi::BufferHandle getSkinnedMeshTransformsBuffer() const {
-    return mSkinnedMeshTransformsBuffer.getHandle();
+  inline rhi::DeviceAddress getSkinnedMeshTransformsBuffer() const {
+    return mSkinnedMeshTransformsBuffer.getAddress();
   }
 
   /**
@@ -456,8 +456,8 @@ public:
    *
    * @return Text transforms buffer
    */
-  inline rhi::BufferHandle getTextTransformsBuffer() const {
-    return mTextTransformsBuffer.getHandle();
+  inline rhi::DeviceAddress getTextTransformsBuffer() const {
+    return mTextTransformsBuffer.getAddress();
   }
 
   /**
@@ -465,8 +465,8 @@ public:
    *
    * @return Skeletons buffer
    */
-  inline rhi::BufferHandle getSkeletonsBuffer() const {
-    return mSkeletonsBuffer.getHandle();
+  inline rhi::DeviceAddress getSkeletonsBuffer() const {
+    return mSkeletonsBuffer.getAddress();
   }
 
   /**
@@ -474,8 +474,8 @@ public:
    *
    * @return Camera buffer
    */
-  inline rhi::BufferHandle getCameraBuffer() const {
-    return mCameraBuffer.getHandle();
+  inline rhi::DeviceAddress getCameraBuffer() const {
+    return mCameraBuffer.getAddress();
   }
 
   /**
@@ -483,8 +483,8 @@ public:
    *
    * @return Scene buffer
    */
-  inline rhi::BufferHandle getSceneBuffer() const {
-    return mSceneBuffer.getHandle();
+  inline rhi::DeviceAddress getSceneBuffer() const {
+    return mSceneBuffer.getAddress();
   }
 
   /**
@@ -492,8 +492,8 @@ public:
    *
    * @return Directional lights buffer
    */
-  inline rhi::BufferHandle getDirectionalLightsBuffer() const {
-    return mDirectionalLightsBuffer.getHandle();
+  inline rhi::DeviceAddress getDirectionalLightsBuffer() const {
+    return mDirectionalLightsBuffer.getAddress();
   }
 
   /**
@@ -501,8 +501,8 @@ public:
    *
    * @return Point lights buffer
    */
-  inline rhi::BufferHandle getPointLightsBuffer() const {
-    return mPointLightsBuffer.getHandle();
+  inline rhi::DeviceAddress getPointLightsBuffer() const {
+    return mPointLightsBuffer.getAddress();
   }
 
   /**
@@ -510,8 +510,8 @@ public:
    *
    * @return Shadow maps buffer
    */
-  inline rhi::BufferHandle getShadowMapsBuffer() const {
-    return mShadowMapsBuffer.getHandle();
+  inline rhi::DeviceAddress getShadowMapsBuffer() const {
+    return mShadowMapsBuffer.getAddress();
   }
 
   /**
@@ -519,8 +519,8 @@ public:
    *
    * @return Skybox buffer
    */
-  inline rhi::BufferHandle getSkyboxBuffer() const {
-    return mSkyboxBuffer.getHandle();
+  inline rhi::DeviceAddress getSkyboxBuffer() const {
+    return mSkyboxBuffer.getAddress();
   }
 
   /**
@@ -528,8 +528,8 @@ public:
    *
    * @return Glyphs buffer
    */
-  inline rhi::BufferHandle getGlyphsBuffer() const {
-    return mTextGlyphsBuffer.getHandle();
+  inline rhi::DeviceAddress getGlyphsBuffer() const {
+    return mTextGlyphsBuffer.getAddress();
   }
 
 private:


### PR DESCRIPTION
- Enable buffer device address features
- Load all features using new version of physical device features
- Add device address type to RHI
- Add method to get device address from buffer
- Use buffer device address for accessing buffers in shaders
- Remove global buffers descriptor set