### PR TITLE
Reduce the number of pipeline barriers between passes in render graph

### DIFF
--- a/editor/src/liquidator/asset/HDRIImporter.cpp
+++ b/editor/src/liquidator/asset/HDRIImporter.cpp
@@ -280,7 +280,7 @@ HDRIImporter::convertEquirectangularToCubemap(float *data, uint32_t width,
 
     commandList.pipelineBarrier(rhi::PipelineStage::PipeTop,
                                 rhi::PipelineStage::ComputeShader,
-                                memoryBarriers, imageBarriers);
+                                memoryBarriers, imageBarriers, {});
 
     commandList.bindPipeline(mPipelineGenerateCubemap);
     commandList.bindDescriptor(mPipelineGenerateCubemap, 0,
@@ -341,7 +341,7 @@ HDRIImporter::generateIrradianceMap(const CubemapData &unfilteredCubemap,
 
   commandList.pipelineBarrier(rhi::PipelineStage::PipeTop,
                               rhi::PipelineStage::ComputeShader, memoryBarriers,
-                              imageBarriers);
+                              imageBarriers, {});
 
   commandList.bindPipeline(mPipelineGenerateIrradianceMap);
   commandList.bindDescriptor(mPipelineGenerateIrradianceMap, 0,

--- a/engine/rhi/core/include/liquid/rhi/NativeRenderCommandListInterface.h
+++ b/engine/rhi/core/include/liquid/rhi/NativeRenderCommandListInterface.h
@@ -158,10 +158,12 @@ public:
    * @param dstStage Destination pipeline stage
    * @param memoryBarriers Memory barriers
    * @param imageBarriers Image barriers
+   * @param bufferBarriers Buffer barriers
    */
   virtual void pipelineBarrier(PipelineStage srcStage, PipelineStage dstStage,
                                std::span<MemoryBarrier> memoryBarriers,
-                               std::span<ImageBarrier> imageBarriers) = 0;
+                               std::span<ImageBarrier> imageBarriers,
+                               std::span<BufferBarrier> bufferBarriers) = 0;
 
   /**
    * @brief Copy texture to buffer

--- a/engine/rhi/core/include/liquid/rhi/PipelineBarrier.h
+++ b/engine/rhi/core/include/liquid/rhi/PipelineBarrier.h
@@ -61,4 +61,34 @@ struct ImageBarrier {
   uint32_t levelCount = 1;
 };
 
+/**
+ * @brief Buffer barrier
+ */
+struct BufferBarrier {
+  /**
+   * Source access flags
+   */
+  Access srcAccess{Access::None};
+
+  /**
+   * Destination access flags
+   */
+  Access dstAccess{Access::None};
+
+  /**
+   * Buffer handle
+   */
+  BufferHandle buffer = BufferHandle::Null;
+
+  /**
+   * Buffer offset
+   */
+  uint32_t offset = 0;
+
+  /**
+   * Buffer size
+   */
+  uint32_t size = 0;
+};
+
 } // namespace liquid::rhi

--- a/engine/rhi/core/include/liquid/rhi/RenderCommandList.h
+++ b/engine/rhi/core/include/liquid/rhi/RenderCommandList.h
@@ -213,12 +213,14 @@ public:
    * @param dstStage Destination pipeline stage
    * @param memoryBarriers Memory barriers
    * @param imageBarriers Image barriers
+   * @param bufferBarriers Buffer barriers
    */
   inline void pipelineBarrier(PipelineStage srcStage, PipelineStage dstStage,
                               std::span<MemoryBarrier> memoryBarriers,
-                              std::span<ImageBarrier> imageBarriers) {
-    mNativeRenderCommandList->pipelineBarrier(srcStage, dstStage,
-                                              memoryBarriers, imageBarriers);
+                              std::span<ImageBarrier> imageBarriers,
+                              std::span<BufferBarrier> bufferBarriers) {
+    mNativeRenderCommandList->pipelineBarrier(
+        srcStage, dstStage, memoryBarriers, imageBarriers, bufferBarriers);
   }
 
   /**

--- a/engine/rhi/mock/include/liquid/rhi-mock/MockCommand.h
+++ b/engine/rhi/mock/include/liquid/rhi-mock/MockCommand.h
@@ -305,6 +305,11 @@ struct MockCommandPipelineBarrier
    * Image barriers
    */
   std::vector<ImageBarrier> imageBarriers;
