### PR TITLE
Add debug error when incompatible descriptor is bound to pipeline

### DIFF
--- a/engine/rhi/core/include/liquid/rhi/DescriptorType.h
+++ b/engine/rhi/core/include/liquid/rhi/DescriptorType.h
@@ -7,7 +7,8 @@ enum class DescriptorType {
   UniformBufferDynamic,
   StorageBuffer,
   CombinedImageSampler,
-  StorageImage
+  StorageImage,
+  None
 };
 
 } // namespace liquid::rhi

--- a/engine/rhi/vulkan/include/liquid/rhi-vulkan/VulkanDescriptorPool.h
+++ b/engine/rhi/vulkan/include/liquid/rhi-vulkan/VulkanDescriptorPool.h
@@ -43,16 +43,6 @@ public:
   void reset();
 
   /**
-   * @brief Create native Vulkan descriptor set
-   *
-   * @param layout Vulkan descriptor set layout
-   * @return Vulkan descriptor set
-   *
-   * @todo Remove after migration
-   */
-  VkDescriptorSet createDescriptor(VkDescriptorSetLayout layout);
-
-  /**
    * @brief Get Vulkan descriptor set
    *
    * @param handle Descriptor handle
@@ -69,6 +59,17 @@ public:
    */
   inline size_t getDescriptorsCount() const { return mDescriptorSets.size(); }
 
+  /**
+   * @brief Get layout from descriptor
+   *
+   * @param descriptor Vulkan descriptor
+   * @return Vulkan descriptor set layout
+   */
+  inline VkDescriptorSetLayout
+  getLayoutFromDescriptor(VkDescriptorSet descriptor) const {
+    return mDescriptorLayoutMap.at(descriptor);
+  }
+
 private:
   /**
    * @brief Create Vulkan descriptor pool
@@ -82,6 +83,9 @@ private:
 
   VkDescriptorPool mDescriptorPool = VK_NULL_HANDLE;
   std::vector<VkDescriptorSet> mDescriptorSets;
+
+  std::unordered_map<VkDescriptorSet, VkDescriptorSetLayout>
+      mDescriptorLayoutMap;
 };
 
 } // namespace liquid::rhi

--- a/engine/rhi/vulkan/include/liquid/rhi-vulkan/VulkanPipeline.h
+++ b/engine/rhi/vulkan/include/liquid/rhi-vulkan/VulkanPipeline.h
@@ -84,6 +84,13 @@ public:
    */
   inline VkPipelineBindPoint getBindPoint() const { return mBindPoint; }
 
