### PR TITLE
Recreate render graph on resize

### DIFF
--- a/editor/src/liquidator/core/EditorRenderer.h
+++ b/editor/src/liquidator/core/EditorRenderer.h
@@ -49,8 +49,10 @@ public:
    *
    * @param graph Render graph
    * @param scenePassData Scene pass data
+   * @param options Renderer options
    */
-  void attach(RenderGraph &graph, const SceneRenderPassData &scenePassData);
+  void attach(RenderGraph &graph, const SceneRenderPassData &scenePassData,
+              const RendererOptions &options);
 
   /**
    * @brief Update frame data

--- a/editor/src/liquidator/core/MousePickingGraph.h
+++ b/editor/src/liquidator/core/MousePickingGraph.h
@@ -28,11 +28,6 @@ public:
                     AssetRegistry &assetRegistry, RenderStorage &renderStorage);
 
   /**
-   * @brief Compile the graph
-   */
-  void compile();
-
-  /**
    * @brief Execute the graph
    *
    * @param commandList Command list
@@ -55,9 +50,9 @@ public:
   /**
    * @brief Set framebuffer size
    *
-   * @param window Framebuffer size
+   * @param size Framebuffer size
    */
-  void setFramebufferSize(Window &window);
+  void setFramebufferSize(glm::uvec2 size);
 
   /**
    * @brief Check is selection is performed in current frame
@@ -69,6 +64,12 @@ public:
   inline bool isSelectionPerformedInFrame(uint32_t frameIndex) const {
     return frameIndex == mFrameIndex;
   }
+
+private:
+  /**
+   * @brief Create render graph
+   */
+  void createRenderGraph();
 
 private:
   RenderStorage &mRenderStorage;
@@ -86,6 +87,9 @@ private:
   rhi::Buffer mSelectedEntityBuffer;
 
   glm::vec2 mMousePos{};
+
+  glm::uvec2 mFramebufferSize{};
+  bool mResized = true;
 
   uint32_t mFrameIndex = std::numeric_limits<uint32_t>::max();
 };

--- a/editor/src/liquidator/editor-scene/EditorCamera.h
+++ b/editor/src/liquidator/editor-scene/EditorCamera.h
@@ -171,8 +171,8 @@ private:
 private:
   float mX = 0.0f;
   float mY = 0.0f;
-  float mWidth = 0.0f;
-  float mHeight = 0.0f;
+  float mWidth = 1.0f;
+  float mHeight = 1.0f;
   float mWheelOffset = 0.0f;
   bool mCaptureMouse = false;
 

--- a/engine/rhi/mock/include/liquid/rhi-mock/MockRenderDevice.h
+++ b/engine/rhi/mock/include/liquid/rhi-mock/MockRenderDevice.h
@@ -164,6 +164,17 @@ public:
   getTextureViewDescription(TextureHandle handle) const;
 
   /**
+   * @brief Check if texture exists in device
+   *
+   * @param handle Texture handle
+   * @retval true Texture exists
+   * @retval false Texture does not exist
+   */
+  inline bool hasTexture(TextureHandle handle) const {
+    return mTextures.exists(handle);
+  }
+
+  /**
    * @brief Destroy texture
    *
    * @param handle Texture handle
@@ -213,6 +224,17 @@ public:
   getRenderPassDescription(RenderPassHandle handle) const;
 
   /**
+   * @brief Check if render pass exists in device
+   *
+   * @param handle Render pass handle
+   * @retval true Render pass exists
+   * @retval false Render pass does not exist
+   */
+  inline bool hasRenderPass(RenderPassHandle handle) const {
+    return mRenderPasses.exists(handle);
+  }
+
+  /**
    * @brief Create framebuffer
    *
    * @param description Framebuffer description
@@ -236,6 +258,17 @@ public:
    */
   const FramebufferDescription
   getFramebufferDescription(FramebufferHandle handle) const;