+
+  /**
+   * Buffer barriers
+   */
+  std::vector<BufferBarrier> bufferBarriers;
 };
 
 /**

--- a/engine/rhi/mock/include/liquid/rhi-mock/MockCommandList.h
+++ b/engine/rhi/mock/include/liquid/rhi-mock/MockCommandList.h
@@ -148,10 +148,12 @@ public:
    * @param dstStage Destination pipeline stage
    * @param memoryBarriers Memory barriers
    * @param imageBarriers Image barriers
+   * @param bufferBarriers Buffer barriers
    */
   void pipelineBarrier(PipelineStage srcStage, PipelineStage dstStage,
                        std::span<MemoryBarrier> memoryBarriers,
-                       std::span<ImageBarrier> imageBarriers) override;
+                       std::span<ImageBarrier> imageBarriers,
+                       std::span<BufferBarrier> bufferBarriers) override;
 
   /**
    * @brief Copy texture to buffer

--- a/engine/rhi/mock/src/MockCommandList.cpp
+++ b/engine/rhi/mock/src/MockCommandList.cpp
@@ -154,11 +154,14 @@ void MockCommandList::setScissor(const glm::ivec2 &offset,
 void MockCommandList::pipelineBarrier(PipelineStage srcStage,
                                       PipelineStage dstStage,
                                       std::span<MemoryBarrier> memoryBarriers,
-                                      std::span<ImageBarrier> imageBarriers) {
+                                      std::span<ImageBarrier> imageBarriers,
+                                      std::span<BufferBarrier> bufferBarriers) {
   auto *command = new MockCommandPipelineBarrier;
-  command->srcStage = dstStage;
+  command->srcStage = srcStage;
+  command->dstStage = dstStage;
   command->memoryBarriers = vectorFrom(memoryBarriers);
   command->imageBarriers = vectorFrom(imageBarriers);
+  command->bufferBarriers = vectorFrom(bufferBarriers);
   mCommands.push_back(std::unique_ptr<MockCommand>(command));
 }
 

--- a/engine/rhi/vulkan/include/liquid/rhi-vulkan/VulkanCommandBuffer.h
+++ b/engine/rhi/vulkan/include/liquid/rhi-vulkan/VulkanCommandBuffer.h
@@ -168,10 +168,12 @@ public:
    * @param dstStage Destination pipeline stage
    * @param memoryBarriers Memory barriers
    * @param imageBarriers Image barriers
+   * @param bufferBarriers Buffer barriers
    */
   void pipelineBarrier(PipelineStage srcStage, PipelineStage dstStage,
                        std::span<MemoryBarrier> memoryBarriers,
-                       std::span<ImageBarrier> imageBarriers) override;
+                       std::span<ImageBarrier> imageBarriers,
+                       std::span<BufferBarrier> bufferBarriers) override;
 
   /**
    * @brief Copy texture to buffer

--- a/engine/src/liquid/renderer/Presenter.cpp
+++ b/engine/src/liquid/renderer/Presenter.cpp
@@ -136,7 +136,7 @@ void Presenter::present(rhi::RenderCommandList &commandList,
     std::array<rhi::ImageBarrier, 1> barriers{imageBarrier};
     commandList.pipelineBarrier(rhi::PipelineStage::ColorAttachmentOutput,
                                 rhi::PipelineStage::FragmentShader, {},
-                                barriers);
+                                barriers, {});
   }
 
   commandList.beginRenderPass(
@@ -165,7 +165,7 @@ void Presenter::present(rhi::RenderCommandList &commandList,
     std::array<rhi::ImageBarrier, 1> barriers{imageBarrier};
     commandList.pipelineBarrier(rhi::PipelineStage::FragmentShader,
                                 rhi::PipelineStage::ColorAttachmentOutput, {},
-                                barriers);
+                                barriers, {});
   }
 }
 

--- a/engine/src/liquid/renderer/RenderGraphPass.h
+++ b/engine/src/liquid/renderer/RenderGraphPass.h
@@ -101,6 +101,11 @@ struct RenderGraphPassBarrier {
    * Image barriers
    */
   std::vector<rhi::ImageBarrier> imageBarriers;
