### PR TITLE
Use physical properties for camera

### DIFF
--- a/STYLE_GUIDE.md
+++ b/STYLE_GUIDE.md
@@ -155,12 +155,12 @@ layout(set = 1, binding = 1) uniform sampler2D uTextures;
 
 **Push constants:**
 
-All push constants must start with `pc` and must be defined in camelCase. Example:
+Push constants are also treated as uniforms, must start with `u`, and must be defined in camelCase. Example:
 
 ```glsl
 layout(push_constant) uniform ModelTransform {
     mat4 modelMatrix
-} pcTransform;
+} uTransform;
 ```
 
 > **Note:**

--- a/editor/assets/shaders/generate-specular-map.comp
+++ b/editor/assets/shaders/generate-specular-map.comp
@@ -9,7 +9,7 @@ layout(set = 0, binding = 1,
        rgba16f) writeonly uniform imageCube uOutputTexture;
 
 layout(push_constant) uniform PushConstants { vec4 data; }
-pcMipParams;
+uMipParams;
 
 layout(local_size_x = 1, local_size_y = 1, local_size_z = 1) in;
 
@@ -18,9 +18,9 @@ const uint NumSamples = 4096;
 void main() {
   ivec3 globalId = ivec3(gl_GlobalInvocationID.xyz);
 
-  float roughness = pcMipParams.data.x;
-  float mipLevel = pcMipParams.data.y;
-  float mipWidth = pcMipParams.data.z;
+  float roughness = uMipParams.data.x;
+  float mipLevel = uMipParams.data.y;
+  float mipWidth = uMipParams.data.z;
 
   vec3 normal = cubeCoordToWorld(globalId, mipWidth);
 

--- a/editor/assets/shaders/object-icons.frag
+++ b/editor/assets/shaders/object-icons.frag
@@ -25,8 +25,8 @@ uDrawParams;
  * @brief Push for icons
  */
 layout(push_constant) uniform IconParams { uvec4 icon; }
-pcIconParams;
+uIconParams;
 
 void main() {
-  outColor = texture(uGlobalTextures[pcIconParams.icon.x], inTexCoord);
+  outColor = texture(uGlobalTextures[uIconParams.icon.x], inTexCoord);
 }

--- a/editor/assets/shaders/outline-color.frag
+++ b/editor/assets/shaders/outline-color.frag
@@ -10,6 +10,6 @@ layout(push_constant) uniform PushConstants {
   vec4 scale;
   vec4 index;
 }
-pcOutline;
+uOutline;
 
-void main() { outColor = pcOutline.color; }
+void main() { outColor = uOutline.color; }

--- a/editor/assets/shaders/outline-geometry.vert
+++ b/editor/assets/shaders/outline-geometry.vert
@@ -28,10 +28,10 @@ layout(push_constant) uniform PushConstants {
   vec4 scale;
   uvec4 index;
 }
-pcOutline;
+uOutline;
 
 void main() {
   gl_Position = getCamera().viewProj *
                 getOutlineTransform(gl_InstanceIndex).modelMatrix *
-                vec4(inPosition * pcOutline.scale.x, 1.0);
+                vec4(inPosition * uOutline.scale.x, 1.0);
 }

--- a/editor/assets/shaders/outline-skinned-geometry.vert
+++ b/editor/assets/shaders/outline-skinned-geometry.vert
@@ -30,7 +30,7 @@ layout(push_constant) uniform PushConstants {
   vec4 scale;
   uvec4 index;
 }
-pcOutline;
+uOutline;
 
 void main() {
   SkeletonItem item = getOutlineSkeleton(0);
@@ -42,5 +42,5 @@ void main() {
 
   gl_Position = getCamera().viewProj *
                 getOutlineTransform(gl_InstanceIndex).modelMatrix * skinMatrix *
-                vec4(inPosition * pcOutline.scale.x, 1.0);
+                vec4(inPosition * uOutline.scale.x, 1.0);
 }

--- a/editor/assets/shaders/outline-sprite.vert
+++ b/editor/assets/shaders/outline-sprite.vert
@@ -28,7 +28,7 @@ layout(push_constant) uniform PushConstants {
   vec4 scale;
   uvec4 index;
 }
-pcOutline;
+uOutline;
 
 const vec2 positions[4] =
     vec2[](vec2(-1, -1), vec2(+1, -1), vec2(-1, +1), vec2(+1, +1));
@@ -36,5 +36,5 @@ const vec2 positions[4] =
 void main() {
   gl_Position = getCamera().viewProj *
                 getOutlineTransform(gl_InstanceIndex).modelMatrix *
-                vec4(positions[gl_VertexIndex] * pcOutline.scale.x, 0.0, 1.0);
+                vec4(positions[gl_VertexIndex] * uOutline.scale.x, 0.0, 1.0);
 }

--- a/editor/src/liquidator/editor-scene/EditorCamera.cpp
+++ b/editor/src/liquidator/editor-scene/EditorCamera.cpp
@@ -125,11 +125,15 @@ void EditorCamera::update(WorkspaceState &state) {
 
   lens.aspectRatio = mWidth / mHeight;
 
-  camera.projectionMatrix = glm::perspective(
-      glm::radians(lens.fovY), lens.aspectRatio, lens.near, lens.far);
+  const float fovY =
+      2.0f * atanf(lens.sensorSize.y / (2.0f * lens.focalLength));
+
+  camera.projectionMatrix =
+      glm::perspective(fovY, lens.aspectRatio, lens.near, lens.far);
 
   camera.viewMatrix = glm::lookAt(lookAt.eye, lookAt.center, lookAt.up);
   camera.projectionViewMatrix = camera.projectionMatrix * camera.viewMatrix;
+  camera.exposure.x = 1.0f;
 }
 
 glm::vec2 EditorCamera::scaleToViewport(const glm::vec2 &pos) const {
@@ -145,8 +149,13 @@ glm::vec2 EditorCamera::scaleToViewport(const glm::vec2 &pos) const {
 Entity EditorCamera::createDefaultCamera(EntityDatabase &entityDatabase) {
   auto camera = entityDatabase.create();
 
-  entityDatabase.set<PerspectiveLens>(camera,
-                                      {DefaultFOV, DefaultNear, DefaultFar});
+  PerspectiveLens lens{};
+  lens.near = DefaultNear;
+  lens.far = DefaultFar;
+  lens.sensorSize = DefaultSensorSize;
+  lens.focalLength = DefaultFocalLength;
+
+  entityDatabase.set(camera, lens);
   entityDatabase.set<Camera>(camera, {});
   entityDatabase.set<CameraLookAt>(camera,
                                    {DefaultEye, DefaultCenter, DefaultUp});

--- a/editor/src/liquidator/editor-scene/EditorCamera.h
+++ b/editor/src/liquidator/editor-scene/EditorCamera.h
@@ -35,9 +35,14 @@ public:
   static constexpr float ZoomSpeed = 0.03f;
 
   /**
-   * Default Field of view value
+   * Default sensor size
    */
-  static constexpr float DefaultFOV = 70.0f;
+  static constexpr glm::vec2 DefaultSensorSize{16.0f, 16.0f};
+
+  /**
+   * Default focal length
+   */
+  static constexpr float DefaultFocalLength = 16.0f;
 
   /**
    * Default near perspective plane

--- a/editor/src/liquidator/ui/EntityPanel.cpp
+++ b/editor/src/liquidator/ui/EntityPanel.cpp
@@ -317,21 +317,6 @@ void EntityPanel::renderCamera(WorkspaceState &state, Scene &scene,
 
     bool sendAction = false;
 
-    float fovY = component.fovY;
-    if (widgets::Input("FOV", fovY, false)) {
-      if (fovY < 0.0f) {
-        fovY = 0.0f;
-      }
-
-      if (!mPerspectiveLensAction) {
-        mPerspectiveLensAction = std::make_unique<EntitySetPerspectiveLens>(
-            mSelectedEntity, component);
-      }
-      component.fovY = fovY;
-
-      sendAction = true;
-    }
-
     float near = component.near;
     if (widgets::Input("Near", near, false)) {
       if (near < 0.0f) {
@@ -359,6 +344,73 @@ void EntityPanel::renderCamera(WorkspaceState &state, Scene &scene,
             mSelectedEntity, component);
       }
       component.far = far;
+
+      sendAction = true;
+    }
+
+    glm::vec2 sensorSize = component.sensorSize;
+    if (widgets::Input("Sensor size (mm)", sensorSize, false)) {
+      sensorSize = glm::max(sensorSize, glm::vec2(0.0f));
+
+      if (!mPerspectiveLensAction) {
+        mPerspectiveLensAction = std::make_unique<EntitySetPerspectiveLens>(
+            mSelectedEntity, component);
+      }
+      component.sensorSize = sensorSize;
+
+      sendAction = true;
+    }
+
+    float focalLength = component.focalLength;
+    if (widgets::Input("Focal length (mm)", focalLength, false)) {
+      focalLength = std::max(focalLength, 0.0f);
+
+      if (!mPerspectiveLensAction) {
+        mPerspectiveLensAction = std::make_unique<EntitySetPerspectiveLens>(
+            mSelectedEntity, component);
+      }
+      component.focalLength = focalLength;
+
+      sendAction = true;
+    }
+
+    float aperture = component.aperture;
+    if (widgets::Input("Aperture", aperture, false)) {
+      if (aperture < 0.0f) {
+        aperture = 0.0f;
+      }
+
+      if (!mPerspectiveLensAction) {
+        mPerspectiveLensAction = std::make_unique<EntitySetPerspectiveLens>(
+            mSelectedEntity, component);
+      }
+      component.aperture = aperture;
+
+      sendAction = true;
+    }
+
+    float shutterSpeed = 1.0f / component.shutterSpeed;
+    if (widgets::Input("Shutter speed (1/s)", shutterSpeed, false)) {
+      if (shutterSpeed < 0.0f) {
+        shutterSpeed = 0.0f;
+      }
+
+      if (!mPerspectiveLensAction) {
+        mPerspectiveLensAction = std::make_unique<EntitySetPerspectiveLens>(
+            mSelectedEntity, component);
+      }
+      component.shutterSpeed = 1.0f / shutterSpeed;
+
+      sendAction = true;
+    }
+
+    uint32_t sensitivity = component.sensitivity;
+    if (widgets::Input("Sensitivity (ISO)", sensitivity, false)) {
+      if (!mPerspectiveLensAction) {
+        mPerspectiveLensAction = std::make_unique<EntitySetPerspectiveLens>(
+            mSelectedEntity, component);
+      }
+      component.sensitivity = sensitivity;
 
       sendAction = true;
     }

--- a/editor/src/liquidator/ui/Widgets.cpp
+++ b/editor/src/liquidator/ui/Widgets.cpp
@@ -216,6 +216,23 @@ Input::Input(String label, glm::vec3 &value, bool autoChange) {
   }
 }
 
+Input::Input(String label, glm::vec2 &value, bool autoChange) {
+  if (autoChange) {
+    auto temp = value;
+
+    renderScalarInput(label, glm::value_ptr(temp), glm::vec2::length(),
+                      ImGuiDataType_Float);
+
+    if (mChanged) {
+      value = temp;
+    }
+
+  } else {
+    renderScalarInput(label, glm::value_ptr(value), glm::vec2::length(),
+                      ImGuiDataType_Float);
+  }
+}
+
 Input::Input(String label, float &value, bool autoChange) {
   if (autoChange) {
     auto temp = value;

--- a/editor/src/liquidator/ui/Widgets.h
+++ b/editor/src/liquidator/ui/Widgets.h
@@ -317,6 +317,15 @@ public:
   Input(String label, glm::vec3 &value, bool autoChange = true);
 
   /**
+   * @brief Render vec2 input
+   *
+   * @param label Input label
+   * @param value Input value
+   * @param autoChange Auto change
+   */
+  Input(String label, glm::vec2 &value, bool autoChange = true);
+
+  /**
    * @brief Render decimal scalar input
    *
    * @param label Input label

--- a/editor/tests/liquidator-tests/actions/EntityCameraActions.test.cpp
+++ b/editor/tests/liquidator-tests/actions/EntityCameraActions.test.cpp
@@ -57,8 +57,8 @@ InitActionsTestSuite(EntityActionsTest, EntityCreatePerspectiveLensActionTest);
 using EntitySetPerspectiveLensActionTest = ActionTestBase;
 
 InitDefaultUpdateComponentTests(EntitySetPerspectiveLensActionTest,
-                                EntitySetPerspectiveLens, PerspectiveLens, fovY,
-                                45.0f);
+                                EntitySetPerspectiveLens, PerspectiveLens,
+                                focalLength, 45.0f);
 
 InitActionsTestSuite(EntityActionsTest, EntitySetPerspectiveLensActionTest);
 

--- a/engine/assets/shaders/bindless/camera.glsl
+++ b/engine/assets/shaders/bindless/camera.glsl
@@ -2,6 +2,7 @@ Buffer(64) Camera {
   mat4 proj;
   mat4 view;
   mat4 viewProj;
+  vec4 exposure;
 };
 
 #define getCamera() uDrawParams.camera

--- a/engine/assets/shaders/imgui.frag
+++ b/engine/assets/shaders/imgui.frag
@@ -12,9 +12,8 @@ layout(set = 0, binding = 0) uniform sampler2D uGlobalTextures[];
 layout(set = 0, binding = 1) writeonly uniform image2D uGlobalImages[];
 
 layout(push_constant) uniform TextureData { layout(offset = 64) uint index; }
-pcTextureData;
+uTextureData;
 
 void main() {
-  outColor =
-      inColor * texture(uGlobalTextures[pcTextureData.index], inTexCoord);
+  outColor = inColor * texture(uGlobalTextures[uTextureData.index], inTexCoord);
 }

--- a/engine/assets/shaders/imgui.vert
+++ b/engine/assets/shaders/imgui.vert
@@ -8,10 +8,10 @@ layout(location = 0) out vec4 outColor;
 layout(location = 1) out vec2 outUV;
 
 layout(push_constant) uniform TransformConstant { mat4 uiTransform; }
-pcTransform;
+uTransform;
 
 void main() {
   outColor = inColor;
   outUV = inUV;
-  gl_Position = pcTransform.uiTransform * vec4(inPosition, 0.0, 1.0);
+  gl_Position = uTransform.uiTransform * vec4(inPosition, 0.0, 1.0);
 }

--- a/engine/assets/shaders/shadowmap-skinned.vert
+++ b/engine/assets/shaders/shadowmap-skinned.vert
@@ -19,7 +19,7 @@ layout(set = 0, binding = 0) uniform DrawParameters {
 uDrawParams;
 
 layout(push_constant) uniform PushConstants { uvec4 shadow; }
-pcShadowParams;
+uShadowParams;
 
 void main() {
   mat4 modelMatrix = getSkinnedMeshTransform(gl_InstanceIndex).modelMatrix;
@@ -30,7 +30,7 @@ void main() {
                     inWeights.z * item.joints[inJoints.z] +
                     inWeights.w * item.joints[inJoints.w];
 
-  gl_Position = getShadowMap(pcShadowParams.shadow.x).shadowMatrix *
+  gl_Position = getShadowMap(uShadowParams.shadow.x).shadowMatrix *
                 modelMatrix * skinMatrix * vec4(inPosition, 1.0);
-  gl_Layer = int(pcShadowParams.shadow.x);
+  gl_Layer = int(uShadowParams.shadow.x);
 }

--- a/engine/assets/shaders/shadowmap.vert
+++ b/engine/assets/shaders/shadowmap.vert
@@ -17,12 +17,12 @@ layout(set = 0, binding = 0) uniform DrawParameters {
 uDrawParams;
 
 layout(push_constant) uniform PushConstants { uvec4 shadow; }
-pcShadowParams;
+uShadowParams;
 
 void main() {
   mat4 modelMatrix = getMeshTransform(gl_InstanceIndex).modelMatrix;
 
-  gl_Position = getShadowMap(pcShadowParams.shadow.x).shadowMatrix *
+  gl_Position = getShadowMap(uShadowParams.shadow.x).shadowMatrix *
                 modelMatrix * vec4(inPosition, 1.0);
-  gl_Layer = int(pcShadowParams.shadow.x);
+  gl_Layer = int(uShadowParams.shadow.x);
 }

--- a/engine/assets/shaders/text.frag
+++ b/engine/assets/shaders/text.frag
@@ -11,7 +11,7 @@ layout(set = 0, binding = 0) uniform sampler2D uGlobalTextures[];
 layout(set = 0, binding = 1) writeonly uniform image2D uGlobalImages[];
 
 layout(push_constant) uniform PushConstants { uvec4 text; }
-pcTextParams;
+uTextParams;
 
 float median(vec3 msd) {
   return max(min(msd.r, msd.g), min(max(msd.r, msd.g), msd.b));
@@ -19,13 +19,13 @@ float median(vec3 msd) {
 
 float screenPxRange() {
   vec2 unitRange =
-      vec2(2.0) / vec2(textureSize(uGlobalTextures[pcTextParams.text.x], 0));
+      vec2(2.0) / vec2(textureSize(uGlobalTextures[uTextParams.text.x], 0));
   vec2 screenTexSize = vec2(1.0) / fwidth(texCoord);
   return max(0.5 * dot(unitRange, screenTexSize), 1.0);
 }
 
 void main() {
-  vec3 msd = texture(uGlobalTextures[pcTextParams.text.x], texCoord).rgb;
+  vec3 msd = texture(uGlobalTextures[uTextParams.text.x], texCoord).rgb;
   float sd = median(msd);
   float screenPxDistance = screenPxRange() * (sd - 0.5);
   float opacity = clamp(screenPxDistance + 0.5, 0.0, 1.0);

--- a/engine/assets/shaders/text.vert
+++ b/engine/assets/shaders/text.vert
@@ -16,7 +16,7 @@ layout(set = 1, binding = 0) uniform DrawParameters {
 uDrawParams;
 
 layout(push_constant) uniform PushConstants { uvec4 text; }
-pcTextParams;
+uTextParams;
 
 const uint QUAD_VERTICES = 6;
 
@@ -25,7 +25,7 @@ void main() {
 
   uint boundIndex = gl_VertexIndex % QUAD_VERTICES;
   uint glyphIndex =
-      pcTextParams.text.y + uint(floor(gl_VertexIndex / QUAD_VERTICES));
+      uTextParams.text.y + uint(floor(gl_VertexIndex / QUAD_VERTICES));
 
   GlyphItem glyph = getGlyph(glyphIndex);
 

--- a/engine/src/liquid/renderer/SceneRenderer.cpp
+++ b/engine/src/liquid/renderer/SceneRenderer.cpp
@@ -641,11 +641,19 @@ SceneRenderPassData SceneRenderer::attach(RenderGraph &graph,
       commandList.bindDescriptor(pipeline, 0,
                                  mRenderStorage.getGlobalTexturesDescriptor());
 
-      glm::uvec4 color{static_cast<uint32_t>(sceneColorResolved.getHandle()),
-                       static_cast<uint32_t>(bloomTexture.getHandle()), 0, 0};
+      struct Data {
+        rhi::TextureHandle sceneColor;
+
+        rhi::TextureHandle bloomTexture;
+
+        rhi::DeviceAddress bufferAddress;
+      };
+
+      Data data{sceneColorResolved.getHandle(), bloomTexture.getHandle(),
+                mFrameData.at(frameIndex).getCameraBuffer()};
 
       commandList.pushConstants(pipeline, rhi::ShaderStage::Fragment, 0,
-                                sizeof(glm::uvec4), glm::value_ptr(color));
+                                sizeof(Data), &data);
 
       commandList.draw(3, 0);
     });

--- a/engine/src/liquid/renderer/SceneRendererFrameData.cpp
+++ b/engine/src/liquid/renderer/SceneRendererFrameData.cpp
@@ -241,6 +241,9 @@ void SceneRendererFrameData::addCascadedShadowMaps(
   float range = far - near;
   float ratio = far / near;
 
+  const float fovY =
+      2.0f * atanf(mCameraLens.sensorSize.y / (2.0f * mCameraLens.focalLength));
+
   for (size_t i = 0; i < static_cast<size_t>(numCascades + 1); ++i) {
     float p =
         static_cast<float>(i + 1) / static_cast<float>(splitDistances.size());
@@ -264,8 +267,7 @@ void SceneRendererFrameData::addCascadedShadowMaps(
     float splitDistance = splitDistances.at(i);
 
     auto splitProjectionMatrix = glm::perspective(
-        glm::radians(mCameraLens.fovY), mCameraLens.aspectRatio,
-        prevSplitDistance, splitDistance);
+        fovY, mCameraLens.aspectRatio, prevSplitDistance, splitDistance);
 
     auto invProjView =
         glm::inverse(splitProjectionMatrix * mCameraData.viewMatrix);

--- a/engine/src/liquid/scene/Camera.h
+++ b/engine/src/liquid/scene/Camera.h
@@ -20,6 +20,13 @@ struct Camera {
    * Camera projection view matrix
    */
   glm::mat4 projectionViewMatrix{1.0};
+
+  /**
+   * Exposure values for camera
+   *
+   * First value represents the EV100 value.
+   */
+  glm::vec4 exposure{1.0f, 0.0f, 0.0f, 0.0f};
 };
 
 } // namespace liquid

--- a/engine/src/liquid/scene/PerspectiveLens.h
+++ b/engine/src/liquid/scene/PerspectiveLens.h
@@ -7,17 +7,43 @@ namespace liquid {
  */
 struct PerspectiveLens {
   /**
-   * Field of view
+   * Default sensor size
+   *
+   * Based on APS-C
    */
-  float fovY = 80.0f;
+  static constexpr glm::vec2 DefaultSensorSize{23.6f, 15.6f};
+
+  /**
+   * Default focal length
+   */
+  static constexpr float DefaultFocalLength = 23.0f;
+
+  /**
+   * Default aperture
+   */
+  static constexpr float DefaultAperture = 22.0f;
+
+  /**
+   * Default shutter speed
+   */
+  static constexpr float DefaultShutterSpeed = 1.0f / 125.0f;
+
+  /**
+   * Default sensitivity
+   */
+  static constexpr uint32_t DefaultSensitivity = 100;
 
   /**
    * Near plane
+   *
+   * Measured in meters
    */
   float near = 0.1f;
 
   /**
    * Far plane
+   *
+   * Measured in meters
    */
   float far = 1000.0f;
 
@@ -25,6 +51,52 @@ struct PerspectiveLens {
    * Aspect ratio
    */
   float aspectRatio = 1.0f;
+
+  /**
+   * Sensor size
+   *
+   * Measured in millimeters
+   */
+  glm::vec2 sensorSize = DefaultSensorSize;
+
+  /**
+   * Lens focal length
+   *
+   * Measured in millimeters
+   */
+  float focalLength = DefaultFocalLength;
+
+  /**
+   * Lens aperture
+   *
+   * Measured in f-stops
+   *
+   * Example: f3.5, f1.6, f22
+   */
+  float aperture = DefaultAperture;
+
+  /**
+   * Camera shutter speed
+   *
+   * A more accurate description
+   * of this term is shutter time
+   * since it is measured in seconds;
+   * however, the term shutter speed
+   * is widely used in photography
+   *
+   * Example: 1/125s, 1/1000s, 1s
+   */
+  float shutterSpeed = DefaultShutterSpeed;
+
+  /**
+   * Camera sensitivity to light
+   *
+   * Also referred to as camera
+   * ISO and is measured in ISO values.
+   *
+   * Example: ISO 100, ISO 400, ISO 1600
+   */
+  uint32_t sensitivity = DefaultSensitivity;
 };
 
 } // namespace liquid

--- a/engine/src/liquid/scene/SceneUpdater.cpp
+++ b/engine/src/liquid/scene/SceneUpdater.cpp
@@ -45,11 +45,20 @@ void SceneUpdater::updateCameras(EntityDatabase &entityDatabase) {
 
   for (auto [entity, lens, world, camera] :
        entityDatabase.view<PerspectiveLens, WorldTransform, Camera>()) {
-    camera.projectionMatrix = glm::perspective(
-        glm::radians(lens.fovY), lens.aspectRatio, lens.near, lens.far);
+
+    const float fovY =
+        2.0f * atanf(lens.sensorSize.y / (2.0f * lens.focalLength));
+
+    camera.projectionMatrix =
+        glm::perspective(fovY, lens.aspectRatio, lens.near, lens.far);
 
     camera.viewMatrix = glm::inverse(world.worldTransform);
     camera.projectionViewMatrix = camera.projectionMatrix * camera.viewMatrix;
+
+    const float ev100 =
+        std::log2f(powf(lens.aperture, 2.0f) * lens.shutterSpeed * 100.0f /
+                   static_cast<float>(lens.sensitivity));
+    camera.exposure.x = ev100;
   }
 }
 

--- a/engine/src/liquid/scene/private/EntitySerializer.cpp
+++ b/engine/src/liquid/scene/private/EntitySerializer.cpp
@@ -80,9 +80,13 @@ YAML::Node EntitySerializer::createComponentsNode(Entity entity) {
     const auto &camera = mEntityDatabase.get<PerspectiveLens>(entity);
 
     components["camera"]["type"] = 0;
-    components["camera"]["fov"] = camera.fovY;
     components["camera"]["near"] = camera.near;
     components["camera"]["far"] = camera.far;
+    components["camera"]["aperture"] = camera.aperture;
+    components["camera"]["sensorSize"] = camera.sensorSize;
+    components["camera"]["focalLength"] = camera.focalLength;
+    components["camera"]["shutterSpeed"] = camera.shutterSpeed;
+    components["camera"]["sensitivity"] = camera.sensitivity;
 
     if (mEntityDatabase.has<AutoAspectRatio>(entity)) {
       components["camera"]["aspectRatio"] = "auto";

--- a/engine/src/liquid/scene/private/SceneLoader.cpp
+++ b/engine/src/liquid/scene/private/SceneLoader.cpp
@@ -239,9 +239,44 @@ Result<bool> SceneLoader::loadComponents(const YAML::Node &node, Entity entity,
 
   if (node["components"]["camera"] && node["components"]["camera"].IsMap()) {
     PerspectiveLens lens{};
-    lens.fovY = node["components"]["camera"]["fov"].as<float>(lens.fovY);
-    lens.near = node["components"]["camera"]["near"].as<float>(lens.near);
-    lens.far = node["components"]["camera"]["far"].as<float>(lens.far);
+    float near = node["components"]["camera"]["near"].as<float>(lens.near);
+    if (near >= 0.0f) {
+      lens.near = near;
+    }
+
+    float far = node["components"]["camera"]["far"].as<float>(lens.far);
+    if (far >= 0.0f) {
+      lens.far = far;
+    }
+
+    glm::vec2 sensorSize =
+        node["components"]["camera"]["sensorSize"].as<glm::vec2>(
+            lens.sensorSize);
+
+    if (sensorSize.x >= 0.0f && sensorSize.y >= 0.0f) {
+      lens.sensorSize = sensorSize;
+    }
+
+    float focalLength =
+        node["components"]["camera"]["focalLength"].as<float>(lens.focalLength);
+    if (focalLength >= 0.0f) {
+      lens.focalLength = focalLength;
+    }
+
+    float aperture =
+        node["components"]["camera"]["aperture"].as<float>(lens.aperture);
+    if (aperture >= 0.0f) {
+      lens.aperture = aperture;
+    }
+
+    float shutterSpeed = node["components"]["camera"]["shutterSpeed"].as<float>(
+        lens.shutterSpeed);
+    if (shutterSpeed >= 0.0f) {
+      lens.shutterSpeed = shutterSpeed;
+    }
+
+    lens.sensitivity = node["components"]["camera"]["sensitivity"].as<uint32_t>(
+        lens.sensitivity);
 
     bool autoRatio = true;
     if (node["components"]["camera"]["aspectRatio"] &&
@@ -256,8 +291,11 @@ Result<bool> SceneLoader::loadComponents(const YAML::Node &node, Entity entity,
     if (autoRatio) {
       mEntityDatabase.set<AutoAspectRatio>(entity, {});
     } else {
-      lens.aspectRatio = node["components"]["camera"]["aspectRatio"].as<float>(
+      float aspectRatio = node["components"]["camera"]["aspectRatio"].as<float>(
           lens.aspectRatio);
+      if (aspectRatio >= 0.0f) {
+        lens.aspectRatio = aspectRatio;
+      }
     }
 
     mEntityDatabase.set<Camera>(entity, {});

--- a/engine/src/liquid/yaml/Yaml.h
+++ b/engine/src/liquid/yaml/Yaml.h
@@ -5,6 +5,41 @@
 namespace YAML {
 
 /**
+ * @brief GLM 2D vector Yaml serializer
+ */
+template <> struct convert<glm::vec2> {
+  /**
+   * @brief Encode GLM 2D vector to Yaml
+   *
+   * @param value GLM 2D vector
+   * @return Yaml node
+   */
+  static Node encode(const glm::vec2 &value) {
+    Node node;
+    node.push_back(value.x);
+    node.push_back(value.y);
+    return node;
+  }
+
+  /**
+   * @brief Decode Yaml to GLM 2D vector
+   *
+   * @param node Yaml node
+   * @param value GLM 2D vector
+   * @retval true Decoding successful
+   * @retval false Decoding failed
+   */
+  static bool decode(const Node &node, glm::vec2 &value) {
+    if (!node.IsSequence() || node.size() != 2) {
+      return false;
+    }
+
+    return convert<float>::decode(node[0], value.x) &&
+           convert<float>::decode(node[1], value.y);
+  }
+};
+
+/**
  * @brief GLM 3D vector Yaml serializer
  */
 template <> struct convert<glm::vec3> {

--- a/engine/tests/liquid-tests/scene/SceneUpdater.test.cpp
+++ b/engine/tests/liquid-tests/scene/SceneUpdater.test.cpp
@@ -97,13 +97,16 @@ TEST_F(SceneUpdaterTest, UpdatesCameraBasedOnTransformAndPerspectiveLens) {
   auto &lens = entityDatabase.get<liquid::PerspectiveLens>(entity);
   auto &camera = entityDatabase.get<liquid::Camera>(entity);
 
-  auto expectedPerspective = glm::perspective(
-      glm::radians(lens.fovY), lens.aspectRatio, lens.near, lens.far);
+  float fovY = 2.0f * atanf(lens.sensorSize.y / (2.0f * lens.focalLength));
+
+  auto expectedPerspective =
+      glm::perspective(fovY, lens.aspectRatio, lens.near, lens.far);
 
   EXPECT_EQ(camera.viewMatrix, glm::inverse(transform.worldTransform));
   EXPECT_EQ(camera.projectionMatrix, expectedPerspective);
   EXPECT_EQ(camera.projectionViewMatrix,
             camera.projectionMatrix * camera.viewMatrix);
+  EXPECT_NEAR(camera.exposure.x, 10.97f, 9.02f);
 }
 
 TEST_F(SceneUpdaterTest, UpdateDirectionalLightsBasedOnTransforms) {

--- a/engine/tests/liquid-tests/scene/private/EntitySerializer.test.cpp
+++ b/engine/tests/liquid-tests/scene/private/EntitySerializer.test.cpp
@@ -408,7 +408,11 @@ TEST_F(EntitySerializerTest, CreatesCameraFieldIfLensComponentExists) {
   lens.aspectRatio = 2.5f;
   lens.far = 200.0f;
   lens.near = 0.2f;
-  lens.fovY = 80.0f;
+  lens.sensorSize = glm::vec2(50.0f, 45.0f);
+  lens.focalLength = 100.0f;
+  lens.aperture = 1.5f;
+  lens.shutterSpeed = 2.5f;
+  lens.sensitivity = 2500;
   entityDatabase.set(entity, lens);
 
   auto node = entitySerializer.createComponentsNode(entity);
@@ -416,10 +420,15 @@ TEST_F(EntitySerializerTest, CreatesCameraFieldIfLensComponentExists) {
   EXPECT_TRUE(node["camera"]);
   EXPECT_TRUE(node["camera"].IsMap());
   EXPECT_EQ(node["camera"]["type"].as<uint32_t>(1000), 0);
-  EXPECT_EQ(node["camera"]["fov"].as<float>(-1.0f), lens.fovY);
   EXPECT_EQ(node["camera"]["near"].as<float>(-1.0f), lens.near);
   EXPECT_EQ(node["camera"]["far"].as<float>(-1.0f), lens.far);
   EXPECT_EQ(node["camera"]["aspectRatio"].as<float>(-1.0f), lens.aspectRatio);
+  EXPECT_EQ(node["camera"]["sensorSize"].as<glm::vec2>(glm::vec2{-1.0f, -1.0f}),
+            lens.sensorSize);
+  EXPECT_EQ(node["camera"]["focalLength"].as<float>(-1.0f), lens.focalLength);
+  EXPECT_EQ(node["camera"]["aperture"].as<float>(-1.0f), lens.aperture);
+  EXPECT_EQ(node["camera"]["shutterSpeed"].as<float>(-1.0f), lens.shutterSpeed);
+  EXPECT_EQ(node["camera"]["sensitivity"].as<float>(-1.0f), lens.sensitivity);
 }
 
 TEST_F(EntitySerializerTest,

--- a/engine/tests/liquid-tests/scene/private/SceneLoader.test.cpp
+++ b/engine/tests/liquid-tests/scene/private/SceneLoader.test.cpp
@@ -102,7 +102,6 @@ TEST_F(SceneLoaderTransformTest,
 
 TEST_F(SceneLoaderTransformTest,
        TriesToFillAllPossibleValuesIfInvalidStructure) {
-
   liquid::LocalTransform defaults{};
   glm::vec3 validPosition(2.0f);
   glm::quat validRotation(0.0f, 1.0f, 0.0f, 0.0f);
@@ -939,39 +938,26 @@ TEST_F(SceneLoaderCameraTest,
 
   liquid::PerspectiveLens defaults{};
 
-  float validFov = 65.0f;
   float validNear = 0.5f;
   float validFar = 1000.0f;
   float validAspectRatio = 2.0f;
-
-  // FOV
-  for (const auto &invalidNode : invalidNodes) {
-    auto [node, entity] = createNode();
-    node["components"]["camera"]["fov"] = invalidNode;
-    node["components"]["camera"]["near"] = validNear;
-    node["components"]["camera"]["far"] = validFar;
-    node["components"]["camera"]["aspectRatio"] = validAspectRatio;
-
-    sceneLoader.loadComponents(node, entity, entityIdCache).getData();
-
-    EXPECT_TRUE(entityDatabase.has<liquid::PerspectiveLens>(entity));
-    EXPECT_FALSE(entityDatabase.has<liquid::AutoAspectRatio>(entity));
-
-    const auto &component = entityDatabase.get<liquid::PerspectiveLens>(entity);
-
-    EXPECT_EQ(component.fovY, defaults.fovY);
-    EXPECT_EQ(component.near, validNear);
-    EXPECT_EQ(component.far, validFar);
-    EXPECT_EQ(component.aspectRatio, validAspectRatio);
-  }
+  glm::vec2 validSensorSize{50.0f, 45.0f};
+  float validFocalLength = 100.0f;
+  float validAperture = 2.5f;
+  float validShutterSpeed = 0.125f;
+  uint32_t validSensitivity = 2500;
 
   // Near
   for (const auto &invalidNode : invalidNodes) {
     auto [node, entity] = createNode();
-    node["components"]["camera"]["fov"] = validFov;
     node["components"]["camera"]["near"] = invalidNode;
     node["components"]["camera"]["far"] = validFar;
     node["components"]["camera"]["aspectRatio"] = validAspectRatio;
+    node["components"]["camera"]["sensorSize"] = validSensorSize;
+    node["components"]["camera"]["focalLength"] = validFocalLength;
+    node["components"]["camera"]["aperture"] = validAperture;
+    node["components"]["camera"]["shutterSpeed"] = validShutterSpeed;
+    node["components"]["camera"]["sensitivity"] = validSensitivity;
 
     sceneLoader.loadComponents(node, entity, entityIdCache).getData();
 
@@ -980,19 +966,27 @@ TEST_F(SceneLoaderCameraTest,
 
     const auto &component = entityDatabase.get<liquid::PerspectiveLens>(entity);
 
-    EXPECT_EQ(component.fovY, validFov);
     EXPECT_EQ(component.near, defaults.near);
     EXPECT_EQ(component.far, validFar);
     EXPECT_EQ(component.aspectRatio, validAspectRatio);
+    EXPECT_EQ(component.sensorSize, validSensorSize);
+    EXPECT_EQ(component.focalLength, validFocalLength);
+    EXPECT_EQ(component.aperture, validAperture);
+    EXPECT_EQ(component.shutterSpeed, validShutterSpeed);
+    EXPECT_EQ(component.sensitivity, validSensitivity);
   }
 
   // Far
   for (const auto &invalidNode : invalidNodes) {
     auto [node, entity] = createNode();
-    node["components"]["camera"]["fov"] = validFov;
     node["components"]["camera"]["near"] = validNear;
     node["components"]["camera"]["far"] = invalidNode;
     node["components"]["camera"]["aspectRatio"] = validAspectRatio;
+    node["components"]["camera"]["sensorSize"] = validSensorSize;
+    node["components"]["camera"]["focalLength"] = validFocalLength;
+    node["components"]["camera"]["aperture"] = validAperture;
+    node["components"]["camera"]["shutterSpeed"] = validShutterSpeed;
+    node["components"]["camera"]["sensitivity"] = validSensitivity;
 
     sceneLoader.loadComponents(node, entity, entityIdCache).getData();
 
@@ -1001,19 +995,27 @@ TEST_F(SceneLoaderCameraTest,
 
     const auto &component = entityDatabase.get<liquid::PerspectiveLens>(entity);
 
-    EXPECT_EQ(component.fovY, validFov);
     EXPECT_EQ(component.near, validNear);
     EXPECT_EQ(component.far, defaults.far);
     EXPECT_EQ(component.aspectRatio, validAspectRatio);
+    EXPECT_EQ(component.sensorSize, validSensorSize);
+    EXPECT_EQ(component.focalLength, validFocalLength);
+    EXPECT_EQ(component.aperture, validAperture);
+    EXPECT_EQ(component.shutterSpeed, validShutterSpeed);
+    EXPECT_EQ(component.sensitivity, validSensitivity);
   }
 
   // Aspect ratio
   for (const auto &invalidNode : invalidNodes) {
     auto [node, entity] = createNode();
-    node["components"]["camera"]["fov"] = validFov;
     node["components"]["camera"]["near"] = validNear;
     node["components"]["camera"]["far"] = validFar;
+    node["components"]["camera"]["sensorSize"] = validSensorSize;
+    node["components"]["camera"]["focalLength"] = validFocalLength;
     node["components"]["camera"]["aspectRatio"] = invalidNode;
+    node["components"]["camera"]["aperture"] = validAperture;
+    node["components"]["camera"]["shutterSpeed"] = validShutterSpeed;
+    node["components"]["camera"]["sensitivity"] = validSensitivity;
 
     sceneLoader.loadComponents(node, entity, entityIdCache).getData();
 
@@ -1022,17 +1024,194 @@ TEST_F(SceneLoaderCameraTest,
 
     const auto &component = entityDatabase.get<liquid::PerspectiveLens>(entity);
 
-    EXPECT_EQ(component.fovY, validFov);
     EXPECT_EQ(component.near, validNear);
     EXPECT_EQ(component.far, validFar);
     EXPECT_EQ(component.aspectRatio, defaults.aspectRatio);
+    EXPECT_EQ(component.sensorSize, validSensorSize);
+    EXPECT_EQ(component.focalLength, validFocalLength);
+    EXPECT_EQ(component.aperture, validAperture);
+    EXPECT_EQ(component.shutterSpeed, validShutterSpeed);
+    EXPECT_EQ(component.sensitivity, validSensitivity);
   }
+
+  // Sensor size
+  for (const auto &invalidNode : invalidNodes) {
+    auto [node, entity] = createNode();
+    node["components"]["camera"]["near"] = validNear;
+    node["components"]["camera"]["far"] = validFar;
+    node["components"]["camera"]["aspectRatio"] = validAspectRatio;
+    node["components"]["camera"]["sensorSize"] = invalidNode;
+    node["components"]["camera"]["focalLength"] = validFocalLength;
+    node["components"]["camera"]["aperture"] = validAperture;
+    node["components"]["camera"]["shutterSpeed"] = validShutterSpeed;
+    node["components"]["camera"]["sensitivity"] = validSensitivity;
+
+    sceneLoader.loadComponents(node, entity, entityIdCache).getData();
+
+    EXPECT_TRUE(entityDatabase.has<liquid::PerspectiveLens>(entity));
+    EXPECT_FALSE(entityDatabase.has<liquid::AutoAspectRatio>(entity));
+
+    const auto &component = entityDatabase.get<liquid::PerspectiveLens>(entity);
+
+    EXPECT_EQ(component.near, validNear);
+    EXPECT_EQ(component.far, validFar);
+    EXPECT_EQ(component.aspectRatio, validAspectRatio);
+    EXPECT_EQ(component.sensorSize, defaults.sensorSize);
+    EXPECT_EQ(component.focalLength, validFocalLength);
+    EXPECT_EQ(component.aperture, validAperture);
+    EXPECT_EQ(component.shutterSpeed, validShutterSpeed);
+    EXPECT_EQ(component.sensitivity, validSensitivity);
+  }
+
+  // Focal length
+  for (const auto &invalidNode : invalidNodes) {
+    auto [node, entity] = createNode();
+    node["components"]["camera"]["near"] = validNear;
+    node["components"]["camera"]["far"] = validFar;
+    node["components"]["camera"]["aspectRatio"] = validAspectRatio;
+    node["components"]["camera"]["sensorSize"] = validSensorSize;
+    node["components"]["camera"]["focalLength"] = invalidNode;
+    node["components"]["camera"]["aperture"] = validAperture;
+    node["components"]["camera"]["shutterSpeed"] = validShutterSpeed;
+    node["components"]["camera"]["sensitivity"] = validSensitivity;
+
+    sceneLoader.loadComponents(node, entity, entityIdCache).getData();
+
+    EXPECT_TRUE(entityDatabase.has<liquid::PerspectiveLens>(entity));
+    EXPECT_FALSE(entityDatabase.has<liquid::AutoAspectRatio>(entity));
+
+    const auto &component = entityDatabase.get<liquid::PerspectiveLens>(entity);
+
+    EXPECT_EQ(component.near, validNear);
+    EXPECT_EQ(component.far, validFar);
+    EXPECT_EQ(component.aspectRatio, validAspectRatio);
+    EXPECT_EQ(component.sensorSize, validSensorSize);
+    EXPECT_EQ(component.focalLength, defaults.focalLength);
+    EXPECT_EQ(component.aperture, validAperture);
+    EXPECT_EQ(component.shutterSpeed, validShutterSpeed);
+    EXPECT_EQ(component.sensitivity, validSensitivity);
+  }
+
+  // Aperture
+  for (const auto &invalidNode : invalidNodes) {
+    auto [node, entity] = createNode();
+    node["components"]["camera"]["near"] = validNear;
+    node["components"]["camera"]["far"] = validFar;
+    node["components"]["camera"]["aspectRatio"] = validAspectRatio;
+    node["components"]["camera"]["sensorSize"] = validSensorSize;
+    node["components"]["camera"]["focalLength"] = validFocalLength;
+    node["components"]["camera"]["aperture"] = invalidNode;
+    node["components"]["camera"]["shutterSpeed"] = validShutterSpeed;
+    node["components"]["camera"]["sensitivity"] = validSensitivity;
+
+    sceneLoader.loadComponents(node, entity, entityIdCache).getData();
+
+    EXPECT_TRUE(entityDatabase.has<liquid::PerspectiveLens>(entity));
+    EXPECT_FALSE(entityDatabase.has<liquid::AutoAspectRatio>(entity));
+
+    const auto &component = entityDatabase.get<liquid::PerspectiveLens>(entity);
+
+    EXPECT_EQ(component.near, validNear);
+    EXPECT_EQ(component.far, validFar);
+    EXPECT_EQ(component.aspectRatio, validAspectRatio);
+    EXPECT_EQ(component.sensorSize, validSensorSize);
+    EXPECT_EQ(component.focalLength, validFocalLength);
+    EXPECT_EQ(component.aperture, defaults.aperture);
+    EXPECT_EQ(component.shutterSpeed, validShutterSpeed);
+    EXPECT_EQ(component.sensitivity, validSensitivity);
+  }
+
+  // Shutter speed
+  for (const auto &invalidNode : invalidNodes) {
+    auto [node, entity] = createNode();
+    node["components"]["camera"]["near"] = validNear;
+    node["components"]["camera"]["far"] = validFar;
+    node["components"]["camera"]["aspectRatio"] = validAspectRatio;
+    node["components"]["camera"]["sensorSize"] = validSensorSize;
+    node["components"]["camera"]["focalLength"] = validFocalLength;
+    node["components"]["camera"]["aperture"] = validAperture;
+    node["components"]["camera"]["shutterSpeed"] = invalidNode;
+    node["components"]["camera"]["sensitivity"] = validSensitivity;
+
+    sceneLoader.loadComponents(node, entity, entityIdCache).getData();
+
+    EXPECT_TRUE(entityDatabase.has<liquid::PerspectiveLens>(entity));
+    EXPECT_FALSE(entityDatabase.has<liquid::AutoAspectRatio>(entity));
+
+    const auto &component = entityDatabase.get<liquid::PerspectiveLens>(entity);
+
+    EXPECT_EQ(component.near, validNear);
+    EXPECT_EQ(component.far, validFar);
+    EXPECT_EQ(component.aspectRatio, validAspectRatio);
+    EXPECT_EQ(component.sensorSize, validSensorSize);
+    EXPECT_EQ(component.focalLength, validFocalLength);
+    EXPECT_EQ(component.aperture, validAperture);
+    EXPECT_EQ(component.shutterSpeed, defaults.shutterSpeed);
+    EXPECT_EQ(component.sensitivity, validSensitivity);
+  }
+
+  // Sensitivity
+  for (const auto &invalidNode : invalidNodes) {
+    auto [node, entity] = createNode();
+    node["components"]["camera"]["near"] = validNear;
+    node["components"]["camera"]["far"] = validFar;
+    node["components"]["camera"]["aspectRatio"] = validAspectRatio;
+    node["components"]["camera"]["sensorSize"] = validSensorSize;
+    node["components"]["camera"]["focalLength"] = validFocalLength;
+    node["components"]["camera"]["aperture"] = validAperture;
+    node["components"]["camera"]["shutterSpeed"] = validShutterSpeed;
+    node["components"]["camera"]["sensitivity"] = invalidNode;
+
+    sceneLoader.loadComponents(node, entity, entityIdCache).getData();
+
+    EXPECT_TRUE(entityDatabase.has<liquid::PerspectiveLens>(entity));
+    EXPECT_FALSE(entityDatabase.has<liquid::AutoAspectRatio>(entity));
+
+    const auto &component = entityDatabase.get<liquid::PerspectiveLens>(entity);
+
+    EXPECT_EQ(component.near, validNear);
+    EXPECT_EQ(component.far, validFar);
+    EXPECT_EQ(component.aspectRatio, validAspectRatio);
+    EXPECT_EQ(component.sensorSize, validSensorSize);
+    EXPECT_EQ(component.focalLength, validFocalLength);
+    EXPECT_EQ(component.aperture, validAperture);
+    EXPECT_EQ(component.shutterSpeed, validShutterSpeed);
+    EXPECT_EQ(component.sensitivity, defaults.sensitivity);
+  }
+}
+
+TEST_F(SceneLoaderCameraTest,
+       CreatesCameraComponentWithDefaultValuesIfValuesAreNegative) {
+  liquid::PerspectiveLens defaults{};
+
+  auto [node, entity] = createNode();
+  node["components"]["camera"]["near"] = -1.0f;
+  node["components"]["camera"]["far"] = -2.0f;
+  node["components"]["camera"]["aspectRatio"] = -3.0f;
+  node["components"]["camera"]["sensorSize"] = glm::vec2(-1.0f, 2.5f);
+  node["components"]["camera"]["focalLength"] = -2.5f;
+  node["components"]["camera"]["aperture"] = -2.5f;
+  node["components"]["camera"]["shutterSpeed"] = -2.5f;
+
+  sceneLoader.loadComponents(node, entity, entityIdCache).getData();
+
+  EXPECT_TRUE(entityDatabase.has<liquid::PerspectiveLens>(entity));
+
+  const auto &component = entityDatabase.get<liquid::PerspectiveLens>(entity);
+
+  EXPECT_EQ(component.near, defaults.near);
+  EXPECT_EQ(component.far, defaults.far);
+  EXPECT_EQ(component.aspectRatio, defaults.aspectRatio);
+  EXPECT_EQ(component.sensorSize, defaults.sensorSize);
+  EXPECT_EQ(component.focalLength, defaults.focalLength);
+  EXPECT_EQ(component.aperture, defaults.aperture);
+  EXPECT_EQ(component.shutterSpeed, defaults.shutterSpeed);
 }
 
 TEST_F(SceneLoaderCameraTest, CreatesCameraComponentWithDefaultValues) {
   liquid::Camera defaults{};
   auto [node, entity] = createNode();
-  node["components"]["camera"]["fov"] = 20.0f;
+  node["components"]["camera"]["focalLength"] = 20.0f;
   sceneLoader.loadComponents(node, entity, entityIdCache).getData();
 
   EXPECT_TRUE(entityDatabase.has<liquid::Camera>(entity));
@@ -1060,25 +1239,37 @@ TEST_F(SceneLoaderCameraTest,
 }
 
 TEST_F(SceneLoaderCameraTest, CreatesCameraComponentWithFileDataIfValidField) {
-  float validFov = 65.0f;
   float validNear = 0.5f;
   float validFar = 1000.0f;
   float validAspectRatio = 2.0f;
+  glm::vec2 validSensorSize{50.0f, 45.0f};
+  float validFocalLength = 100.0f;
+  float validAperture = 2.5f;
+  float validShutterSpeed = 0.125f;
+  uint32_t validSensitivity = 2500;
 
   auto [node, entity] = createNode();
-  node["components"]["camera"]["fov"] = validFov;
   node["components"]["camera"]["near"] = validNear;
   node["components"]["camera"]["far"] = validFar;
   node["components"]["camera"]["aspectRatio"] = validAspectRatio;
+  node["components"]["camera"]["sensorSize"] = validSensorSize;
+  node["components"]["camera"]["focalLength"] = validFocalLength;
+  node["components"]["camera"]["aperture"] = validAperture;
+  node["components"]["camera"]["shutterSpeed"] = validShutterSpeed;
+  node["components"]["camera"]["sensitivity"] = validSensitivity;
 
   sceneLoader.loadComponents(node, entity, entityIdCache).getData();
 
   const auto &lens = entityDatabase.get<liquid::PerspectiveLens>(entity);
 
-  EXPECT_EQ(lens.fovY, validFov);
   EXPECT_EQ(lens.near, validNear);
   EXPECT_EQ(lens.far, validFar);
   EXPECT_EQ(lens.aspectRatio, validAspectRatio);
+  EXPECT_EQ(lens.sensorSize, validSensorSize);
+  EXPECT_EQ(lens.focalLength, validFocalLength);
+  EXPECT_EQ(lens.aperture, validAperture);
+  EXPECT_EQ(lens.shutterSpeed, validShutterSpeed);
+  EXPECT_EQ(lens.sensitivity, validSensitivity);
 }
 
 using SceneLoaderAudioTest = SceneLoaderTest;


### PR DESCRIPTION
- Add aperture, shutter speed, and sensitivity to perspective lens
- Add exposure to camera
- Calculate EV100 from from perspective lens properties
- Apply exposure to final texture after bloom
- Replace FOV with focal length and sensor size
- Rename push constant prefix to uniform
- Add vec2 serialization to Yaml
- Add vec2 input to Input widget
- Rename scene updater test