+  /**
+   * @brief Get debug name
+   *
+   * @return Debug name
+   */
+  const String &getDebugName() const { return mDebugName; }
+
 private:
   /**
    * @brief Create pipeline layout
@@ -103,6 +110,8 @@ private:
   VkPipelineBindPoint mBindPoint = VK_PIPELINE_BIND_POINT_MAX_ENUM;
 
   std::unordered_map<uint32_t, VkDescriptorSetLayout> mDescriptorLayouts;
+
+  String mDebugName;
 };
 
 } // namespace liquid::rhi

--- a/engine/rhi/vulkan/src/VulkanCommandBuffer.cpp
+++ b/engine/rhi/vulkan/src/VulkanCommandBuffer.cpp
@@ -59,6 +59,13 @@ void VulkanCommandBuffer::bindDescriptor(PipelineHandle pipeline,
   VkDescriptorSet descriptorSet =
       mDescriptorPool.getDescriptorSet(descriptor.getHandle());
 
+  LIQUID_ASSERT(
+      vulkanPipeline->getDescriptorLayout(firstSet) ==
+          mDescriptorPool.getLayoutFromDescriptor(descriptorSet),
+      "Layout of provided descriptor does not match the layout for set #" +
+          std::to_string(firstSet) + " that is defined in pipeline \"" +
+          vulkanPipeline->getDebugName() + "\"");
+
   vkCmdBindDescriptorSets(
       mCommandBuffer, vulkanPipeline->getBindPoint(),
       vulkanPipeline->getPipelineLayout(), firstSet, 1, &descriptorSet,

--- a/engine/rhi/vulkan/src/VulkanDescriptorPool.cpp
+++ b/engine/rhi/vulkan/src/VulkanDescriptorPool.cpp
@@ -1,4 +1,5 @@
 #include "liquid/core/Base.h"
+#include "liquid/core/Debug.h"
 #include "liquid/core/Engine.h"
 
 #include "VulkanDescriptorPool.h"
@@ -89,29 +90,13 @@ VulkanDescriptorPool::createDescriptor(DescriptorLayoutHandle layout) {
 
   mDescriptorSets.push_back(descriptorSet);
 
+  LiquidDebugOnly(
+      { mDescriptorLayoutMap.insert_or_assign(descriptorSet, vulkanLayout); });
+
+  auto handle = static_cast<DescriptorHandle>(mDescriptorSets.size());
+
   return Descriptor(new VulkanDescriptorSet(mDevice, mRegistry, descriptorSet),
-                    static_cast<DescriptorHandle>(mDescriptorSets.size()));
-}
-
-VkDescriptorSet
-VulkanDescriptorPool::createDescriptor(VkDescriptorSetLayout layout) {
-  VkDescriptorSet descriptorSet = VK_NULL_HANDLE;
-
-  VkDescriptorSetAllocateInfo descriptorSetAllocateInfo{};
-  descriptorSetAllocateInfo.sType =
-      VK_STRUCTURE_TYPE_DESCRIPTOR_SET_ALLOCATE_INFO;
-  descriptorSetAllocateInfo.pNext = nullptr;
-  descriptorSetAllocateInfo.descriptorPool = mDescriptorPool;
-  descriptorSetAllocateInfo.pSetLayouts = &layout;
-  descriptorSetAllocateInfo.descriptorSetCount = 1;
-
-  checkForVulkanError(vkAllocateDescriptorSets(
-                          mDevice, &descriptorSetAllocateInfo, &descriptorSet),
-                      "Failed to allocate descriptor set");
-
-  mDescriptorSets.push_back(descriptorSet);
-
-  return descriptorSet;
+                    handle);
 }
 
 void VulkanDescriptorPool::reset() {

--- a/engine/rhi/vulkan/src/VulkanMapping.cpp
+++ b/engine/rhi/vulkan/src/VulkanMapping.cpp
@@ -332,6 +332,7 @@ VkFilter VulkanMapping::getFilter(Filter filter) {
     return VK_FILTER_LINEAR;
   default:
     LIQUID_ASSERT(false, "Filter does not exist");
+    return VK_FILTER_MAX_ENUM;
   }
 }
 
@@ -348,6 +349,7 @@ VulkanMapping::getDescriptorType(VkDescriptorType descriptorType) {
     return DescriptorType::StorageImage;
   default:
     LIQUID_ASSERT(false, "Descriptor type does not exist");
+    return DescriptorType::None;
   }
 }
 

--- a/engine/rhi/vulkan/src/VulkanPipeline.cpp
+++ b/engine/rhi/vulkan/src/VulkanPipeline.cpp
@@ -14,7 +14,8 @@ VulkanPipeline::VulkanPipeline(const GraphicsPipelineDescription &description,
                                VulkanDeviceObject &device,
                                const VulkanResourceRegistry &registry,
                                VulkanPipelineLayoutCache &pipelineLayoutCache)
-    : mDevice(device), mBindPoint(VK_PIPELINE_BIND_POINT_GRAPHICS) {
+    : mDevice(device), mDebugName(description.debugName),
+      mBindPoint(VK_PIPELINE_BIND_POINT_GRAPHICS) {
 
   std::vector<VulkanShader *> shaders{
       registry.getShaders().at(description.vertexShader).get(),
@@ -237,7 +238,8 @@ VulkanPipeline::VulkanPipeline(const ComputePipelineDescription &description,
                                VulkanDeviceObject &device,
                                const VulkanResourceRegistry &registry,
                                VulkanPipelineLayoutCache &pipelineLayoutCache)
-    : mDevice(device), mBindPoint(VK_PIPELINE_BIND_POINT_COMPUTE) {
+    : mDevice(device), mDebugName(description.debugName),
+      mBindPoint(VK_PIPELINE_BIND_POINT_COMPUTE) {
 
   VulkanShader *computeShader =
       registry.getShaders().at(description.computeShader).get();

--- a/engine/src/liquid/core/Debug.h
+++ b/engine/src/liquid/core/Debug.h
@@ -1,0 +1,12 @@
+#pragma once
+
+#ifdef LIQUID_DEBUG
+#define LiquidDebugOnly(Content)                                               \
+  do {                                                                         \
+    Content                                                                    \
+  } while (false)
+#else
+#define LiquidDebugOnly(Content)                                               \
+  do {                                                                         \
+  } while (false)
+#endif

--- a/engine/src/liquid/imgui/ImguiRenderer.cpp
+++ b/engine/src/liquid/imgui/ImguiRenderer.cpp
@@ -105,7 +105,10 @@ ImguiRenderPassData ImguiRenderer::attach(RenderGraph &graph,
       rhi::PipelineColorBlend{{rhi::PipelineColorBlendAttachment{
           true, rhi::BlendFactor::SrcAlpha, rhi::BlendFactor::OneMinusSrcAlpha,
           rhi::BlendOp::Add, rhi::BlendFactor::One,
-          rhi::BlendFactor::OneMinusSrcAlpha, rhi::BlendOp::Add}}}});
+          rhi::BlendFactor::OneMinusSrcAlpha, rhi::BlendOp::Add}}},
+      {},
+      {},
+      "imgui"});
 
   pass.addPipeline(pipeline);
 


### PR DESCRIPTION
- Add Debug only utility that only runs in debug mode
- Store a map of all descriptor sets and layouts in debug mode
- Add debug assertion to bind descriptor command to test if layout is compatible with pipeline layout at given set
- Remove unused createDescriptor function from Vulkan descriptor pool
- Add pipeline debug name for imgui pipeline
- Fix compile issue in release mode