+
+  /**
+   * @brief Check if framebuffer exists in device
+   *
+   * @param handle Framebuffer handle
+   * @retval true Framebuffer exists
+   * @retval false Framebuffer does not exist
+   */
+  inline bool hasFramebuffer(FramebufferHandle handle) const {
+    return mFramebuffers.exists(handle);
+  }
 
   /**
    * @brief Create graphics pipeline

--- a/engine/rhi/vulkan/src/VulkanTexture.cpp
+++ b/engine/rhi/vulkan/src/VulkanTexture.cpp
@@ -26,6 +26,10 @@ VulkanTexture::VulkanTexture(const TextureDescription &description,
     : mAllocator(allocator), mDevice(device),
       mFormat(VulkanMapping::getFormat(description.format)),
       mDescription(description) {
+
+  LIQUID_ASSERT(description.width > 0 && description.height > 0,
+                "Texture dimensions cannot be zero");
+
   LIQUID_ASSERT(description.type == TextureType::Cubemap
                     ? description.layerCount == 6
                     : true,

--- a/engine/src/liquid/imgui/ImguiRenderer.cpp
+++ b/engine/src/liquid/imgui/ImguiRenderer.cpp
@@ -68,22 +68,19 @@ ImguiRenderer::~ImguiRenderer() {
   ImGui::DestroyContext();
 }
 
-ImguiRenderPassData ImguiRenderer::attach(RenderGraph &graph) {
+ImguiRenderPassData ImguiRenderer::attach(RenderGraph &graph,
+                                          const RendererOptions &options) {
   LIQUID_ASSERT(mReady, "Fonts are not built. Call ImguiRenderer::loadFonts "
                         "before starting rendering");
 
-  static constexpr uint32_t FramebufferSizePercentage = 100;
-
   rhi::TextureDescription imguiDesc{};
   imguiDesc.usage = rhi::TextureUsage::Color | rhi::TextureUsage::Sampled;
-  imguiDesc.width = FramebufferSizePercentage;
-  imguiDesc.height = FramebufferSizePercentage;
+  imguiDesc.width = options.size.x;
+  imguiDesc.height = options.size.y;
   imguiDesc.layerCount = 1;
   imguiDesc.format = rhi::Format::Rgba8Srgb;
   imguiDesc.debugName = "Imgui color";
-  auto imguiReal =
-      mRenderStorage.createFramebufferRelativeTexture(imguiDesc, false);
-  auto imgui = graph.import(imguiReal);
+  auto imgui = graph.create(imguiDesc);
 
   auto &pass = graph.addGraphicsPass("imgui");
   pass.write(imgui, AttachmentType::Color, mClearColor);

--- a/engine/src/liquid/imgui/ImguiRenderer.h
+++ b/engine/src/liquid/imgui/ImguiRenderer.h
@@ -6,6 +6,7 @@
 #include "liquid/renderer/RenderGraph.h"
 #include "liquid/rhi/RenderDevice.h"
 #include "liquid/renderer/RenderStorage.h"
+#include "liquid/renderer/RendererOptions.h"
 
 #include "liquid/imgui/Imgui.h"
 
@@ -23,7 +24,7 @@ struct ImguiRenderPassData {
   /**
    * Imgui texture
    */
-  rhi::TextureHandle imguiColor;
+  RenderGraphResource<rhi::TextureHandle> imguiColor;
 };
 
 /**
@@ -90,9 +91,11 @@ public:
    * @brief Attach render passes to render graph
    *
    * @param graph Render graph
+   * @param options Renderer options
    * @return Imgui render pass data
    */
-  ImguiRenderPassData attach(RenderGraph &graph);
+  ImguiRenderPassData attach(RenderGraph &graph,
+                             const RendererOptions &options);
 
   /**
    * @brief Set clear color

--- a/engine/src/liquid/renderer/BindlessDrawParameters.cpp
+++ b/engine/src/liquid/renderer/BindlessDrawParameters.cpp
@@ -57,6 +57,15 @@ void BindlessDrawParameters::build(rhi::RenderDevice *device) {
   }
 }
 
+void BindlessDrawParameters::destroy(rhi::RenderDevice *device) {
+  mRanges.clear();
+  mLastOffset = 0;
+  if (rhi::isHandleValid(mBuffer.getHandle())) {
+    device->destroyBuffer(mBuffer.getHandle());
+    mBuffer = rhi::Buffer();
+  }
+}
+
 size_t
 BindlessDrawParameters::padSizeToMinimumUniformAlignment(size_t originalSize) {
   if (mMinBufferAlignment > 0) {

--- a/engine/src/liquid/renderer/BindlessDrawParameters.h
+++ b/engine/src/liquid/renderer/BindlessDrawParameters.h
@@ -56,6 +56,13 @@ public:
    */
   void build(rhi::RenderDevice *device);
 
