### PR TITLE
Use Vulkan synchronization 2

### DIFF
--- a/editor/src/liquidator/asset/HDRIImporter.cpp
+++ b/editor/src/liquidator/asset/HDRIImporter.cpp
@@ -271,16 +271,12 @@ HDRIImporter::convertEquirectangularToCubemap(float *data, uint32_t width,
 
     auto commandList = device->requestImmediateCommandList();
 
-    std::array<rhi::MemoryBarrier, 1> memoryBarriers{
-        {rhi::MemoryBarrier{rhi::Access::None, rhi::Access::ShaderWrite}}};
-    std::array<rhi::ImageBarrier, 1> imageBarriers{
-        {rhi::ImageBarrier{rhi::Access::None, rhi::Access::ShaderWrite,
-                           rhi::ImageLayout::Undefined,
-                           rhi::ImageLayout::General, unfilteredCubemap}}};
+    std::array<rhi::ImageBarrier, 1> imageBarriers{{rhi::ImageBarrier{
+        rhi::Access::None, rhi::Access::ShaderWrite, rhi::PipelineStage::None,
+        rhi::PipelineStage::ComputeShader, rhi::ImageLayout::Undefined,
+        rhi::ImageLayout::General, unfilteredCubemap}}};
 
-    commandList.pipelineBarrier(rhi::PipelineStage::PipeTop,
-                                rhi::PipelineStage::ComputeShader,
-                                memoryBarriers, imageBarriers, {});
+    commandList.pipelineBarrier({}, imageBarriers, {});
 
     commandList.bindPipeline(mPipelineGenerateCubemap);
     commandList.bindDescriptor(mPipelineGenerateCubemap, 0,
@@ -327,21 +323,17 @@ HDRIImporter::generateIrradianceMap(const CubemapData &unfilteredCubemap,
 
   auto commandList = device->requestImmediateCommandList();
 
-  std::array<rhi::MemoryBarrier, 2> memoryBarriers{
-      rhi::MemoryBarrier{rhi::Access::None, rhi::Access::ShaderRead},
-      rhi::MemoryBarrier{rhi::Access::None, rhi::Access::ShaderWrite}};
-
   std::array<rhi::ImageBarrier, 2> imageBarriers{
       rhi::ImageBarrier{
-          rhi::Access::None, rhi::Access::ShaderRead, rhi::ImageLayout::General,
+          rhi::Access::None, rhi::Access::ShaderRead, rhi::PipelineStage::None,
+          rhi::PipelineStage::ComputeShader, rhi::ImageLayout::General,
           rhi::ImageLayout::ShaderReadOnlyOptimal, unfilteredCubemap.texture},
-      rhi::ImageBarrier{rhi::Access::None, rhi::Access::ShaderWrite,
-                        rhi::ImageLayout::Undefined, rhi::ImageLayout::General,
-                        irradianceCubemap}};
+      rhi::ImageBarrier{
+          rhi::Access::None, rhi::Access::ShaderWrite, rhi::PipelineStage::None,
+          rhi::PipelineStage::ComputeShader, rhi::ImageLayout::Undefined,
+          rhi::ImageLayout::General, irradianceCubemap}};
 
-  commandList.pipelineBarrier(rhi::PipelineStage::PipeTop,
-                              rhi::PipelineStage::ComputeShader, memoryBarriers,
-                              imageBarriers, {});
+  commandList.pipelineBarrier({}, imageBarriers, {});
 
   commandList.bindPipeline(mPipelineGenerateIrradianceMap);
   commandList.bindDescriptor(mPipelineGenerateIrradianceMap, 0,

--- a/engine/rhi/core/include/liquid/rhi/AccessFlags.h
+++ b/engine/rhi/core/include/liquid/rhi/AccessFlags.h
@@ -2,25 +2,28 @@
 
 namespace liquid::rhi {
 
-enum class Access {
+enum class Access : uint64_t {
   None = 0,
-  IndirectCommandRead = 0x00000001,
-  IndexRead = 0x00000002,
-  VertexAttributeRead = 0x00000004,
-  UniformRead = 0x00000008,
-  InputAttachmentRead = 0x00000010,
-  ShaderRead = 0x00000020,
-  ShaderWrite = 0x00000040,
-  ColorAttachmentRead = 0x00000080,
-  ColorAttachmentWrite = 0x00000100,
-  DepthStencilAttachmentRead = 0x00000200,
-  DepthStencilAttachmentWrite = 0x00000400,
-  TransferRead = 0x00000800,
-  TransferWrite = 0x00001000,
-  HostRead = 0x00002000,
-  HostWrite = 0x00004000,
-  MemoryRead = 0x00008000,
-  MemoryWrite = 0x00010000,
+  IndirectCommandRead = 0x00000001ULL,
+  IndexRead = 0x00000002ULL,
+  VertexAttributeRead = 0x00000004ULL,
+  UniformRead = 0x00000008ULL,
+  InputAttachmentRead = 0x00000010ULL,
+  ShaderRead = 0x00000020ULL,
+  ShaderWrite = 0x00000040ULL,
+  ColorAttachmentRead = 0x00000080ULL,
+  ColorAttachmentWrite = 0x00000100ULL,
+  DepthStencilAttachmentRead = 0x00000200ULL,
+  DepthStencilAttachmentWrite = 0x00000400ULL,
+  TransferRead = 0x00000800ULL,
+  TransferWrite = 0x00001000ULL,
+  HostRead = 0x00002000ULL,
+  HostWrite = 0x00004000ULL,
+  MemoryRead = 0x00008000ULL,
+  MemoryWrite = 0x00010000ULL,
+  ShaderSampledRead = 0x100000000ULL,
+  ShaderStorageRead = 0x200000000ULL,
+  ShaderStorageWrite = 0x400000000ULL
 };
 
 EnableBitwiseEnum(Access)

--- a/engine/rhi/core/include/liquid/rhi/ImageLayout.h
+++ b/engine/rhi/core/include/liquid/rhi/ImageLayout.h
@@ -12,7 +12,9 @@ enum class ImageLayout {
   TransferSourceOptimal = 6,
   TransferDestinationOptimal = 7,
   Preinitialized = 8,
-  PresentSource = 1000001002
+  PresentSource = 1000001002,
+  ReadOnlyOptimal = 1000314000,
+  AttachmentOptional = 1000314001,
 };
 
 } // namespace liquid::rhi

--- a/engine/rhi/core/include/liquid/rhi/NativeRenderCommandListInterface.h
+++ b/engine/rhi/core/include/liquid/rhi/NativeRenderCommandListInterface.h
@@ -154,14 +154,11 @@ public:
   /**
    * @brief Pipeline barrier
    *
-   * @param srcStage Source pipeline stage
-   * @param dstStage Destination pipeline stage
    * @param memoryBarriers Memory barriers
    * @param imageBarriers Image barriers
    * @param bufferBarriers Buffer barriers
    */
-  virtual void pipelineBarrier(PipelineStage srcStage, PipelineStage dstStage,
-                               std::span<MemoryBarrier> memoryBarriers,
+  virtual void pipelineBarrier(std::span<MemoryBarrier> memoryBarriers,
                                std::span<ImageBarrier> imageBarriers,
                                std::span<BufferBarrier> bufferBarriers) = 0;
 

--- a/engine/rhi/core/include/liquid/rhi/PipelineBarrier.h
+++ b/engine/rhi/core/include/liquid/rhi/PipelineBarrier.h
@@ -3,6 +3,7 @@
 #include "RenderHandle.h"
 #include "AccessFlags.h"
 #include "ImageLayout.h"
+#include "StageFlags.h"
 
 namespace liquid::rhi {
 
@@ -19,6 +20,16 @@ struct MemoryBarrier {
    * Destination access flags
    */
   Access dstAccess{Access::None};
+
+  /**
+   * Source pipeline stage
+   */
+  PipelineStage srcStage{PipelineStage::None};
+
+  /**
+   * Destination pipeline stage
+   */
+  PipelineStage dstStage{PipelineStage::None};
 };
 
 /**
@@ -34,6 +45,16 @@ struct ImageBarrier {
    * Destination access flags
    */
   Access dstAccess{Access::None};
+
+  /**
+   * Source pipeline stage
+   */
+  PipelineStage srcStage{PipelineStage::None};
+
+  /**
+   * Destination pipeline stage
+   */
+  PipelineStage dstStage{PipelineStage::None};
 
   /**
    * Source image layout
@@ -74,6 +95,16 @@ struct BufferBarrier {
    * Destination access flags
    */
   Access dstAccess{Access::None};
+
+  /**
+   * Source pipeline stage
+   */
+  PipelineStage srcStage{PipelineStage::None};
+
+  /**
+   * Destination pipeline stage
+   */
+  PipelineStage dstStage{PipelineStage::None};
 
   /**
    * Buffer handle

--- a/engine/rhi/core/include/liquid/rhi/RenderCommandList.h
+++ b/engine/rhi/core/include/liquid/rhi/RenderCommandList.h
@@ -209,18 +209,15 @@ public:
   /**
    * @brief Pipeline barrier
    *
-   * @param srcStage Source pipeline stage
-   * @param dstStage Destination pipeline stage
    * @param memoryBarriers Memory barriers
    * @param imageBarriers Image barriers
    * @param bufferBarriers Buffer barriers
    */
-  inline void pipelineBarrier(PipelineStage srcStage, PipelineStage dstStage,
-                              std::span<MemoryBarrier> memoryBarriers,
+  inline void pipelineBarrier(std::span<MemoryBarrier> memoryBarriers,
                               std::span<ImageBarrier> imageBarriers,
                               std::span<BufferBarrier> bufferBarriers) {
-    mNativeRenderCommandList->pipelineBarrier(
-        srcStage, dstStage, memoryBarriers, imageBarriers, bufferBarriers);
+    mNativeRenderCommandList->pipelineBarrier(memoryBarriers, imageBarriers,
+                                              bufferBarriers);
   }
 
   /**

--- a/engine/rhi/core/include/liquid/rhi/StageFlags.h
+++ b/engine/rhi/core/include/liquid/rhi/StageFlags.h
@@ -12,22 +12,25 @@ enum class ShaderStage {
 
 EnableBitwiseEnum(ShaderStage);
 
-enum class PipelineStage {
-  PipeTop = 0x00000001,
-  DrawIndirect = 0x00000002,
-  VertexInput = 0x00000004,
-  VertexShader = 0x00000008,
-  FragmentShader = 0x00000080,
-  EarlyFragmentTests = 0x00000100,
-  LateFragmentTests = 0x00000200,
-  ColorAttachmentOutput = 0x00000400,
-  ComputeShader = 0x00000800,
-  Transfer = 0x00001000,
-  PipeBottom = 0x00002000,
-  Host = 0x00004000,
-  AllGraphics = 0x00008000,
-  AllCommands = 0x00010000,
-  None = 0
+enum class PipelineStage : uint64_t {
+  None = 0ULL,
+  DrawIndirect = 0x00000002ULL,
+  VertexShader = 0x00000008ULL,
+  FragmentShader = 0x00000080ULL,
+  EarlyFragmentTests = 0x00000100ULL,
+  LateFragmentTests = 0x00000200ULL,
+  ColorAttachmentOutput = 0x00000400ULL,
+  ComputeShader = 0x00000800ULL,
+  Transfer = 0x00001000ULL,
+  Host = 0x00004000ULL,
+  AllGraphics = 0x00008000ULL,
+  AllCommands = 0x00010000ULL,
+  Copy = 0x100000000ULL,
+  Resolve = 0x200000000ULL,
+  Blit = 0x400000000ULL,
+  Clear = 0x800000000ULL,
+  IndexInput = 0x1000000000ULL,
+  VertexAttributeInput = 0x2000000000ULL
 };
 
 EnableBitwiseEnum(PipelineStage);

--- a/engine/rhi/mock/include/liquid/rhi-mock/MockCommandList.h
+++ b/engine/rhi/mock/include/liquid/rhi-mock/MockCommandList.h
@@ -144,14 +144,11 @@ public:
   /**
    * @brief Pipeline barrier
    *
-   * @param srcStage Source pipeline stage
-   * @param dstStage Destination pipeline stage
    * @param memoryBarriers Memory barriers
    * @param imageBarriers Image barriers
    * @param bufferBarriers Buffer barriers
    */
-  void pipelineBarrier(PipelineStage srcStage, PipelineStage dstStage,
-                       std::span<MemoryBarrier> memoryBarriers,
+  void pipelineBarrier(std::span<MemoryBarrier> memoryBarriers,
                        std::span<ImageBarrier> imageBarriers,
                        std::span<BufferBarrier> bufferBarriers) override;
 

--- a/engine/rhi/mock/src/MockCommandList.cpp
+++ b/engine/rhi/mock/src/MockCommandList.cpp
@@ -151,14 +151,10 @@ void MockCommandList::setScissor(const glm::ivec2 &offset,
   mCommands.push_back(std::unique_ptr<MockCommand>(command));
 }
 
-void MockCommandList::pipelineBarrier(PipelineStage srcStage,
-                                      PipelineStage dstStage,
-                                      std::span<MemoryBarrier> memoryBarriers,
+void MockCommandList::pipelineBarrier(std::span<MemoryBarrier> memoryBarriers,
                                       std::span<ImageBarrier> imageBarriers,
                                       std::span<BufferBarrier> bufferBarriers) {
   auto *command = new MockCommandPipelineBarrier;
-  command->srcStage = srcStage;
-  command->dstStage = dstStage;
   command->memoryBarriers = vectorFrom(memoryBarriers);
   command->imageBarriers = vectorFrom(imageBarriers);
   command->bufferBarriers = vectorFrom(bufferBarriers);

--- a/engine/rhi/vulkan/include/liquid/rhi-vulkan/VulkanCommandBuffer.h
+++ b/engine/rhi/vulkan/include/liquid/rhi-vulkan/VulkanCommandBuffer.h
@@ -164,14 +164,11 @@ public:
   /**
    * @brief Pipeline barrier
    *
-   * @param srcStage Source pipeline stage
-   * @param dstStage Destination pipeline stage
    * @param memoryBarriers Memory barriers
    * @param imageBarriers Image barriers
    * @param bufferBarriers Buffer barriers
    */
-  void pipelineBarrier(PipelineStage srcStage, PipelineStage dstStage,
-                       std::span<MemoryBarrier> memoryBarriers,
+  void pipelineBarrier(std::span<MemoryBarrier> memoryBarriers,
                        std::span<ImageBarrier> imageBarriers,
                        std::span<BufferBarrier> bufferBarriers) override;
 

--- a/engine/rhi/vulkan/include/liquid/rhi-vulkan/VulkanMapping.h
+++ b/engine/rhi/vulkan/include/liquid/rhi-vulkan/VulkanMapping.h
@@ -124,7 +124,7 @@ public:
    * @param access Access
    * @return Vulkan access flags
    */
-  static VkAccessFlags getAccessFlags(Access access);
+  static VkAccessFlags2 getAccessFlags(Access access);
 
   /**
    * @brief Get Vulkan image layout
@@ -157,7 +157,7 @@ public:
    * @param pipelineStage Pipeline stage
    * @return Vulkan pipeline stage flags
    */
-  static VkPipelineStageFlags
+  static VkPipelineStageFlags2
   getPipelineStageFlags(PipelineStage pipelineStage);
 
   /**

--- a/engine/rhi/vulkan/include/liquid/rhi-vulkan/VulkanQueue.h
+++ b/engine/rhi/vulkan/include/liquid/rhi-vulkan/VulkanQueue.h
@@ -5,36 +5,6 @@
 namespace liquid::rhi {
 
 /**
- * @brief Vulkan submit info
- */
-struct VulkanSubmitInfo {
-  /**
-   * Pipeline stage flags to wait for
-   */
-  VkPipelineStageFlags waitStages;
-
-  /**
-   * Semaphores to wait for
-   */
-  std::vector<VkSemaphore> waitSemaphores;
-
-  /**
-   * Semaphores to signal
-   */
-  std::vector<VkSemaphore> signalSemaphores;
-
-  /**
-   * Fence to signal
-   */
-  VkFence fence = VK_NULL_HANDLE;
-
-  /**
-   * Command buffers
-   */
-  std::vector<VkCommandBuffer> commandBuffers;
-};
-
-/**
  * @brief Vulkan queue
  */
 class VulkanQueue {
@@ -71,9 +41,15 @@ public:
   /**
    * @brief Submit queue
    *
-   * @param submitInfo Submit info
+   * @param fence Submission fence
+   * @param commandBufferInfos Command buffer infos
+   * @param waitSemaphoreInfos Command buffer infos
+   * @param signalSemaphoreInfos Command buffer infos
    */
-  void submit(VulkanSubmitInfo submitInfo);
+  void submit(VkFence fence,
+              std::span<VkCommandBufferSubmitInfo> commandBufferInfos,
+              std::span<VkSemaphoreSubmitInfo> waitSemaphoreInfos,
+              std::span<VkSemaphoreSubmitInfo> signalSemaphoreInfos);
 
   /**
    * @brief Wait for idle

--- a/engine/rhi/vulkan/src/VulkanDeviceObject.cpp
+++ b/engine/rhi/vulkan/src/VulkanDeviceObject.cpp
@@ -60,6 +60,7 @@ VulkanDeviceObject::VulkanDeviceObject(
   extensions.push_back(VK_KHR_SWAPCHAIN_EXTENSION_NAME);
   extensions.push_back(VK_EXT_SHADER_VIEWPORT_INDEX_LAYER_EXTENSION_NAME);
   extensions.push_back(VK_KHR_SHADER_DRAW_PARAMETERS_EXTENSION_NAME);
+  extensions.push_back(VK_KHR_SYNCHRONIZATION_2_EXTENSION_NAME);
 
   const auto &portabilityExt = std::find_if(
       pdExtensions.cbegin(), pdExtensions.cend(), [](const auto &ext) {
@@ -87,11 +88,17 @@ VulkanDeviceObject::VulkanDeviceObject(
       VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_BUFFER_DEVICE_ADDRESS_FEATURES;
   bufferDeviceAddressFeatures.pNext = &descriptorIndexingFeatures;
 
+  VkPhysicalDeviceSynchronization2Features sync2Features{};
+  sync2Features.sType =
+      VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SYNCHRONIZATION_2_FEATURES;
+  sync2Features.pNext = &bufferDeviceAddressFeatures;
+
   VkPhysicalDeviceFeatures2 deviceFeatures{};
   deviceFeatures.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2;
-  deviceFeatures.pNext = &bufferDeviceAddressFeatures;
+  deviceFeatures.pNext = &sync2Features;
   vkGetPhysicalDeviceFeatures2(physicalDevice, &deviceFeatures);
 
+  assertFeature(sync2Features.synchronization2, "Synchronization 2");
   assertFeature(bufferDeviceAddressFeatures.bufferDeviceAddress,
                 "Buffer device address > Buffer device address");
   assertFeature(descriptorIndexingFeatures.descriptorBindingPartiallyBound,

--- a/engine/rhi/vulkan/src/VulkanMapping.cpp
+++ b/engine/rhi/vulkan/src/VulkanMapping.cpp
@@ -226,8 +226,8 @@ VulkanMapping::getDescriptorType(DescriptorType descriptorType) {
   }
 }
 
-VkAccessFlags VulkanMapping::getAccessFlags(Access access) {
-  return static_cast<VkAccessFlags>(access);
+VkAccessFlags2 VulkanMapping::getAccessFlags(Access access) {
+  return static_cast<VkAccessFlags2>(access);
 }
 
 VkImageLayout VulkanMapping::getImageLayout(ImageLayout imageLayout) {
@@ -250,6 +250,10 @@ VkImageLayout VulkanMapping::getImageLayout(ImageLayout imageLayout) {
     return VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL;
   case ImageLayout::Preinitialized:
     return VK_IMAGE_LAYOUT_PREINITIALIZED;
+  case ImageLayout::ReadOnlyOptimal:
+    return VK_IMAGE_LAYOUT_READ_ONLY_OPTIMAL;
+  case ImageLayout::AttachmentOptional:
+    return VK_IMAGE_LAYOUT_ATTACHMENT_OPTIMAL;
   case ImageLayout::PresentSource:
     return VK_IMAGE_LAYOUT_PRESENT_SRC_KHR;
   default:
@@ -273,9 +277,9 @@ VkShaderStageFlags VulkanMapping::getShaderStageFlags(ShaderStage shaderStage) {
   return static_cast<VkShaderStageFlags>(shaderStage);
 }
 
-VkPipelineStageFlags
+VkPipelineStageFlags2
 VulkanMapping::getPipelineStageFlags(PipelineStage pipelineStage) {
-  return static_cast<VkPipelineStageFlags>(pipelineStage);
+  return static_cast<VkPipelineStageFlags2>(pipelineStage);
 }
 
 VkIndexType VulkanMapping::getIndexType(IndexType indexType) {

--- a/engine/rhi/vulkan/src/VulkanQueue.cpp
+++ b/engine/rhi/vulkan/src/VulkanQueue.cpp
@@ -10,23 +10,26 @@ VulkanQueue::VulkanQueue(VulkanDeviceObject &device, uint32_t queueIndex)
   vkGetDeviceQueue(device, mQueueIndex, 0, &mQueue);
 }
 
-void VulkanQueue::submit(VulkanSubmitInfo submitInfo) {
-  std::array<VkPipelineStageFlags, 1> waitStages{submitInfo.waitStages};
-  VkSubmitInfo vkSubmitInfo{};
-  vkSubmitInfo.sType = VK_STRUCTURE_TYPE_SUBMIT_INFO;
-  vkSubmitInfo.pNext = nullptr;
-  vkSubmitInfo.waitSemaphoreCount =
-      static_cast<uint32_t>(submitInfo.waitSemaphores.size());
-  vkSubmitInfo.pWaitSemaphores = submitInfo.waitSemaphores.data();
-  vkSubmitInfo.pWaitDstStageMask = waitStages.data();
-  vkSubmitInfo.commandBufferCount =
-      static_cast<uint32_t>(submitInfo.commandBuffers.size());
-  vkSubmitInfo.pCommandBuffers = submitInfo.commandBuffers.data();
-  vkSubmitInfo.signalSemaphoreCount =
-      static_cast<uint32_t>(submitInfo.signalSemaphores.size());
-  vkSubmitInfo.pSignalSemaphores = submitInfo.signalSemaphores.data();
+void VulkanQueue::submit(
+    VkFence fence, std::span<VkCommandBufferSubmitInfo> commandBufferInfos,
+    std::span<VkSemaphoreSubmitInfo> waitSemaphoreInfos,
+    std::span<VkSemaphoreSubmitInfo> signalSemaphoreInfos) {
 
-  checkForVulkanError(vkQueueSubmit(mQueue, 1, &vkSubmitInfo, submitInfo.fence),
+  VkSubmitInfo2 submitInfo{};
+  submitInfo.sType = VK_STRUCTURE_TYPE_SUBMIT_INFO_2;
+  submitInfo.pNext = nullptr;
+  submitInfo.flags = 0;
+  submitInfo.commandBufferInfoCount =
+      static_cast<uint32_t>(commandBufferInfos.size());
+  submitInfo.pCommandBufferInfos = commandBufferInfos.data();
+  submitInfo.waitSemaphoreInfoCount =
+      static_cast<uint32_t>(waitSemaphoreInfos.size());
+  submitInfo.pWaitSemaphoreInfos = waitSemaphoreInfos.data();
+  submitInfo.signalSemaphoreInfoCount =
+      static_cast<uint32_t>(signalSemaphoreInfos.size());
+  submitInfo.pSignalSemaphoreInfos = signalSemaphoreInfos.data();
+
+  checkForVulkanError(vkQueueSubmit2KHR(mQueue, 1, &submitInfo, fence),
                       "Failed to submit to queue");
 }
 

--- a/engine/rhi/vulkan/src/VulkanRenderDevice.cpp
+++ b/engine/rhi/vulkan/src/VulkanRenderDevice.cpp
@@ -70,10 +70,16 @@ void VulkanRenderDevice::submitImmediate(RenderCommandList &commandList) {
 
   vkEndCommandBuffer(commandBuffer);
 
-  VulkanSubmitInfo submitInfo{};
-  submitInfo.commandBuffers = {commandBuffer};
+  VkCommandBufferSubmitInfo commandBufferInfo{};
+  commandBufferInfo.sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_SUBMIT_INFO;
+  commandBufferInfo.pNext = nullptr;
+  commandBufferInfo.commandBuffer = commandBuffer;
+  commandBufferInfo.deviceMask = 0;
 
-  mGraphicsQueue.submit(submitInfo);
+  std::array<VkCommandBufferSubmitInfo, 1> commandBufferInfos{
+      commandBufferInfo};
+
+  mGraphicsQueue.submit(VK_NULL_HANDLE, commandBufferInfos, {}, {});
   mGraphicsQueue.waitForIdle();
 }
 

--- a/engine/src/liquid/renderer/Presenter.cpp
+++ b/engine/src/liquid/renderer/Presenter.cpp
@@ -131,12 +131,12 @@ void Presenter::present(rhi::RenderCommandList &commandList,
     imageBarrier.dstLayout = rhi::ImageLayout::ShaderReadOnlyOptimal;
     imageBarrier.srcAccess = rhi::Access::ColorAttachmentWrite;
     imageBarrier.dstAccess = rhi::Access::ShaderRead;
+    imageBarrier.srcStage = rhi::PipelineStage::ColorAttachmentOutput;
+    imageBarrier.dstStage = rhi::PipelineStage::FragmentShader;
     imageBarrier.texture = handle;
 
     std::array<rhi::ImageBarrier, 1> barriers{imageBarrier};
-    commandList.pipelineBarrier(rhi::PipelineStage::ColorAttachmentOutput,
-                                rhi::PipelineStage::FragmentShader, {},
-                                barriers, {});
+    commandList.pipelineBarrier({}, barriers, {});
   }
 
   commandList.beginRenderPass(
@@ -161,11 +161,11 @@ void Presenter::present(rhi::RenderCommandList &commandList,
     imageBarrier.texture = handle;
     imageBarrier.srcAccess = rhi::Access::ShaderRead;
     imageBarrier.dstAccess = rhi::Access::ColorAttachmentWrite;
+    imageBarrier.srcStage = rhi::PipelineStage::FragmentShader;
+    imageBarrier.dstStage = rhi::PipelineStage::ColorAttachmentOutput;
 
     std::array<rhi::ImageBarrier, 1> barriers{imageBarrier};
-    commandList.pipelineBarrier(rhi::PipelineStage::FragmentShader,
-                                rhi::PipelineStage::ColorAttachmentOutput, {},
-                                barriers, {});
+    commandList.pipelineBarrier({}, barriers, {});
   }
 }
 

--- a/engine/src/liquid/renderer/RenderGraphPass.h
+++ b/engine/src/liquid/renderer/RenderGraphPass.h
@@ -78,21 +78,6 @@ struct RenderGraphPassBufferData {
  */
 struct RenderGraphPassBarrier {
   /**
-   * Barrier enabled
-   */
-  bool enabled = false;
-
-  /**
-   * Source pipeline stage
-   */
-  rhi::PipelineStage srcStage{rhi::PipelineStage::None};
-
-  /**
-   * Destination pipeline stage
-   */
-  rhi::PipelineStage dstStage{rhi::PipelineStage::None};
-
-  /**
    * Memory barriers
    */
   std::vector<rhi::MemoryBarrier> memoryBarriers;

--- a/engine/src/liquid/renderer/RenderGraphSyncDependency.cpp
+++ b/engine/src/liquid/renderer/RenderGraphSyncDependency.cpp
@@ -60,12 +60,12 @@ RenderGraphSyncDependency::getBufferRead(RenderGraphPassType type,
   rhi::PipelineStage stage = rhi::PipelineStage::None;
 
   if (BitwiseEnumContains(usage, rhi::BufferUsage::Vertex)) {
-    stage |= rhi::PipelineStage::VertexInput;
+    stage |= rhi::PipelineStage::VertexAttributeInput;
     access |= rhi::Access::VertexAttributeRead;
   }
 
   if (BitwiseEnumContains(usage, rhi::BufferUsage::Index)) {
-    stage |= rhi::PipelineStage::VertexInput;
+    stage |= rhi::PipelineStage::IndexInput;
     access |= rhi::Access::IndexRead;
   }
 

--- a/engine/src/liquid/renderer/SceneRenderer.cpp
+++ b/engine/src/liquid/renderer/SceneRenderer.cpp
@@ -546,12 +546,12 @@ SceneRenderPassData SceneRenderer::attach(RenderGraph &graph,
           imageBarrier.dstAccess = rhi::Access::ShaderRead;
           imageBarrier.dstLayout = rhi::ImageLayout::ShaderReadOnlyOptimal;
           imageBarrier.texture = bloomTexture;
+          imageBarrier.srcStage = rhi::PipelineStage::ComputeShader;
+          imageBarrier.dstStage = rhi::PipelineStage::ComputeShader;
 
           std::array<rhi::ImageBarrier, 1> imageBarriers{imageBarrier};
 
-          commandList.pipelineBarrier(rhi::PipelineStage::ComputeShader,
-                                      rhi::PipelineStage::ComputeShader, {},
-                                      imageBarriers, {});
+          commandList.pipelineBarrier({}, imageBarriers, {});
 
           glm::uvec4 texture{static_cast<uint32_t>(source.texture.getHandle()),
                              static_cast<uint32_t>(target.texture.getHandle()),
@@ -579,6 +579,8 @@ SceneRenderPassData SceneRenderer::attach(RenderGraph &graph,
           imageBarrierSrc.srcLayout = rhi::ImageLayout::General;
           imageBarrierSrc.dstAccess = rhi::Access::ShaderRead;
           imageBarrierSrc.dstLayout = rhi::ImageLayout::ShaderReadOnlyOptimal;
+          imageBarrierSrc.srcStage = rhi::PipelineStage::ComputeShader;
+          imageBarrierSrc.dstStage = rhi::PipelineStage::ComputeShader;
           imageBarrierSrc.texture = bloomTexture;
 
           rhi::ImageBarrier imageBarrierDst{};
@@ -589,13 +591,13 @@ SceneRenderPassData SceneRenderer::attach(RenderGraph &graph,
           imageBarrierDst.dstAccess = rhi::Access::ShaderWrite;
           imageBarrierDst.dstLayout = rhi::ImageLayout::General;
           imageBarrierDst.texture = bloomTexture;
+          imageBarrierDst.srcStage = rhi::PipelineStage::ComputeShader;
+          imageBarrierDst.dstStage = rhi::PipelineStage::ComputeShader;
 
           std::array<rhi::ImageBarrier, 2> imageBarriers{imageBarrierSrc,
                                                          imageBarrierDst};
 
-          commandList.pipelineBarrier(rhi::PipelineStage::ComputeShader,
-                                      rhi::PipelineStage::ComputeShader, {},
-                                      imageBarriers, {});
+          commandList.pipelineBarrier({}, imageBarriers, {});
 
           const auto &source = bloomChain.at(level);
           const auto &target = bloomChain.at(level - 1);

--- a/engine/src/liquid/renderer/TextureUtils.cpp
+++ b/engine/src/liquid/renderer/TextureUtils.cpp
@@ -24,12 +24,12 @@ void TextureUtils::copyDataToTexture(
   barrier.dstAccess = rhi::Access::TransferWrite;
   barrier.srcLayout = rhi::ImageLayout::Undefined;
   barrier.dstLayout = rhi::ImageLayout::TransferDestinationOptimal;
+  barrier.srcStage = rhi::PipelineStage::None;
+  barrier.dstStage = rhi::PipelineStage::Transfer;
   barrier.texture = destination;
 
   std::array<rhi::ImageBarrier, 1> preBarriers{barrier};
-  commandList.pipelineBarrier(rhi::PipelineStage::PipeTop,
-                              rhi::PipelineStage::Transfer, {}, preBarriers,
-                              {});
+  commandList.pipelineBarrier({}, preBarriers, {});
 
   std::vector<rhi::CopyRegion> copies(destinationLevels.size());
   for (size_t i = 0; i < copies.size(); ++i) {
@@ -51,10 +51,10 @@ void TextureUtils::copyDataToTexture(
   barrier.dstLayout = destinationLayout;
   barrier.srcAccess = rhi::Access::TransferWrite;
   barrier.dstAccess = rhi::Access::None;
+  barrier.srcStage = rhi::PipelineStage::Transfer;
+  barrier.dstStage = rhi::PipelineStage::AllCommands;
   std::array<rhi::ImageBarrier, 1> postBarriers{barrier};
-  commandList.pipelineBarrier(rhi::PipelineStage::Transfer,
-                              rhi::PipelineStage::PipeTop, {}, postBarriers,
-                              {});
+  commandList.pipelineBarrier({}, postBarriers, {});
 
   device->submitImmediate(commandList);
 
@@ -82,11 +82,11 @@ void TextureUtils::copyTextureToData(
   barrier.srcLayout = rhi::ImageLayout::Undefined;
   barrier.dstLayout = rhi::ImageLayout::TransferSourceOptimal;
   barrier.texture = source;
+  barrier.srcStage = rhi::PipelineStage::None;
+  barrier.dstStage = rhi::PipelineStage::Transfer;
 
   std::array<rhi::ImageBarrier, 1> preBarriers{barrier};
-  commandList.pipelineBarrier(rhi::PipelineStage::PipeTop,
-                              rhi::PipelineStage::Transfer, {}, preBarriers,
-                              {});
+  commandList.pipelineBarrier({}, preBarriers, {});
 
   std::vector<rhi::CopyRegion> copies(sourceLevels.size());
   for (size_t i = 0; i < copies.size(); ++i) {
@@ -107,10 +107,10 @@ void TextureUtils::copyTextureToData(
   barrier.dstLayout = sourceLayout;
   barrier.srcAccess = rhi::Access::None;
   barrier.dstAccess = rhi::Access::None;
+  barrier.srcStage = rhi::PipelineStage::Transfer;
+  barrier.dstStage = rhi::PipelineStage::AllCommands;
   std::array<rhi::ImageBarrier, 1> postBarriers{barrier};
-  commandList.pipelineBarrier(rhi::PipelineStage::Transfer,
-                              rhi::PipelineStage::PipeTop, {}, postBarriers,
-                              {});
+  commandList.pipelineBarrier({}, postBarriers, {});
 
   device->submitImmediate(commandList);
 
@@ -136,11 +136,11 @@ void TextureUtils::generateMipMapsForTexture(rhi::RenderDevice *device,
   barrier.dstAccess = rhi::Access::TransferWrite;
   barrier.srcLayout = rhi::ImageLayout::Undefined;
   barrier.dstLayout = rhi::ImageLayout::TransferDestinationOptimal;
+  barrier.srcStage = rhi::PipelineStage::Transfer;
+  barrier.dstStage = rhi::PipelineStage::Transfer;
 
   std::array<rhi::ImageBarrier, 1> preBarriers{barrier};
-  commandList.pipelineBarrier(rhi::PipelineStage::Transfer,
-                              rhi::PipelineStage::Transfer, {}, preBarriers,
-                              {});
+  commandList.pipelineBarrier({}, preBarriers, {});
 
   barrier.srcAccess = rhi::Access::TransferWrite;
   barrier.dstAccess = rhi::Access::TransferRead;
@@ -153,9 +153,10 @@ void TextureUtils::generateMipMapsForTexture(rhi::RenderDevice *device,
 
   for (uint32_t i = 1; i < levels; ++i) {
     barrier.baseLevel = i - 1;
+    barrier.srcStage = rhi::PipelineStage::Transfer;
+    barrier.dstStage = rhi::PipelineStage::Transfer;
     std::array<rhi::ImageBarrier, 1> barriers{barrier};
-    commandList.pipelineBarrier(rhi::PipelineStage::Transfer,
-                                rhi::PipelineStage::Transfer, {}, barriers, {});
+    commandList.pipelineBarrier({}, barriers, {});
 
     rhi::BlitRegion region{};
     region.srcOffsets.at(0) = {0, 0, 0};
@@ -185,11 +186,11 @@ void TextureUtils::generateMipMapsForTexture(rhi::RenderDevice *device,
   barrier.dstLayout = layout;
   barrier.srcAccess = rhi::Access::None;
   barrier.dstAccess = rhi::Access::None;
+  barrier.srcStage = rhi::PipelineStage::Transfer;
+  barrier.dstStage = rhi::PipelineStage::AllCommands;
 
   std::array<rhi::ImageBarrier, 1> postBarriers{barrier};
-  commandList.pipelineBarrier(rhi::PipelineStage::Transfer,
-                              rhi::PipelineStage::PipeTop, {}, postBarriers,
-                              {});
+  commandList.pipelineBarrier({}, postBarriers, {});
 
   device->submitImmediate(commandList);
 }

--- a/engine/tests/liquid-tests/renderer/RenderGraphSyncDependency.test.cpp
+++ b/engine/tests/liquid-tests/renderer/RenderGraphSyncDependency.test.cpp
@@ -111,7 +111,7 @@ TEST_F(RenderGraphSyncDependencyBufferReadTest,
   auto dependency = liquid::RenderGraphSyncDependency::getBufferRead(
       liquid::RenderGraphPassType::Graphics, liquid::rhi::BufferUsage::Vertex);
 
-  EXPECT_EQ(dependency.stage, liquid::rhi::PipelineStage::VertexInput);
+  EXPECT_EQ(dependency.stage, liquid::rhi::PipelineStage::VertexAttributeInput);
   EXPECT_EQ(dependency.access, liquid::rhi::Access::VertexAttributeRead);
 }
 
@@ -120,7 +120,7 @@ TEST_F(RenderGraphSyncDependencyBufferReadTest,
   auto dependency = liquid::RenderGraphSyncDependency::getBufferRead(
       liquid::RenderGraphPassType::Graphics, liquid::rhi::BufferUsage::Index);
 
-  EXPECT_EQ(dependency.stage, liquid::rhi::PipelineStage::VertexInput);
+  EXPECT_EQ(dependency.stage, liquid::rhi::PipelineStage::IndexInput);
   EXPECT_EQ(dependency.access, liquid::rhi::Access::IndexRead);
 }
 
@@ -158,8 +158,9 @@ TEST_F(RenderGraphSyncDependencyBufferReadTest,
       liquid::RenderGraphPassType::Graphics,
       liquid::rhi::BufferUsage::Storage | liquid::rhi::BufferUsage::Vertex);
 
-  EXPECT_EQ(dependency.stage, liquid::rhi::PipelineStage::FragmentShader |
-                                  liquid::rhi::PipelineStage::VertexInput);
+  EXPECT_EQ(dependency.stage,
+            liquid::rhi::PipelineStage::FragmentShader |
+                liquid::rhi::PipelineStage::VertexAttributeInput);
   EXPECT_EQ(dependency.access, liquid::rhi::Access::ShaderRead |
                                    liquid::rhi::Access::VertexAttributeRead);
 }


### PR DESCRIPTION
- Use new Vulkan submission flow
- Add new access flags, image layouts, and stage flags
- Use sync2 format for pipeline barrier
- Pass pipeline stage directly to barriers
- Update render graph to use sync2 format
- Make barrier tests more readable
- Remove pipe top and pipe bottom