+
+  /**
+   * Buffer barriers
+   */
+  std::vector<rhi::BufferBarrier> bufferBarriers;
 };
 
 /**
@@ -305,21 +310,12 @@ public:
   inline const glm::uvec3 &getDimensions() const { return mDimensions; }
 
   /**
-   * @brief Get pass pre barrier
+   * @brief Get pass synchronization dependencies
    *
-   * @return Pass pre barrier
+   * @return Pass syncronization dependencies
    */
-  inline const RenderGraphPassBarrier &getPreBarrier() const {
-    return mPreBarrier;
-  }
-
-  /**
-   * @brief Get pass pre barrier
-   *
-   * @return Pass pre barrier
-   */
-  inline const RenderGraphPassBarrier &getPostBarrier() const {
-    return mPostBarrier;
+  inline const RenderGraphPassBarrier &getSyncDependencies() const {
+    return mDependencies;
   }
 
 private:
@@ -330,8 +326,7 @@ private:
   std::vector<RenderGraphPassBufferData> mBufferInputs;
   std::vector<RenderGraphPassBufferData> mBufferOutputs;
 
-  RenderGraphPassBarrier mPreBarrier;
-  RenderGraphPassBarrier mPostBarrier;
+  RenderGraphPassBarrier mDependencies;
 
   ExecutorFn mExecutor;
 

--- a/engine/src/liquid/renderer/RenderGraphSyncDependency.cpp
+++ b/engine/src/liquid/renderer/RenderGraphSyncDependency.cpp
@@ -1,0 +1,86 @@
+#include "liquid/core/Base.h"
+#include "RenderGraphSyncDependency.h"
+
+namespace liquid {
+
+RenderGraphTextureSyncDependency
+RenderGraphSyncDependency::getTextureRead(RenderGraphPassType type) {
+  if (type == RenderGraphPassType::Compute) {
+    return {rhi::PipelineStage::ComputeShader, rhi::Access::ShaderRead,
+            rhi::ImageLayout::ShaderReadOnlyOptimal};
+  }
+
+  return {rhi::PipelineStage::FragmentShader, rhi::Access::ShaderRead,
+          rhi::ImageLayout::ShaderReadOnlyOptimal};
+}
+
+RenderGraphTextureSyncDependency
+RenderGraphSyncDependency::getTextureWrite(RenderGraphPassType type,
+                                           AttachmentType attachmentType) {
+  if (type == RenderGraphPassType::Compute) {
+    return {rhi::PipelineStage::ComputeShader, rhi::Access::ShaderWrite,
+            rhi::ImageLayout::General};
+  }
+
+  if (attachmentType == AttachmentType::Color ||
+      attachmentType == AttachmentType::Resolve) {
+    return {rhi::PipelineStage::ColorAttachmentOutput,
+            rhi::Access::ColorAttachmentWrite,
+            rhi::ImageLayout::ColorAttachmentOptimal};
+  }
+
+  if (attachmentType == AttachmentType::Depth) {
+    return {rhi::PipelineStage::EarlyFragmentTests |
+                rhi::PipelineStage::LateFragmentTests,
+            rhi::Access::DepthStencilAttachmentWrite,
+            rhi::ImageLayout::DepthStencilAttachmentOptimal};
+  }
+
+  return {rhi::PipelineStage::None, rhi::Access::None,
+          rhi::ImageLayout::Undefined};
+}
+
+RenderGraphBufferSyncDependency
+RenderGraphSyncDependency::getBufferWrite(RenderGraphPassType type) {
+  if (type == RenderGraphPassType::Compute) {
+    return {rhi::PipelineStage::ComputeShader, rhi::Access::ShaderWrite};
+  }
+
+  return {rhi::PipelineStage::FragmentShader, rhi::Access::ShaderWrite};
+}
+
+RenderGraphBufferSyncDependency
+RenderGraphSyncDependency::getBufferRead(RenderGraphPassType type,
+                                         rhi::BufferUsage usage) {
+  if (type == RenderGraphPassType::Compute) {
+    return {rhi::PipelineStage::ComputeShader, rhi::Access::ShaderRead};
+  }
+
+  rhi::Access access = rhi::Access::None;
+  rhi::PipelineStage stage = rhi::PipelineStage::None;
+
+  if (BitwiseEnumContains(usage, rhi::BufferUsage::Vertex)) {
+    stage |= rhi::PipelineStage::VertexInput;
+    access |= rhi::Access::VertexAttributeRead;
+  }
+
+  if (BitwiseEnumContains(usage, rhi::BufferUsage::Index)) {
+    stage |= rhi::PipelineStage::VertexInput;
+    access |= rhi::Access::IndexRead;
+  }
+
+  if (BitwiseEnumContains(usage, rhi::BufferUsage::Indirect)) {
+    stage |= rhi::PipelineStage::DrawIndirect;
+    access |= rhi::Access::IndirectCommandRead;
+  }
+
+  if (BitwiseEnumContains(usage, rhi::BufferUsage::Uniform) ||
+      BitwiseEnumContains(usage, rhi::BufferUsage::Storage)) {
+    stage |= rhi::PipelineStage::FragmentShader;
+    access |= rhi::Access::ShaderRead;
+  }
+
+  return {stage, access};
+}
+
+} // namespace liquid

--- a/engine/src/liquid/renderer/RenderGraphSyncDependency.h
+++ b/engine/src/liquid/renderer/RenderGraphSyncDependency.h
@@ -1,0 +1,86 @@
+#pragma once
+
+#include "RenderGraphPass.h"
+
+namespace liquid {
+
+/**
+ * @brief Render graph texture sync dependency
+ */
+struct RenderGraphTextureSyncDependency {
+  /**
+   * Pipeline stage
+   */
+  rhi::PipelineStage stage;
+
+  /**
+   * Access
+   */
+  rhi::Access access;
+
+  /**
+   * Image layout
+   */
+  rhi::ImageLayout layout;
+};
+
+/**
+ * @brief Render graph buffer sync dependency
+ */
+struct RenderGraphBufferSyncDependency {
+  /**
+   * Pipeline stage
+   */
+  rhi::PipelineStage stage;
+
+  /**
+   * Access
+   */
+  rhi::Access access;
+};
+
+/**
+ * @brief Render graph sync dependency utilities
+ */
+class RenderGraphSyncDependency {
+public:
+  /**
+   * @brief Get sync dependency for texture read operation
+   *
+   * @param type Render graph pass type
+   * @return Render graph texture sync dependency
+   */
+  static RenderGraphTextureSyncDependency
+  getTextureRead(RenderGraphPassType type);
+
+  /**
+   * @brief Get sync dependency for texture write operation
+   *
+   * @param type Render graph pass type
+   * @param attachmentType Attachment type
+   * @return Render graph texture sync dependency
+   */
+  static RenderGraphTextureSyncDependency
+  getTextureWrite(RenderGraphPassType type, AttachmentType attachmentType);
+
+  /**
+   * @brief Get sync dependency for buffer read
+   *
+   * @param type Render graph pass type
+   * @param usage Buffer usage
+   * @return Render graph buffer sync dependency
+   */
+  static RenderGraphBufferSyncDependency getBufferRead(RenderGraphPassType type,
+                                                       rhi::BufferUsage usage);
+
+  /**
+   * @brief Get sync dependency for buffer write
+   *
+   * @param type Render graph pass type
+   * @return Render graph buffer sync dependency
+   */
+  static RenderGraphBufferSyncDependency
+  getBufferWrite(RenderGraphPassType type);
+};
+
+} // namespace liquid

--- a/engine/src/liquid/renderer/TextureUtils.cpp
+++ b/engine/src/liquid/renderer/TextureUtils.cpp
@@ -28,7 +28,8 @@ void TextureUtils::copyDataToTexture(
 
   std::array<rhi::ImageBarrier, 1> preBarriers{barrier};
   commandList.pipelineBarrier(rhi::PipelineStage::PipeTop,
-                              rhi::PipelineStage::Transfer, {}, preBarriers);
+                              rhi::PipelineStage::Transfer, {}, preBarriers,
+                              {});
 
   std::vector<rhi::CopyRegion> copies(destinationLevels.size());
   for (size_t i = 0; i < copies.size(); ++i) {
@@ -52,7 +53,8 @@ void TextureUtils::copyDataToTexture(
   barrier.dstAccess = rhi::Access::None;
   std::array<rhi::ImageBarrier, 1> postBarriers{barrier};
   commandList.pipelineBarrier(rhi::PipelineStage::Transfer,
-                              rhi::PipelineStage::PipeTop, {}, postBarriers);
+                              rhi::PipelineStage::PipeTop, {}, postBarriers,
+                              {});
 
   device->submitImmediate(commandList);
 
@@ -83,7 +85,8 @@ void TextureUtils::copyTextureToData(
 
   std::array<rhi::ImageBarrier, 1> preBarriers{barrier};
   commandList.pipelineBarrier(rhi::PipelineStage::PipeTop,
-                              rhi::PipelineStage::Transfer, {}, preBarriers);
+                              rhi::PipelineStage::Transfer, {}, preBarriers,
+                              {});
 
   std::vector<rhi::CopyRegion> copies(sourceLevels.size());
   for (size_t i = 0; i < copies.size(); ++i) {
@@ -106,7 +109,8 @@ void TextureUtils::copyTextureToData(
   barrier.dstAccess = rhi::Access::None;
   std::array<rhi::ImageBarrier, 1> postBarriers{barrier};
   commandList.pipelineBarrier(rhi::PipelineStage::Transfer,
-                              rhi::PipelineStage::PipeTop, {}, postBarriers);
+                              rhi::PipelineStage::PipeTop, {}, postBarriers,
+                              {});
 
   device->submitImmediate(commandList);
 
@@ -135,7 +139,8 @@ void TextureUtils::generateMipMapsForTexture(rhi::RenderDevice *device,
 
   std::array<rhi::ImageBarrier, 1> preBarriers{barrier};
   commandList.pipelineBarrier(rhi::PipelineStage::Transfer,
-                              rhi::PipelineStage::Transfer, {}, preBarriers);
+                              rhi::PipelineStage::Transfer, {}, preBarriers,
+                              {});
 
   barrier.srcAccess = rhi::Access::TransferWrite;
   barrier.dstAccess = rhi::Access::TransferRead;
@@ -150,7 +155,7 @@ void TextureUtils::generateMipMapsForTexture(rhi::RenderDevice *device,
     barrier.baseLevel = i - 1;
     std::array<rhi::ImageBarrier, 1> barriers{barrier};
     commandList.pipelineBarrier(rhi::PipelineStage::Transfer,
-                                rhi::PipelineStage::Transfer, {}, barriers);
+                                rhi::PipelineStage::Transfer, {}, barriers, {});
 
     rhi::BlitRegion region{};
     region.srcOffsets.at(0) = {0, 0, 0};
@@ -183,7 +188,8 @@ void TextureUtils::generateMipMapsForTexture(rhi::RenderDevice *device,
 
   std::array<rhi::ImageBarrier, 1> postBarriers{barrier};
   commandList.pipelineBarrier(rhi::PipelineStage::Transfer,
-                              rhi::PipelineStage::PipeTop, {}, postBarriers);
+                              rhi::PipelineStage::PipeTop, {}, postBarriers,
+                              {});
 
   device->submitImmediate(commandList);
 }

--- a/engine/tests/liquid-tests/renderer/RenderGraphSyncDependency.test.cpp
+++ b/engine/tests/liquid-tests/renderer/RenderGraphSyncDependency.test.cpp
@@ -1,0 +1,185 @@
+#include "liquid/core/Base.h"
+#include "liquid-tests/Testing.h"
+
+#include "liquid/renderer/RenderGraphSyncDependency.h"
+
+class RenderGraphSyncDependencyTextureReadTest : public ::testing::Test {};
+
+TEST_F(RenderGraphSyncDependencyTextureReadTest,
+       ReturnsComputeShaderWhenPassIsCompute) {
+  auto dependency = liquid::RenderGraphSyncDependency::getTextureRead(
+      liquid::RenderGraphPassType::Compute);
+
+  EXPECT_EQ(dependency.stage, liquid::rhi::PipelineStage::ComputeShader);
+  EXPECT_EQ(dependency.access, liquid::rhi::Access::ShaderRead);
+  EXPECT_EQ(dependency.layout, liquid::rhi::ImageLayout::ShaderReadOnlyOptimal);
+}
+
+TEST_F(RenderGraphSyncDependencyTextureReadTest,
+       ReturnsFragmentShaderDependencyWhenPassIsGraphics) {
+  auto dependency = liquid::RenderGraphSyncDependency::getTextureRead(
+      liquid::RenderGraphPassType::Graphics);
+
+  EXPECT_EQ(dependency.stage, liquid::rhi::PipelineStage::FragmentShader);
+  EXPECT_EQ(dependency.access, liquid::rhi::Access::ShaderRead);
+  EXPECT_EQ(dependency.layout, liquid::rhi::ImageLayout::ShaderReadOnlyOptimal);
+}
+
+class RenderGraphSyncDependencyTextureWriteTest : public ::testing::Test {};
+
+TEST_F(RenderGraphSyncDependencyTextureWriteTest,
+       ReturnsColorAttachmentWriteWhenPassIsGraphicsAndAttachmentIsColor) {
+  auto dependency = liquid::RenderGraphSyncDependency::getTextureWrite(
+      liquid::RenderGraphPassType::Graphics, liquid::AttachmentType::Color);
+
+  EXPECT_EQ(dependency.stage,
+            liquid::rhi::PipelineStage::ColorAttachmentOutput);
+  EXPECT_EQ(dependency.access, liquid::rhi::Access::ColorAttachmentWrite);
+  EXPECT_EQ(dependency.layout,
+            liquid::rhi::ImageLayout::ColorAttachmentOptimal);
+}
+
+TEST_F(RenderGraphSyncDependencyTextureWriteTest,
+       ReturnsColorAttachmentWriteWhenPassIsGraphicsAndAttachmentIsResolve) {
+  auto dependency = liquid::RenderGraphSyncDependency::getTextureWrite(
+      liquid::RenderGraphPassType::Graphics, liquid::AttachmentType::Resolve);
+
+  EXPECT_EQ(dependency.stage,
+            liquid::rhi::PipelineStage::ColorAttachmentOutput);
+  EXPECT_EQ(dependency.access, liquid::rhi::Access::ColorAttachmentWrite);
+  EXPECT_EQ(dependency.layout,
+            liquid::rhi::ImageLayout::ColorAttachmentOptimal);
+}
+
+TEST_F(RenderGraphSyncDependencyTextureWriteTest,
+       ReturnsDepthAttachmentWriteWhenPassIsGraphicsAndAttachmentIsDepth) {
+  auto dependency = liquid::RenderGraphSyncDependency::getTextureWrite(
+      liquid::RenderGraphPassType::Graphics, liquid::AttachmentType::Depth);
+
+  EXPECT_EQ(dependency.stage,
+            liquid::rhi::PipelineStage::EarlyFragmentTests |
+                liquid::rhi::PipelineStage::LateFragmentTests);
+  EXPECT_EQ(dependency.access,
+            liquid::rhi::Access::DepthStencilAttachmentWrite);
+  EXPECT_EQ(dependency.layout,
+            liquid::rhi::ImageLayout::DepthStencilAttachmentOptimal);
+}
+
+TEST_F(RenderGraphSyncDependencyTextureWriteTest,
+       ReturnsComputeShaderWhenPassIsComputeAndAttachmentIsColor) {
+  auto dependency = liquid::RenderGraphSyncDependency::getTextureWrite(
+      liquid::RenderGraphPassType::Compute, liquid::AttachmentType::Color);
+
+  EXPECT_EQ(dependency.stage, liquid::rhi::PipelineStage::ComputeShader);
+  EXPECT_EQ(dependency.access, liquid::rhi::Access::ShaderWrite);
+  EXPECT_EQ(dependency.layout, liquid::rhi::ImageLayout::General);
+}
+
+TEST_F(RenderGraphSyncDependencyTextureWriteTest,
+       ReturnsComputeShaderWhenPassIsComputeAndAttachmentIsResolve) {
+  auto dependency = liquid::RenderGraphSyncDependency::getTextureWrite(
+      liquid::RenderGraphPassType::Compute, liquid::AttachmentType::Resolve);
+
+  EXPECT_EQ(dependency.stage, liquid::rhi::PipelineStage::ComputeShader);
+  EXPECT_EQ(dependency.access, liquid::rhi::Access::ShaderWrite);
+  EXPECT_EQ(dependency.layout, liquid::rhi::ImageLayout::General);
+}
+
+TEST_F(RenderGraphSyncDependencyTextureWriteTest,
+       ReturnsComputeShaderWhenPassIsComputeAndAttachmentIsDepth) {
+  auto dependency = liquid::RenderGraphSyncDependency::getTextureWrite(
+      liquid::RenderGraphPassType::Compute, liquid::AttachmentType::Depth);
+
+  EXPECT_EQ(dependency.stage, liquid::rhi::PipelineStage::ComputeShader);
+  EXPECT_EQ(dependency.access, liquid::rhi::Access::ShaderWrite);
+  EXPECT_EQ(dependency.layout, liquid::rhi::ImageLayout::General);
+}
+
+class RenderGraphSyncDependencyBufferReadTest : public ::testing::Test {};
+
+TEST_F(RenderGraphSyncDependencyBufferReadTest,
+       ReturnsComputeShaderWhenPassIsCompute) {
+  auto dependency = liquid::RenderGraphSyncDependency::getBufferRead(
+      liquid::RenderGraphPassType::Compute, liquid::rhi::BufferUsage::Indirect);
+
+  EXPECT_EQ(dependency.stage, liquid::rhi::PipelineStage::ComputeShader);
+  EXPECT_EQ(dependency.access, liquid::rhi::Access::ShaderRead);
+}
+
+TEST_F(RenderGraphSyncDependencyBufferReadTest,
+       ReturnsVertexReadWhenPassIsGraphicsAndUsageIncludesVertex) {
+  auto dependency = liquid::RenderGraphSyncDependency::getBufferRead(
+      liquid::RenderGraphPassType::Graphics, liquid::rhi::BufferUsage::Vertex);
+
+  EXPECT_EQ(dependency.stage, liquid::rhi::PipelineStage::VertexInput);
+  EXPECT_EQ(dependency.access, liquid::rhi::Access::VertexAttributeRead);
+}
+
+TEST_F(RenderGraphSyncDependencyBufferReadTest,
+       ReturnsIndexReadWhenPassIsGraphicsAndUsageIncludesIndex) {
+  auto dependency = liquid::RenderGraphSyncDependency::getBufferRead(
+      liquid::RenderGraphPassType::Graphics, liquid::rhi::BufferUsage::Index);
+
+  EXPECT_EQ(dependency.stage, liquid::rhi::PipelineStage::VertexInput);
+  EXPECT_EQ(dependency.access, liquid::rhi::Access::IndexRead);
+}
+
+TEST_F(RenderGraphSyncDependencyBufferReadTest,
+       ReturnsIndirectReadWhenPassIsGraphicsAndUsageIncludesIndirect) {
+  auto dependency = liquid::RenderGraphSyncDependency::getBufferRead(
+      liquid::RenderGraphPassType::Graphics,
+      liquid::rhi::BufferUsage::Indirect);
+
+  EXPECT_EQ(dependency.stage, liquid::rhi::PipelineStage::DrawIndirect);
+  EXPECT_EQ(dependency.access, liquid::rhi::Access::IndirectCommandRead);
+}
+
+TEST_F(RenderGraphSyncDependencyBufferReadTest,
+       ReturnsFragmentShaderReadWhenBufferUsageIncludesUniform) {
+  auto dependency = liquid::RenderGraphSyncDependency::getBufferRead(
+      liquid::RenderGraphPassType::Graphics, liquid::rhi::BufferUsage::Uniform);
+
+  EXPECT_EQ(dependency.stage, liquid::rhi::PipelineStage::FragmentShader);
+  EXPECT_EQ(dependency.access, liquid::rhi::Access::ShaderRead);
+}
+
+TEST_F(RenderGraphSyncDependencyBufferReadTest,
+       ReturnsFragmentShaderReadWhenBufferUsageIncludesStorage) {
+  auto dependency = liquid::RenderGraphSyncDependency::getBufferRead(
+      liquid::RenderGraphPassType::Graphics, liquid::rhi::BufferUsage::Storage);
+
+  EXPECT_EQ(dependency.stage, liquid::rhi::PipelineStage::FragmentShader);
+  EXPECT_EQ(dependency.access, liquid::rhi::Access::ShaderRead);
+}
+
+TEST_F(RenderGraphSyncDependencyBufferReadTest,
+       ReturnsMultipleStagesForMultipleUsage) {
+  auto dependency = liquid::RenderGraphSyncDependency::getBufferRead(
+      liquid::RenderGraphPassType::Graphics,
+      liquid::rhi::BufferUsage::Storage | liquid::rhi::BufferUsage::Vertex);
+
+  EXPECT_EQ(dependency.stage, liquid::rhi::PipelineStage::FragmentShader |
+                                  liquid::rhi::PipelineStage::VertexInput);
+  EXPECT_EQ(dependency.access, liquid::rhi::Access::ShaderRead |
+                                   liquid::rhi::Access::VertexAttributeRead);
+}
+
+class RenderGraphSyncDependencyBufferWriteTest : public ::testing::Test {};
+
+TEST_F(RenderGraphSyncDependencyBufferWriteTest,
+       ReturnsComputeShaderWhenPassIsCompute) {
+  auto dependency = liquid::RenderGraphSyncDependency::getBufferWrite(
+      liquid::RenderGraphPassType::Compute);
+
+  EXPECT_EQ(dependency.stage, liquid::rhi::PipelineStage::ComputeShader);
+  EXPECT_EQ(dependency.access, liquid::rhi::Access::ShaderWrite);
+}
+
+TEST_F(RenderGraphSyncDependencyBufferWriteTest,
+       ReturnsFragmentShaderWhenPassIsGraphics) {
+  auto dependency = liquid::RenderGraphSyncDependency::getBufferWrite(
+      liquid::RenderGraphPassType::Graphics);
+
+  EXPECT_EQ(dependency.stage, liquid::rhi::PipelineStage::FragmentShader);
+  EXPECT_EQ(dependency.access, liquid::rhi::Access::ShaderWrite);
+}


### PR DESCRIPTION
- Remove old barrier system for textures and buffers
- Use only image barriers for render targets
- Use only buffer barriers for buffers
- Add buffer barriers to pipeline barrier command