+  /**
+   * @brief Destroy buffers and descriptor
+   *
+   * @param device Render device
+   */
+  void destroy(rhi::RenderDevice *device);
+
 private:
   /**
    * @brief Pad size to minimum uniform alignment

--- a/engine/src/liquid/renderer/Presenter.cpp
+++ b/engine/src/liquid/renderer/Presenter.cpp
@@ -49,6 +49,7 @@ Presenter::Presenter(RenderStorage &renderStorage)
 }
 
 void Presenter::updateFramebuffers(const rhi::Swapchain &swapchain) {
+  mUpdateRequired = false;
   mExtent = swapchain.extent;
 
   rhi::RenderPassAttachmentDescription attachment{};
@@ -111,11 +112,7 @@ void Presenter::updateFramebuffers(const rhi::Swapchain &swapchain) {
     device->createFramebuffer(framebufferDescription, mFramebuffers.at(i));
   }
 
-  if (rhi::isHandleValid(mPresentTexture)) {
-    std::array<rhi::TextureHandle, 1> textures{mPresentTexture};
-    mPresentDescriptor.write(0, textures,
-                             rhi::DescriptorType::CombinedImageSampler);
-  }
+  mPresentTexture = rhi::TextureHandle::Null;
 }
 
 void Presenter::present(rhi::RenderCommandList &commandList,
@@ -171,5 +168,7 @@ void Presenter::present(rhi::RenderCommandList &commandList,
                                 barriers);
   }
 }
+
+void Presenter::enqueueFramebufferUpdate() { mUpdateRequired = true; }
 
 } // namespace liquid

--- a/engine/src/liquid/renderer/Presenter.h
+++ b/engine/src/liquid/renderer/Presenter.h
@@ -37,6 +37,19 @@ public:
   void present(rhi::RenderCommandList &commandList, rhi::TextureHandle handle,
                uint32_t imageIndex);
 
+  /**
+   * @brief Set flag to update framebuffers
+   */
+  void enqueueFramebufferUpdate();
+
+  /**
+   * @brief Check if framebuffer update is required
+   *
+   * @retval true Framebuffer update is required
+   * @retval false Framebuffer update is not required
+   */
+  inline bool requiresFramebufferUpdate() const { return mUpdateRequired; }
+
 private:
   RenderStorage &mRenderStorage;
   rhi::RenderPassHandle mPresentPass = rhi::RenderPassHandle::Null;
@@ -45,6 +58,8 @@ private:
   glm::uvec2 mExtent{0, 0};
   rhi::TextureHandle mPresentTexture{0};
   rhi::Descriptor mPresentDescriptor;
+
+  bool mUpdateRequired = false;
 };
 
 } // namespace liquid

--- a/engine/src/liquid/renderer/RenderGraph.h
+++ b/engine/src/liquid/renderer/RenderGraph.h
@@ -58,14 +58,6 @@ public:
   RGTexture create(const rhi::TextureDescription &description);
 
   /**
-   * @brief Create dynamic texture
-   *
-   * @param creator Texture creator
-   * @return Render graph texture
-   */
-  RGTexture create(RGTextureCreator creator);
-
-  /**
    * @brief Create texture view
    *
    * @param texture Render graph texture
@@ -103,6 +95,13 @@ public:
   void build(RenderStorage &storage);
 
   /**
+   * @brief Clear render graph
+   *
+   * @param storage Render storage
+   */
+  void destroy(RenderStorage &storage);
+
+  /**
    * @brief Get passes
    *
    * @return Render graph passes
@@ -117,30 +116,6 @@ public:
   inline std::vector<RenderGraphPass> &getCompiledPasses() {
     return mCompiledPasses;
   }
-
-  /**
-   * @brief Set framebuffer extent
-   *
-   * @param framebufferExtent Framebuffer extent
-   */
-  void setFramebufferExtent(glm::uvec2 framebufferExtent);
-
-  /**
-   * @brief Get framebuffer extent
-   *
-   * @return Framebuffer extent
-   */
-  inline const glm::uvec2 &getFramebufferExtent() const {
-    return mFramebufferExtent;
-  }
-
-  /**
-   * @brief Check if recreate is necessary
-   *
-   * @retval true Passes have changed
-   * @retval false Passes have not changed
-   */
-  inline bool isDirty() const { return mDirty != GraphDirty::None; }
 
   /**
    * @brief Get name
@@ -199,19 +174,11 @@ private:
   void buildComputePass(RenderGraphPass &pass, RenderStorage &storage);
 
 private:
-  // Passes
+  RenderGraphRegistry mRegistry;
+  String mName;
+
   std::vector<RenderGraphPass> mPasses;
   std::vector<RenderGraphPass> mCompiledPasses;
-
-private:
-  // Resources
-  RenderGraphRegistry mRegistry;
-
-private:
-  glm::uvec2 mFramebufferExtent{};
-  GraphDirty mDirty = GraphDirty::None;
-
-  String mName;
 };
 
 } // namespace liquid

--- a/engine/src/liquid/renderer/RenderGraphPass.h
+++ b/engine/src/liquid/renderer/RenderGraphPass.h
@@ -270,6 +270,15 @@ public:
   inline rhi::FramebufferHandle getFramebuffer() const { return mFramebuffer; }
 
   /**
+   * @brief Get pipelines
+   *
+   * @return Pipelines
+   */
+  inline const std::vector<rhi::PipelineHandle> &getPipelines() const {
+    return mPipelines;
+  }
+
+  /**
    * @brief Get output buffers
    *
    * @return Output buffers

--- a/engine/src/liquid/renderer/RenderStorage.h
+++ b/engine/src/liquid/renderer/RenderStorage.h
@@ -54,6 +54,13 @@ public:
                     bool addToDescriptor = true);
 
   /**
+   * @brief Destroy texture
+   *
+   * @param handle Texture handle
+   */
+  void destroyTexture(rhi::TextureHandle handle);
+
+  /**
    * @brief Create shader
    *
    * @param name Shader name
@@ -78,17 +85,6 @@ public:
    * @param handle Texture handle
    */
   void addToDescriptor(rhi::TextureHandle handle);
