### PR TITLE
Add Bloom

### DIFF
--- a/editor/assets/shaders/object-icons.frag
+++ b/editor/assets/shaders/object-icons.frag
@@ -7,6 +7,7 @@ layout(location = 0) out vec4 outColor;
 #include "bindless-editor.glsl"
 
 layout(set = 0, binding = 0) uniform sampler2D uGlobalTextures[];
+layout(set = 0, binding = 1) writeonly uniform image2D uGlobalImages[];
 
 layout(set = 1, binding = 0) uniform DrawParameters {
   Empty gizmoTransforms;

--- a/editor/src/liquidator/asset/gltf/MaterialStep.cpp
+++ b/editor/src/liquidator/asset/gltf/MaterialStep.cpp
@@ -82,6 +82,18 @@ void loadMaterials(GLTFImportData &importData) {
     material.data.emissiveFactor =
         glm::vec3{emissiveFactor[0], emissiveFactor[1], emissiveFactor[2]};
 
+    auto emissiveStrengthExt =
+        gltfMaterial.extensions.find("KHR_materials_emissive_strength");
+
+    if (emissiveStrengthExt != gltfMaterial.extensions.end() &&
+        emissiveStrengthExt->second.IsObject()) {
+      auto strength = emissiveStrengthExt->second.Get("emissiveStrength");
+      if (strength.IsReal()) {
+        material.data.emissiveFactor *=
+            static_cast<float>(strength.GetNumberAsDouble());
+      }
+    }
+
     auto path = assetCache.createMaterialFromAsset(material);
     auto handle = assetCache.loadMaterialFromFile(path.getData());
     importData.materials.map.insert_or_assign(i, handle.getData());

--- a/engine/assets/shaders/bindless/base.glsl
+++ b/engine/assets/shaders/bindless/base.glsl
@@ -4,6 +4,7 @@
 #define Bindless 1
 #define BindlessDescriptorSet 0
 #define BindlessTexturesBinding 0
+#define BindlessImagesBinding 1
 
 #define Buffer(alignment)                                                      \
   layout(buffer_reference, std430, buffer_reference_align = alignment) buffer

--- a/engine/assets/shaders/bloom-downsample.comp
+++ b/engine/assets/shaders/bloom-downsample.comp
@@ -1,0 +1,74 @@
+#version 450
+#extension GL_ARB_separate_shader_objects : enable
+#extension GL_EXT_nonuniform_qualifier : require
+
+layout(local_size_x = 32, local_size_y = 32, local_size_z = 1) in;
+
+layout(set = 0, binding = 0) uniform sampler2D uGlobalTextures[];
+layout(set = 0, binding = 1) writeonly uniform image2D uGlobalImages[];
+
+layout(push_constant) uniform DrawParameters { uvec4 textures; };
+
+vec3 sampleSource(float x, float y) {
+  return texture(uGlobalTextures[textures.x], vec2(x, y)).rgb;
+}
+
+vec3 pow3(vec3 v, float p) {
+  return vec3(pow(v.x, p), pow(v.y, p), pow(v.z, p));
+}
+
+vec3 linearToSrgb(vec3 v) { return pow3(v, 1.0 / 2.2); }
+
+float karisAverage(vec3 col) {
+  float luma = dot(linearToSrgb(col), vec3(0.2126f, 0.7152f, 0.0722f)) * 0.25;
+  return 1.0 / (1.0 + luma);
+}
+
+void main() {
+  ivec2 dstSize = imageSize(uGlobalImages[textures.y]);
+  ivec2 dstUV = ivec2(gl_GlobalInvocationID.xy);
+
+  vec2 texel = 1.0 / vec2(imageSize(uGlobalImages[textures.x]));
+  vec2 texel2 = 2.0 * texel;
+
+  vec2 srcUV = (vec2(gl_GlobalInvocationID.xy) + vec2(0.5)) * 2.0 * texel;
+
+  vec3 a = sampleSource(srcUV.x - texel2.x, srcUV.y + texel2.y);
+  vec3 b = sampleSource(srcUV.x, srcUV.y + texel2.y);
+  vec3 c = sampleSource(srcUV.x + texel2.x, srcUV.y + texel2.y);
+
+  vec3 d = sampleSource(srcUV.x - texel2.x, srcUV.y);
+  vec3 e = sampleSource(srcUV.x, srcUV.y);
+  vec3 f = sampleSource(srcUV.x + texel2.x, srcUV.y);
+
+  vec3 g = sampleSource(srcUV.x - texel2.x, srcUV.y - texel2.y);
+  vec3 h = sampleSource(srcUV.x, srcUV.y - texel2.y);
+  vec3 i = sampleSource(srcUV.x + texel2.x, srcUV.y - texel2.y);
+
+  vec3 j = sampleSource(srcUV.x - texel.x, srcUV.y + texel.y);
+  vec3 k = sampleSource(srcUV.x + texel.x, srcUV.y + texel.y);
+  vec3 l = sampleSource(srcUV.x - texel.x, srcUV.y - texel.y);
+  vec3 m = sampleSource(srcUV.x + texel.x, srcUV.y - texel.y);
+
+  vec3 color = vec3(0.0);
+
+  if (textures.z == 0) {
+    vec3 c0 = (a + b + d + e) * (0.125 / 4.0);
+    vec3 c1 = (b + c + e + f) * (0.125 / 4.0);
+    vec3 c2 = (d + e + g + h) * (0.125 / 4.0);
+    vec3 c3 = (e + f + h + i) * (0.125 / 4.0);
+    vec3 c4 = (j + k + l + m) * (0.5 / 4.0);
+    c0 *= karisAverage(c0);
+    c1 *= karisAverage(c1);
+    c2 *= karisAverage(c2);
+    c3 *= karisAverage(c3);
+    c4 *= karisAverage(c4);
+    color = c0 + c1 + c2 + c3 + c4;
+  } else {
+    color = (a + c + g + i) * 0.03125;
+    color += (b + d + f + h) * 0.0625;
+    color += (e + j + k + l + m) * 0.125;
+  }
+
+  imageStore(uGlobalImages[textures.y], dstUV, vec4(color, 1.0));
+}

--- a/engine/assets/shaders/bloom-upsample.comp
+++ b/engine/assets/shaders/bloom-upsample.comp
@@ -1,0 +1,44 @@
+#version 450
+#extension GL_ARB_separate_shader_objects : enable
+#extension GL_EXT_nonuniform_qualifier : require
+
+layout(local_size_x = 32, local_size_y = 32, local_size_z = 1) in;
+
+layout(set = 0, binding = 0) uniform sampler2D uGlobalTextures[];
+layout(set = 0, binding = 1) writeonly uniform image2D uGlobalImages[];
+
+layout(push_constant) uniform DrawParameters { uvec4 textures; };
+
+vec3 sampleSource(float x, float y) {
+  return texture(uGlobalTextures[textures.x], vec2(x, y)).rgb;
+}
+
+void main() {
+  vec2 srcSize = vec2(imageSize(uGlobalImages[textures.x]));
+  vec2 texel = 1.0 / srcSize;
+
+  vec2 srcUV = (vec2(gl_GlobalInvocationID.xy) + 0.5) * texel * 0.5;
+
+  ivec2 dstUV = ivec2(gl_GlobalInvocationID.xy);
+
+  float aspectRatio = srcSize.x / srcSize.y;
+
+  const float RadiusConstant = 0.01;
+  vec2 radius = vec2(RadiusConstant, RadiusConstant * aspectRatio);
+
+  vec3 a = sampleSource(srcUV.x - radius.x, srcUV.y + radius.y);
+  vec3 b = sampleSource(srcUV.x, srcUV.y + radius.x);
+  vec3 c = sampleSource(srcUV.x + radius.x, srcUV.y + radius.y);
+
+  vec3 d = sampleSource(srcUV.x - radius.x, srcUV.y);
+  vec3 e = sampleSource(srcUV.x, srcUV.y);
+  vec3 f = sampleSource(srcUV.x + radius.x, srcUV.y);
+
+  vec3 g = sampleSource(srcUV.x - radius.x, srcUV.y - radius.y);
+  vec3 h = sampleSource(srcUV.x, srcUV.y - radius.y);
+  vec3 i = sampleSource(srcUV.x + radius.x, srcUV.y - radius.y);
+
+  vec3 color = e * 0.25 + (b + d + f + h) * 0.125 + (a + c + g + i) * 0.0625;
+
+  imageStore(uGlobalImages[textures.y], dstUV, vec4(color, 1.0));
+}

--- a/engine/assets/shaders/extract-bright-colors.comp
+++ b/engine/assets/shaders/extract-bright-colors.comp
@@ -1,0 +1,32 @@
+#version 450
+#extension GL_ARB_separate_shader_objects : enable
+#extension GL_EXT_nonuniform_qualifier : require
+#extension GL_EXT_debug_printf : enable
+
+layout(local_size_x = 32, local_size_y = 32, local_size_z = 1) in;
+
+layout(set = 0, binding = 0) uniform sampler2D uGlobalTextures[];
+layout(set = 0, binding = 1) writeonly uniform image2D uGlobalImages[];
+
+layout(push_constant) uniform DrawParameters { uvec4 textures; };
+
+const float BrightnessTreshold = 1.0;
+
+void main() {
+  uvec2 size = textureSize(uGlobalTextures[textures.y], 0);
+
+  vec2 texCoord = vec2(float(gl_GlobalInvocationID.x) / float(size.x),
+                       float(gl_GlobalInvocationID.y) / float(size.y));
+
+  vec4 color = texture(uGlobalTextures[textures.x], texCoord);
+
+  float brightness = 0.2126 * color.x + 0.7152 * color.y + 0.0722 * color.z;
+
+  if (brightness > BrightnessTreshold) {
+    imageStore(uGlobalImages[textures.y], ivec2(gl_GlobalInvocationID.xy),
+               color);
+  } else {
+    imageStore(uGlobalImages[textures.y], ivec2(gl_GlobalInvocationID.xy),
+               vec4(0.0));
+  }
+}

--- a/engine/assets/shaders/generate-brdf-lut.comp
+++ b/engine/assets/shaders/generate-brdf-lut.comp
@@ -1,6 +1,5 @@
 #version 450
 #extension GL_ARB_separate_shader_objects : enable
-#extension GL_EXT_debug_printf : enable
 
 #include "generate-ibl.glsl"
 

--- a/engine/assets/shaders/geometry-skinned.vert
+++ b/engine/assets/shaders/geometry-skinned.vert
@@ -18,8 +18,7 @@ layout(location = 3) out mat3 outTBN;
 #include "bindless/camera.glsl"
 
 layout(set = 0, binding = 0) uniform sampler2D uGlobalTextures[];
-layout(set = 0, binding = 0) uniform sampler2DArray uTextures2DArray[];
-layout(set = 0, binding = 0) uniform samplerCube uTexturesCube[];
+layout(set = 0, binding = 1) writeonly uniform image2D uGlobalImages[];
 
 layout(set = 1, binding = 0) uniform DrawParameters {
   TransformsArray meshTransforms;

--- a/engine/assets/shaders/geometry.vert
+++ b/engine/assets/shaders/geometry.vert
@@ -16,6 +16,8 @@ layout(location = 3) out mat3 outTBN;
 #include "bindless/camera.glsl"
 
 layout(set = 0, binding = 0) uniform sampler2D uGlobalTextures[];
+layout(set = 0, binding = 1) writeonly uniform image2D uGlobalImages[];
+
 layout(set = 1, binding = 0) uniform DrawParameters {
   TransformsArray meshTransforms;
   TransformsArray skinnedMeshTransforms;

--- a/engine/assets/shaders/hdr.frag
+++ b/engine/assets/shaders/hdr.frag
@@ -6,29 +6,45 @@ layout(location = 0) in vec2 inTexCoord;
 layout(location = 0) out vec4 outColor;
 
 layout(set = 0, binding = 0) uniform sampler2D uGlobalTextures[];
+layout(set = 0, binding = 1) writeonly uniform image2D uGlobalImages[];
 
 layout(push_constant) uniform DrawParameters { uvec4 index; };
 
 const vec3 Gamma = vec3(1.0 / 2.2);
 
-/**
- * @brief ACES tonemapping
- *
- * @param color RGB color
- * @return Tonemapped color
- */
-vec3 aces(vec3 color) {
-  const float a = 2.51;
-  const float b = 0.03;
-  const float c = 2.43;
-  const float d = 0.59;
-  const float e = 0.14;
-  return clamp((color * (a * color + b)) / (color * (c * color + d) + e), 0.0,
-               1.0);
+const mat3 aces_input_matrix =
+    mat3(0.59719f, 0.35458f, 0.04823f, 0.07600f, 0.90834f, 0.01566f, 0.02840f,
+         0.13383f, 0.83777f);
+
+const mat3 aces_output_matrix =
+    mat3(1.60475f, -0.53108f, -0.07367f, -0.10208f, 1.10813f, -0.00605f,
+         -0.00327f, -0.07276f, 1.07602f);
+
+vec3 mul(mat3 m, vec3 v) {
+  float x = m[0][0] * v[0] + m[0][1] * v[1] + m[0][2] * v[2];
+  float y = m[1][0] * v[0] + m[1][1] * v[1] + m[1][2] * v[2];
+  float z = m[2][0] * v[0] + m[2][1] * v[1] + m[2][2] * v[2];
+  return vec3(x, y, z);
 }
+
+vec3 rtt_and_odt_fit(vec3 v) {
+  vec3 a = v * (v + 0.0245786) - 0.000090537;
+  vec3 b = v * (0.983729 * v + 0.4329510) + 0.238081;
+  return a / b;
+}
+
+vec3 aces(vec3 v) {
+  v = mul(aces_input_matrix, v);
+  v = rtt_and_odt_fit(v);
+  return mul(aces_output_matrix, v);
+}
+
+const float BloomContribution = 0.2;
 
 void main() {
   vec4 hdrColor = texture(uGlobalTextures[index.x], inTexCoord);
+  vec3 bloomColor = texture(uGlobalTextures[index.y], inTexCoord).rgb;
 
-  outColor = vec4(aces(hdrColor.rgb), hdrColor.a);
+  outColor =
+      vec4(aces(mix(hdrColor.rgb, bloomColor, BloomContribution)), hdrColor.a);
 }

--- a/engine/assets/shaders/imgui.frag
+++ b/engine/assets/shaders/imgui.frag
@@ -1,12 +1,15 @@
 #version 450 core
 #extension GL_EXT_nonuniform_qualifier : enable
 
+#include "bindless/base.glsl"
+
 layout(location = 0) in vec4 inColor;
 layout(location = 1) in vec2 inTexCoord;
 
 layout(location = 0) out vec4 outColor;
 
 layout(set = 0, binding = 0) uniform sampler2D uGlobalTextures[];
+layout(set = 0, binding = 1) writeonly uniform image2D uGlobalImages[];
 
 layout(push_constant) uniform TextureData { layout(offset = 64) uint index; }
 pcTextureData;

--- a/engine/assets/shaders/pbr.frag
+++ b/engine/assets/shaders/pbr.frag
@@ -17,6 +17,7 @@ layout(location = 0) out vec4 outColor;
 layout(set = 0, binding = 0) uniform sampler2D uGlobalTextures[];
 layout(set = 0, binding = 0) uniform sampler2DArray uTextures2DArray[];
 layout(set = 0, binding = 0) uniform samplerCube uTexturesCube[];
+layout(set = 0, binding = 1) writeonly uniform image2D uGlobalImages[];
 
 layout(set = 1, binding = 0) uniform DrawParameters {
   Empty meshTransforms;

--- a/engine/assets/shaders/skybox.frag
+++ b/engine/assets/shaders/skybox.frag
@@ -8,6 +8,7 @@ layout(location = 0) out vec4 outColor;
 #include "bindless/base.glsl"
 
 layout(set = 0, binding = 0) uniform samplerCube uGlobalTextures[];
+layout(set = 0, binding = 1) writeonly uniform image2D uGlobalImages[];
 
 /**
  * @brief Skybox

--- a/engine/assets/shaders/sprite.frag
+++ b/engine/assets/shaders/sprite.frag
@@ -13,6 +13,8 @@ layout(location = 1) in flat uint inTextureIndex;
 layout(location = 0) out vec4 outColor;
 
 layout(set = 0, binding = 0) uniform sampler2D uGlobalTextures[];
+layout(set = 0, binding = 1) writeonly uniform image2D uGlobalImages[];
+
 layout(set = 1, binding = 0) uniform DrawParameters {
   Empty camera;
   Empty transforms;

--- a/engine/assets/shaders/sprite.vert
+++ b/engine/assets/shaders/sprite.vert
@@ -11,6 +11,8 @@ layout(location = 0) out vec2 outTexCoord;
 layout(location = 1) out flat uint outTextureIndex;
 
 layout(set = 0, binding = 0) uniform sampler2D uGlobalTextures[];
+layout(set = 0, binding = 1) writeonly uniform image2D uGlobalImages[];
+
 layout(set = 1, binding = 0) uniform DrawParameters {
   Camera camera;
   TransformsArray transforms;

--- a/engine/assets/shaders/text.frag
+++ b/engine/assets/shaders/text.frag
@@ -8,6 +8,7 @@ layout(location = 0) out vec4 outColor;
 #include "bindless/base.glsl"
 
 layout(set = 0, binding = 0) uniform sampler2D uGlobalTextures[];
+layout(set = 0, binding = 1) writeonly uniform image2D uGlobalImages[];
 
 layout(push_constant) uniform PushConstants { uvec4 text; }
 pcTextParams;

--- a/engine/premake5.lua
+++ b/engine/premake5.lua
@@ -22,6 +22,9 @@ function copyEngineAssets()
         "glslc "..assetsPath.."/shaders/fullscreen-quad.frag -o"..outputPath.."/shaders/fullscreen-quad.frag.spv",
         "glslc "..assetsPath.."/shaders/fullscreen-quad.vert -o"..outputPath.."/shaders/fullscreen-quad.vert.spv",
         "glslc "..assetsPath.."/shaders/generate-brdf-lut.comp -o "..outputPath.."/shaders/generate-brdf-lut.comp.spv",
+        "glslc "..assetsPath.."/shaders/extract-bright-colors.comp -o "..outputPath.."/shaders/extract-bright-colors.comp.spv",
+        "glslc "..assetsPath.."/shaders/bloom-downsample.comp -o "..outputPath.."/shaders/bloom-downsample.comp.spv",
+        "glslc "..assetsPath.."/shaders/bloom-upsample.comp -o "..outputPath.."/shaders/bloom-upsample.comp.spv",
         "glslc "..assetsPath.."/shaders/hdr.frag -o "..outputPath.."/shaders/hdr.frag.spv",
 
         -- Fonts

--- a/engine/rhi/vulkan/src/VulkanTexture.cpp
+++ b/engine/rhi/vulkan/src/VulkanTexture.cpp
@@ -140,11 +140,11 @@ VulkanTexture::VulkanTexture(const TextureDescription &description,
   samplerCreateInfo.sType = VK_STRUCTURE_TYPE_SAMPLER_CREATE_INFO;
   samplerCreateInfo.pNext = nullptr;
   samplerCreateInfo.flags = 0;
-  samplerCreateInfo.addressModeU = VK_SAMPLER_ADDRESS_MODE_REPEAT;
-  samplerCreateInfo.addressModeV = VK_SAMPLER_ADDRESS_MODE_REPEAT;
-  samplerCreateInfo.addressModeW = VK_SAMPLER_ADDRESS_MODE_REPEAT;
-  samplerCreateInfo.minFilter = VK_FILTER_NEAREST;
-  samplerCreateInfo.magFilter = VK_FILTER_NEAREST;
+  samplerCreateInfo.addressModeU = VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE;
+  samplerCreateInfo.addressModeV = VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE;
+  samplerCreateInfo.addressModeW = VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE;
+  samplerCreateInfo.minFilter = VK_FILTER_LINEAR;
+  samplerCreateInfo.magFilter = VK_FILTER_LINEAR;
   samplerCreateInfo.minLod = 0.0f;
   samplerCreateInfo.maxLod = VK_LOD_CLAMP_NONE;
   checkForVulkanError(
@@ -201,11 +201,11 @@ VulkanTexture::VulkanTexture(const TextureViewDescription &description,
   samplerCreateInfo.sType = VK_STRUCTURE_TYPE_SAMPLER_CREATE_INFO;
   samplerCreateInfo.pNext = nullptr;
   samplerCreateInfo.flags = 0;
-  samplerCreateInfo.addressModeU = VK_SAMPLER_ADDRESS_MODE_REPEAT;
-  samplerCreateInfo.addressModeV = VK_SAMPLER_ADDRESS_MODE_REPEAT;
-  samplerCreateInfo.addressModeW = VK_SAMPLER_ADDRESS_MODE_REPEAT;
-  samplerCreateInfo.minFilter = VK_FILTER_NEAREST;
-  samplerCreateInfo.magFilter = VK_FILTER_NEAREST;
+  samplerCreateInfo.addressModeU = VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE;
+  samplerCreateInfo.addressModeV = VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE;
+  samplerCreateInfo.addressModeW = VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE;
+  samplerCreateInfo.minFilter = VK_FILTER_LINEAR;
+  samplerCreateInfo.magFilter = VK_FILTER_LINEAR;
   samplerCreateInfo.minLod = 0.0f;
   samplerCreateInfo.maxLod = VK_LOD_CLAMP_NONE;
   checkForVulkanError(


### PR DESCRIPTION
- Add global storage images descriptor binding
- Update all shaders to support global images
- Add bloom pass and shaders
- Use real ACES tonemapping
- Add emissive strength property to GLTF material step
- Use specified mip levels of texture for image barriers in render graph
- Change default sampler to always clamp to edge and bilinear filtering