-
-  /**
-   * @brief Create framebuffer relative texture
-   *
-   * @param description Texture description
-   * @param addToDescriptor Add texture to global descriptor
-   * @return Texture handle
-   */
-  rhi::TextureHandle createFramebufferRelativeTexture(
-      const liquid::rhi::TextureDescription &description,
-      bool addToDescriptor = true);
 
   /**
    * @brief Get new texture handle
@@ -143,31 +139,6 @@ public:
    */
   inline rhi::RenderDevice *getDevice() { return mDevice; }
 
-  /**
-   * @brief Recreate framebuffer relative textures
-   *
-   * @retval true Framebuffer relative textures recreated
-   * @retval false Framebuffer relative textures do not require recreate
-   */
-  bool recreateFramebufferRelativeTextures();
-
-  /**
-   * @brief Check if texture is framebuffer relative
-   *
-   * @param handle Texture handle
-   * @retval true Texture is framebuffer relative
-   * @retval false Texture is not framebuffer relative
-   */
-  bool isFramebufferRelative(rhi::TextureHandle handle);
-
-  /**
-   * @brief Set framebuffer size
-   *
-   * @param width Framebuffer width
-   * @param height Framebuffer height
-   */
-  void setFramebufferSize(uint32_t width, uint32_t height);
-
 public:
   /**
    * @brief Add graphics pipeline
@@ -217,18 +188,6 @@ private:
   rhi::DescriptorLayoutHandle mMaterialDescriptorLayout{0};
 
   rhi::Descriptor mGlobalTexturesDescriptor;
-
-  size_t mResizeListener = 0;
-
-  std::map<rhi::TextureHandle, rhi::TextureDescription>
-      mFramebufferRelativeTextures;
-  std::vector<rhi::TextureHandle>
-      mFramebufferRelativeTexturesInGlobalDescriptor;
-
-  bool mNeedsSwapchainResize = false;
-
-  uint32_t mWidth = 0;
-  uint32_t mHeight = 0;
 
   std::vector<std::variant<rhi::GraphicsPipelineDescription,
                            rhi::ComputePipelineDescription>>

--- a/engine/src/liquid/renderer/RendererOptions.h
+++ b/engine/src/liquid/renderer/RendererOptions.h
@@ -1,0 +1,15 @@
+#pragma once
+
+namespace liquid {
+
+/**
+ * @brief Renderer options
+ */
+struct RendererOptions {
+  /**
+   * Framebuffer size
+   */
+  glm::uvec2 size;
+};
+
+} // namespace liquid

--- a/engine/src/liquid/renderer/SceneRenderer.h
+++ b/engine/src/liquid/renderer/SceneRenderer.h
@@ -3,6 +3,7 @@
 #include "liquid/rhi/RenderCommandList.h"
 #include "liquid/renderer/RenderGraph.h"
 #include "liquid/asset/AssetRegistry.h"
+#include "liquid/renderer/RendererOptions.h"
 #include "SceneRendererFrameData.h"
 
 namespace liquid {
@@ -63,9 +64,11 @@ public:
    * @brief Attach passes to render graph
    *
    * @param graph Render graph
+   * @param options Renderer options
    * @return Scene render pass data
    */
-  SceneRenderPassData attach(RenderGraph &graph);
+  SceneRenderPassData attach(RenderGraph &graph,
+                             const RendererOptions &options);
 
   /**
    * @brief Attach text pass to render graph

--- a/engine/src/liquid/scripting/ScriptingSystem.cpp
+++ b/engine/src/liquid/scripting/ScriptingSystem.cpp
@@ -125,8 +125,9 @@ void ScriptingSystem::createScriptingData(Script &component, Entity entity) {
         KeyboardEvent::Pressed, [this, &component](const auto &data) {
           component.scope.luaGetGlobal("on_key_press");
 
-          auto table = component.scope.createTable(1);
+          auto table = component.scope.createTable(2);
           table.set("key", data.key);
+          table.set("mods", data.mods);
 
           component.scope.call(1);
         });
@@ -136,8 +137,9 @@ void ScriptingSystem::createScriptingData(Script &component, Entity entity) {
     component.onKeyRelease = mEventSystem.observe(
         KeyboardEvent::Released, [this, &component](const auto &data) {
           component.scope.luaGetGlobal("on_key_release");
-          auto table = component.scope.createTable(1);
+          auto table = component.scope.createTable(2);
           table.set("key", data.key);
+          table.set("mods", data.mods);
 
           component.scope.call(1);
         });

--- a/engine/tests/fixtures/scripting-system-tester.lua
+++ b/engine/tests/fixtures/scripting-system-tester.lua
@@ -2,6 +2,7 @@ value = 0
 event = 0
 target = -1
 key_value = -1
+key_mods = -1
 global_dt = 0.0
 
 function start()
@@ -26,9 +27,11 @@ end
 function on_key_press(key)
     event = 3
     key_value = key.key
+    key_mods = key.mods
 end
 
 function on_key_release(key)
     event = 4
     key_value = key.key
+    key_mods = key.mods
 end

--- a/engine/tests/liquid-tests/scripting/ScriptingSystem.test.cpp
+++ b/engine/tests/liquid-tests/scripting/ScriptingSystem.test.cpp
@@ -335,12 +335,13 @@ TEST_F(ScriptingSystemTest, CallsScriptKeyPressEventIfKeyIsPressed) {
 
   scriptingSystem.start(entityDatabase);
 
-  eventSystem.dispatch(liquid::KeyboardEvent::Pressed, {15});
+  eventSystem.dispatch(liquid::KeyboardEvent::Pressed, {15, -1, 3});
   eventSystem.poll();
 
   auto *luaScope = component.scope.getLuaState();
   EXPECT_EQ(component.scope.getGlobal<int32_t>("event"), 3);
   EXPECT_EQ(component.scope.getGlobal<int32_t>("key_value"), 15);
+  EXPECT_EQ(component.scope.getGlobal<int32_t>("key_mods"), 3);
 }
 
 TEST_F(ScriptingSystemTest, CallsScriptKeyReleaseEventIfKeyIsReleased) {
@@ -355,9 +356,10 @@ TEST_F(ScriptingSystemTest, CallsScriptKeyReleaseEventIfKeyIsReleased) {
 
   scriptingSystem.start(entityDatabase);
 
-  eventSystem.dispatch(liquid::KeyboardEvent::Released, {35});
+  eventSystem.dispatch(liquid::KeyboardEvent::Released, {35, -1, 3});
   eventSystem.poll();
 
   EXPECT_EQ(component.scope.getGlobal<int32_t>("event"), 4);
   EXPECT_EQ(component.scope.getGlobal<int32_t>("key_value"), 35);
+  EXPECT_EQ(component.scope.getGlobal<int32_t>("key_mods"), 3);
 }


### PR DESCRIPTION
- Remove size based texture creation from render graph
- Remove render graph dirty flag
- Add render graph to renderer
- Add renderer options
- Create imgui texture as a transient resource
- Create all scene textures as transient resources
- Get rid of framebuffer relative textures in render storage
- Fix camera aspect ratio calculation error when window is minimized
- Destroy bindless params on render graph recreate
- Add mods to keyboard event in scripting system